### PR TITLE
Resolved the latest OSRB comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Continuous integration: lint (Ruff) + forecasting unit tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,15 @@ Maintainers may ask for more detail, a smaller reproducer, or a quick test under
 
 ## Licensing
 
-By contributing, you agree that your contributions will be licensed under the **Apache License, Version 2.0**, the same license that covers the project (see [`LICENSE`](LICENSE) in the repository root).
+**License for contributions:** This project **only** accepts contributions that you license under the **Apache License, Version 2.0**. Do not submit code under any other license terms (including proprietary, copyleft-only, or incompatible licenses). By opening a pull request or otherwise contributing, you agree that your contributions will be distributed under Apache-2.0 on the same terms as the rest of this repository (see [`LICENSE`](LICENSE) at the repository root).
 
-Third-party notices and PyPI dependency summaries are in [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md). **Verbatim upstream license files** for source included in this repo live under [`third_party/`](third_party/) (see [`third_party/README.md`](third_party/README.md)).
+That obligation is separate from the **Developer Certificate of Origin** below: every commit must still include a valid `Signed-off-by` line certifying the DCO.
+
+Third-party notices and PyPI dependency summaries are in [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md). **Verbatim upstream license files** for source included in this repo live under [`third_party/`](third_party/) (see [`third_party/README.md`](third_party/README.md)). Attribution required by the Apache License for redistributed third-party components appears in [`NOTICE`](NOTICE) and in [`LICENSE`](LICENSE) under **ADDITIONAL THIRD-PARTY LICENSES**.
 
 ### Source file headers
 
-- **NVIDIA-authored** Python files use SPDX short-form tags (`SPDX-FileCopyrightText`, `SPDX-License-Identifier`) per SPDX Specification v2.3, Annex E.
+- **NVIDIA-authored** Python files use SPDX short-form tags (`SPDX-FileCopyrightText`, `SPDX-License-Identifier`) per SPDX Specification v2.3, Annex E. Use the copyright attribution **`Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES.`** (see [`scripts/add_spdx_headers.py`](scripts/add_spdx_headers.py) for the shared template).
 - Files that include third-party or modified third-party code must retain **upstream copyright and license notices** in the file (SPDX alone is not a substitute where upstream terms require full notice).
 
 You can refresh SPDX headers on Python trees with:
@@ -49,52 +51,55 @@ External contributors should ensure they have the rights to submit their changes
 
 ## Developer Certificate of Origin
 
-We use the **Developer Certificate of Origin (DCO)** for contribution approval. The canonical text is published at:
+We use the **Developer Certificate of Origin (DCO)** for contribution approval.
 
-**[https://developercertificate.org/](https://developercertificate.org/)**
+**Link to DCO:** [Developer Certificate of Origin](https://developercertificate.org/)
 
-### Signing your work
+#### Signing Your Work
 
-Every commit must include a `Signed-off-by` trailer that matches the author of the patch. Use Git’s sign-off option:
+- We require that all contributors “sign-off” on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
+  - Any contribution which contains commits that are not Signed-Off will not be accepted.
+- To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
 
-```bash
-git commit -s -m "Your descriptive commit message"
-```
+  ```bash
+  $ git commit -s -m "Add cool feature."
+  ```
 
-That appends a line such as:
+  This will append the following to your commit message:
 
-```text
-Signed-off-by: Your Name <your.email@example.com>
-```
+  ```text
+  Signed-off-by: Your Name <your.email@example.com>
+  ```
 
-By signing off, you assert that you agree to the DCO for that commit.
+- Full text of the DCO (<https://developercertificate.org/>):
 
-Full DCO text (same as [developercertificate.org](https://developercertificate.org/)):
-
-```text
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-1 Letterman Drive
-Suite D4700
-San Francisco, CA, 94129
-
-Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
-
-(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
-
-(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
-```
+  ```text
+  Developer Certificate of Origin
+  Version 1.1
+  Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+  Everyone is permitted to copy and distribute verbatim copies of this
+  license document, but changing it is not allowed.
+  Developer's Certificate of Origin 1.1
+  By making a contribution to this project, I certify that:
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
+  ```
 
 Contributions consisting of commits without a valid sign-off cannot be merged.
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 NVIDIA Corporation
+   Copyright 2026 NVIDIA CORPORATION & AFFILIATES.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,3 +199,40 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+================================================================================
+ADDITIONAL THIRD-PARTY LICENSES
+
+This repository incorporates third-party software under terms separate from
+the Apache License, Version 2.0, which applies to NVIDIA-authored portions of
+this project (see above). The following license applies to the indicated
+third-party components only.
+
+-------------------------------------------------------------------------------
+MIT License — DPM-Solver (PyTorch implementation)
+
+Copyright (c) 2022 Cheng Lu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Upstream project: https://github.com/LuChengTHU/dpm-solver
+Included in this repository as: ad_diffusion/utils/dpm_solver_pytorch.py
+(full license copy also at: third_party/dpm-solver/LICENSE)
+-------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 .DEFAULT_GOAL := help

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+NV-Tesseract
+
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+
+This product includes software licensed under the Apache License, Version 2.0.
+See the LICENSE file in this repository for the full Apache 2.0 license text.
+
+This product includes third-party software governed by the MIT License:
+
+  DPM-Solver — Copyright (c) 2022 Cheng Lu
+  https://github.com/LuChengTHU/dpm-solver
+
+The full MIT license text for DPM-Solver is preserved in this repository at:
+
+  third_party/dpm-solver/LICENSE
+
+and is reproduced in the LICENSE file under "ADDITIONAL THIRD-PARTY LICENSES".

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ These paths support NVIDIA OSRB / release checklist items:
 | Item | Location in this repo |
 |------|------------------------|
 | Apache License 2.0 (project) | [`LICENSE`](LICENSE) |
+| NOTICE (Apache 2.0 §4(d) attributions) | [`NOTICE`](NOTICE) |
+| Third-party MIT (DPM-Solver) in LICENSE | [`LICENSE`](LICENSE) — section **ADDITIONAL THIRD-PARTY LICENSES** |
 | Third-party and dependency notices | [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md); upstream license **files** for included source under [`third_party/`](third_party/) |
 | Per-file SPDX / copyright headers | Python sources under `forecasting/`, `ad_diffusion/`, `scripts/` (see [`CONTRIBUTING.md`](CONTRIBUTING.md)) |
 | Developer Certificate of Origin (DCO) | [`CONTRIBUTING.md`](CONTRIBUTING.md#developer-certificate-of-origin) — canonical text: [developercertificate.org](https://developercertificate.org/) |
@@ -163,7 +165,7 @@ These paths support NVIDIA OSRB / release checklist items:
 
 ## License
 
-This project is licensed under the Apache License, Version 2.0 — see [`LICENSE`](LICENSE). Third-party and dependency information is in [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md).
+This project is licensed under the Apache License, Version 2.0 — see [`LICENSE`](LICENSE). Third-party attribution required on distribution is summarized in [`NOTICE`](NOTICE); dependency summaries are in [`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md).
 
 ## Blogs
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -8,6 +8,8 @@ NV-Tesseract source code authored by NVIDIA is offered under the Apache License,
 
 - **[`LICENSE`](LICENSE)**
 
+Redistribution notices under Apache 2.0 §4(d) are in **[`NOTICE`](NOTICE)**. The **MIT license** for included DPM-Solver material appears both in [`LICENSE`](LICENSE) (**ADDITIONAL THIRD-PARTY LICENSES**) and in [`third_party/dpm-solver/LICENSE`](third_party/dpm-solver/LICENSE).
+
 ## Per-file notices
 
 Python modules use SPDX license tags (`SPDX-License-Identifier`) and NVIDIA copyright lines where applicable, consistent with SPDX Specification v2.3, Annex E (short identifiers in source files). Files that incorporate or modify third-party source include the upstream copyright and license notice in addition to NVIDIA attribution — for example [`ad_diffusion/utils/dpm_solver_pytorch.py`](ad_diffusion/utils/dpm_solver_pytorch.py).

--- a/ad_diffusion/examples/quick_example.py
+++ b/ad_diffusion/examples/quick_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/ad_diffusion/models/diff_models.py
+++ b/ad_diffusion/models/diff_models.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/ad_diffusion/models/main_model.py
+++ b/ad_diffusion/models/main_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/ad_diffusion/models/utils.py
+++ b/ad_diffusion/models/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/ad_diffusion/sdk/inference_ad.py
+++ b/ad_diffusion/sdk/inference_ad.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/ad_diffusion/sdk/inference_worker.py
+++ b/ad_diffusion/sdk/inference_worker.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Worker script for multi-GPU inference.

--- a/ad_diffusion/sdk/thresholds.py
+++ b/ad_diffusion/sdk/thresholds.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/ad_diffusion/utils/adaptive_threshold.py
+++ b/ad_diffusion/utils/adaptive_threshold.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/ad_diffusion/utils/dpm_solver_pytorch.py
+++ b/ad_diffusion/utils/dpm_solver_pytorch.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 Cheng Lu
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
 #
-# This file is derived from DPM-Solver (PyTorch implementation):
+# This file incorporates code derived from DPM-Solver (PyTorch implementation):
 #   https://github.com/LuChengTHU/dpm-solver/blob/main/dpm_solver_pytorch.py
 #
 # A verbatim copy of the upstream MIT license is also kept at:
@@ -29,9 +28,15 @@
 #
 # SPDX-License-Identifier: MIT
 #
-# Modifications by NVIDIA Corporation are contributed as part of the NV-Tesseract
-# project under the Apache License, Version 2.0; see the LICENSE file at the
-# repository root.
+# -----------------------------------------------------------------------------
+# NVIDIA modifications to this file:
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modifications by NVIDIA CORPORATION & AFFILIATES are licensed under the Apache
+# License, Version 2.0. See the LICENSE file at the repository root for the full
+# license text.
+# -----------------------------------------------------------------------------
 
 import torch
 

--- a/ad_diffusion/utils/json_utils.py
+++ b/ad_diffusion/utils/json_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """JSON serialization utilities for numpy arrays, DataFrames, and sklearn models.

--- a/ad_diffusion/utils/tsb_ad_preprocessor.py
+++ b/ad_diffusion/utils/tsb_ad_preprocessor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/forecasting/backbone.py
+++ b/forecasting/backbone.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/forecasting/dataset_longhorizon.py
+++ b/forecasting/dataset_longhorizon.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/forecasting/interpretability.py
+++ b/forecasting/interpretability.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/forecasting/model.py
+++ b/forecasting/model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/forecasting/sdk/__init__.py
+++ b/forecasting/sdk/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Forecasting SDK — re-exports public API from `sdk.forecasting`."""

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib

--- a/forecasting/sdk/quick_example.py
+++ b/forecasting/sdk/quick_example.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace

--- a/scripts/add_spdx_headers.py
+++ b/scripts/add_spdx_headers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: Apache-2.0
 
 """Insert SPDX short-form tags into Python files.
@@ -20,7 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 # SPDX tags (Python '#' comments). License must match repo LICENSE (Apache-2.0 here).
 HEADER_LINES = [
-    "# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA Corporation",
+    "# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.",
     "# SPDX-License-Identifier: Apache-2.0",
 ]
 


### PR DESCRIPTION
- LICENSE: Apache appendix uses NVIDIA CORPORATION & AFFILIATES.; ADDITIONAL THIRD-PARTY LICENSES adds DPM-Solver / Cheng Lu and full MIT text — https://github.com/NVIDIA/NV-Tesseract/blob/main/LICENSE
- NOTICE: root NOTICE for §4(d) attributions — https://github.com/NVIDIA/NV-Tesseract/blob/main/NOTICE
- CONTRIBUTING.md: contributions only under Apache-2.0 plus DCO — https://github.com/NVIDIA/NV-Tesseract/blob/main/CONTRIBUTING.md
- Headers: SPDX lines use NVIDIA CORPORATION & AFFILIATES.; template — https://github.com/NVIDIA/NV-Tesseract/blob/main/scripts/add_spdx_headers.py
- dpm_solver_pytorch.py: upstream MIT preserved; NVIDIA Apache-2.0 modification header — https://github.com/NVIDIA/NV-Tesseract/blob/main/ad_diffusion/utils/dpm_solver_pytorch.py