### PR TITLE
Adding sample finetuning scripts to guide the users towards fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,12 @@ darr_result = perform_forecasting(
 ### Forecasting
 - See [`forecasting/README.md`](forecasting/README.md) for full API reference and examples
 - Run [`forecasting/sdk/quick_example.py`](forecasting/sdk/quick_example.py) for an end-to-end example
+- Fine-tune on your own CSV with [`forecasting/examples/finetune_example.py`](forecasting/examples/finetune_example.py)
 
 ### Anomaly Detection
 - See [`ad_diffusion/README.md`](ad_diffusion/README.md) for detailed usage and configuration
 - Run [`ad_diffusion/examples/quick_example.py`](ad_diffusion/examples/quick_example.py) for an end-to-end example with synthetic or custom datasets
+- Fine-tune on normal windows from your own CSV with [`ad_diffusion/examples/finetune_example.py`](ad_diffusion/examples/finetune_example.py)
 
 ## Capabilities
 
@@ -113,6 +115,7 @@ NV-Tesseract/
 ├── forecasting/                 # Time series forecasting
 │   ├── pyproject.toml           # Project configuration  
 │   ├── README.md                # Forecasting documentation
+│   ├── examples/                # Fine-tuning examples
 │   ├── model.py                 # Model construction utilities
 │   ├── dataset_longhorizon.py   # Dataset classes for long-horizon forecasting
 │   └── sdk/
@@ -130,6 +133,7 @@ NV-Tesseract/
 │   ├── utils/                   # Preprocessing and utilities
 │   └── examples/                # Usage examples and datasets
 │       ├── quick_example.py     # Complete example (synthetic + custom data)
+│       ├── finetune_example.py  # CSV fine-tuning example
 │       └── datasets/            # Sample datasets and documentation
 └── Makefile                     # Linting and formatting commands
 ```

--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -155,6 +155,7 @@ ad_diffusion/
 │   └── dpm_solver_pytorch.py  # DPM-Solver for fast inference
 ├── examples/                   # Examples and sample data
 │   ├── quick_example.py       # Complete usage example
+│   ├── finetune_example.py    # CSV fine-tuning example
 │   └── datasets/              # Sample datasets for testing
 ├── README.md                  # This file
 ├── pyproject.toml            # Project configuration
@@ -199,6 +200,51 @@ This example demonstrates:
 - Applying adaptive thresholding (SCS/MACS)
 - Using both synthetic and real-world datasets
 - Evaluating results against ground truth
+
+## Fine-tuning
+
+Use `examples/finetune_example.py` to fine-tune AD Diffusion on normal windows from your own data. The CSV should contain mostly normal behavior. Numeric feature columns are used for training; use `--timestamp-col`, `--label-col`, and `--drop-cols` to remove metadata columns from the feature matrix.
+
+```bash
+uv run python examples/finetune_example.py \
+  --csv /path/to/normal_training_data.csv \
+  --timestamp-col timestamp \
+  --label-col is_anomaly \
+  --epochs 10 \
+  --batch-size 16 \
+  --lr 1e-5 \
+  --output-dir artifacts/finetune_my_data
+```
+
+To use a separate validation file instead of a temporal split:
+
+```bash
+uv run python examples/finetune_example.py \
+  --csv /path/to/train_normal.csv \
+  --val-csv /path/to/val_normal.csv \
+  --timestamp-col timestamp \
+  --epochs 10 \
+  --output-dir artifacts/finetune_my_data
+```
+
+The output directory contains:
+
+- `best_finetuned_model.pth` - best validation checkpoint, compatible with the SDK inference loader
+- `final_finetuned_model.pth` - final epoch checkpoint
+- `metrics.json` - training and validation losses
+- `finetune_config.yaml` - model configuration used for fine-tuning
+
+Run anomaly detection with the fine-tuned checkpoint:
+
+```python
+results = perform_anomaly_analysis_with_diffusion(
+    df=df,
+    threshold_strategy="scs",
+    model_path="artifacts/finetune_my_data/best_finetuned_model.pth",
+    config_path="artifacts/finetune_my_data/finetune_config.yaml",
+    nsample=15,
+)
+```
 
 ## System Requirements
 

--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -234,11 +234,13 @@ The output directory contains:
 - `metrics.json` - training and validation losses
 - `finetune_config.yaml` - model configuration used for fine-tuning
 
-Run anomaly detection with the fine-tuned checkpoint:
+Run anomaly detection with the fine-tuned checkpoint. Pass only numeric analysis columns to `df`; drop timestamp, label, and other metadata columns before calling the SDK.
 
 ```python
+analysis_df = df.select_dtypes(include="number").drop(columns=["is_anomaly"], errors="ignore")
+
 results = perform_anomaly_analysis_with_diffusion(
-    df=df,
+    df=analysis_df,
     threshold_strategy="scs",
     model_path="artifacts/finetune_my_data/best_finetuned_model.pth",
     config_path="artifacts/finetune_my_data/finetune_config.yaml",

--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -216,6 +216,8 @@ uv run python examples/finetune_example.py \
   --output-dir artifacts/finetune_my_data
 ```
 
+When using the default temporal validation split, the validation partition must contain at least `--window-length` rows. The default `--val-ratio 0.3` works with the bundled 500-row sample dataset and default `--window-length 100`. If you lower `--val-ratio`, either increase the dataset size, pass a separate `--val-csv`, or reduce `--window-length`.
+
 To use a separate validation file instead of a temporal split:
 
 ```bash

--- a/ad_diffusion/examples/finetune_example.py
+++ b/ad_diffusion/examples/finetune_example.py
@@ -340,7 +340,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--split", type=int, default=None, help="Number of alternating mask segments per window.")
     parser.add_argument("--mask-ratio", type=float, default=0.7, help="Random masking ratio used during training.")
     parser.add_argument("--scale-factor", type=float, default=None)
-    parser.add_argument("--val-ratio", type=float, default=0.1)
+    parser.add_argument(
+        "--val-ratio",
+        type=float,
+        default=0.3,
+        help="Temporal validation fraction when --val-csv is not used. Keep validation rows >= --window-length.",
+    )
     return parser.parse_args()
 
 

--- a/ad_diffusion/examples/finetune_example.py
+++ b/ad_diffusion/examples/finetune_example.py
@@ -39,8 +39,8 @@ from tqdm import tqdm
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from models.main_model import TSDiffuser_Generic  # noqa: E402
-from sdk.inference_ad import (  # noqa: E402
+from models.main_model import TSDiffuser_Generic
+from sdk.inference_ad import (
     DEFAULT_CONFIG_FILENAME,
     DEFAULT_MODEL_FILENAME,
     HF_REPO_ID,

--- a/ad_diffusion/examples/finetune_example.py
+++ b/ad_diffusion/examples/finetune_example.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fine-tune NV-Tesseract AD Diffusion on normal windows from a user CSV.
+
+Run from the ad_diffusion directory:
+    uv run python examples/finetune_example.py \
+        --csv /path/to/normal_training_data.csv \
+        --timestamp-col timestamp \
+        --label-col is_anomaly \
+        --epochs 10 \
+        --output-dir artifacts/finetune_my_data
+
+The training CSV should contain mostly normal behavior. Non-numeric columns are
+ignored; pass --timestamp-col, --label-col, or --drop-cols to exclude numeric
+metadata from the feature matrix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+import yaml
+from sklearn.decomposition import PCA
+from torch.utils.data import DataLoader, Dataset
+from tqdm import tqdm
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from models.main_model import TSDiffuser_Generic  # noqa: E402
+from sdk.inference_ad import (  # noqa: E402
+    DEFAULT_CONFIG_FILENAME,
+    DEFAULT_MODEL_FILENAME,
+    HF_REPO_ID,
+    download_model_weights,
+    load_config,
+)
+
+LOGGER = logging.getLogger("ad_diffusion_finetune")
+
+
+class FeatureAdapter:
+    """Fit train-time dimensionality adaptation and min-max scaling."""
+
+    def __init__(self, target_dim: int, scale_factor: float, seed: int) -> None:
+        self.target_dim = target_dim
+        self.scale_factor = scale_factor
+        self.seed = seed
+        self.pca: PCA | None = None
+        self.min_: np.ndarray | None = None
+        self.max_: np.ndarray | None = None
+        self.input_dim: int | None = None
+
+    def fit(self, data: np.ndarray) -> None:
+        self.input_dim = int(data.shape[1])
+        if data.shape[1] > self.target_dim:
+            if data.shape[0] < self.target_dim:
+                raise ValueError(
+                    f"PCA needs at least target_dim rows; got {data.shape[0]} rows for target_dim={self.target_dim}."
+                )
+            self.pca = PCA(n_components=self.target_dim, random_state=self.seed)
+            data = self.pca.fit_transform(data)
+        elif data.shape[1] < self.target_dim:
+            data = self._pad(data)
+
+        self.min_ = data.min(axis=0)
+        self.max_ = data.max(axis=0)
+
+    def transform(self, data: np.ndarray) -> torch.Tensor:
+        if self.min_ is None or self.max_ is None:
+            raise RuntimeError("FeatureAdapter.fit must be called before transform.")
+
+        if self.pca is not None:
+            data = self.pca.transform(data)
+        elif data.shape[1] < self.target_dim:
+            data = self._pad(data)
+        elif data.shape[1] > self.target_dim:
+            data = data[:, : self.target_dim]
+
+        denom = np.where((self.max_ - self.min_) == 0, 1.0, self.max_ - self.min_)
+        data = (data - self.min_) / denom
+        data = np.nan_to_num(data, nan=0.0, posinf=1.0, neginf=0.0)
+        return torch.tensor(data, dtype=torch.float32) * self.scale_factor
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "target_dim": self.target_dim,
+            "input_dim": self.input_dim,
+            "scale_factor": self.scale_factor,
+            "uses_pca": self.pca is not None,
+            "min": self.min_.tolist() if self.min_ is not None else None,
+            "max": self.max_.tolist() if self.max_ is not None else None,
+        }
+
+    def _pad(self, data: np.ndarray) -> np.ndarray:
+        pad_width = self.target_dim - data.shape[1]
+        return np.pad(data, ((0, 0), (0, pad_width)), mode="constant", constant_values=0.0)
+
+
+class MaskedWindowDataset(Dataset):
+    """Sliding windows with complementary segment masks used by TSDiffuser_Generic."""
+
+    def __init__(self, data: torch.Tensor, window_length: int, stride: int, split: int) -> None:
+        if window_length <= 0:
+            raise ValueError("window_length must be positive.")
+        if split <= 0:
+            raise ValueError("split must be positive.")
+        if window_length % split != 0:
+            raise ValueError("window_length must be divisible by split.")
+        if len(data) < window_length:
+            raise ValueError(f"Need at least {window_length} rows, got {len(data)}.")
+
+        self.data = data
+        self.window_length = window_length
+        self.stride = max(1, stride)
+        self.split = split
+        self.begin_indexes = list(range(0, len(data) - window_length + 1, self.stride))
+
+    def __len__(self) -> int:
+        return len(self.begin_indexes)
+
+    def __getitem__(self, idx: int) -> dict[str, torch.Tensor]:
+        start_idx = self.begin_indexes[idx]
+        observed_data = self.data[start_idx : start_idx + self.window_length]
+        observed_mask = torch.ones_like(observed_data)
+        strategy_type = torch.tensor(random.randint(0, 1), dtype=torch.long)
+
+        return {
+            "observed_data": observed_data,
+            "observed_mask": observed_mask,
+            "gt_mask": self._create_mask(observed_mask, int(strategy_type.item())),
+            "timepoints": torch.arange(self.window_length, dtype=torch.float32),
+            "strategy_type": strategy_type,
+        }
+
+    def _create_mask(self, observed_mask: torch.Tensor, strategy_type: int) -> torch.Tensor:
+        mask = torch.zeros_like(observed_mask)
+        segment = self.window_length // self.split
+        for split_idx in range(self.split):
+            start = split_idx * segment
+            end = min(start + segment, self.window_length)
+            if (split_idx % 2 == 0 and strategy_type == 0) or (split_idx % 2 == 1 and strategy_type == 1):
+                mask[start:end] = 1
+        return mask
+
+
+def parse_column_list(value: str | None) -> list[str]:
+    if value is None or value.strip() == "":
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def get_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def load_numeric_frame(path: str, args: argparse.Namespace) -> tuple[np.ndarray, list[str]]:
+    df = pd.read_csv(path)
+    drop_cols = set(parse_column_list(args.drop_cols))
+    for col in (args.timestamp_col, args.label_col):
+        if col:
+            drop_cols.add(col)
+    existing_drop_cols = [col for col in drop_cols if col in df.columns]
+    if existing_drop_cols:
+        df = df.drop(columns=existing_drop_cols)
+
+    numeric_df = df.select_dtypes(include=[np.number]).copy()
+    if numeric_df.empty:
+        raise ValueError(f"No numeric feature columns found in {path}.")
+
+    numeric_df = numeric_df.replace([np.inf, -np.inf], np.nan).ffill().bfill().fillna(0.0)
+    return numeric_df.to_numpy(dtype=np.float32), list(numeric_df.columns)
+
+
+def split_arrays(args: argparse.Namespace) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    train_raw, columns = load_numeric_frame(args.csv, args)
+    if args.val_csv:
+        val_raw, val_columns = load_numeric_frame(args.val_csv, args)
+        if val_columns != columns:
+            raise ValueError("Validation CSV numeric feature columns must match the training CSV.")
+        return train_raw, val_raw, columns
+
+    if not 0.0 < args.val_ratio < 1.0:
+        raise ValueError("--val-ratio must be between 0 and 1 when --val-csv is not used.")
+    split_idx = int(round(len(train_raw) * (1.0 - args.val_ratio)))
+    if split_idx <= 0 or split_idx >= len(train_raw):
+        raise ValueError("Validation split produced an empty train or validation partition.")
+    return train_raw[:split_idx], train_raw[split_idx:], columns
+
+
+def resolve_model_assets(args: argparse.Namespace) -> tuple[str, str]:
+    model_path = args.pretrained_model or DEFAULT_MODEL_FILENAME
+    config_path = args.config or DEFAULT_CONFIG_FILENAME
+
+    model_exists = Path(model_path).exists()
+    config_exists = Path(config_path).exists()
+    if model_exists and config_exists:
+        return model_path, config_path
+    if args.no_download:
+        missing = [path for path, exists in ((model_path, model_exists), (config_path, config_exists)) if not exists]
+        raise FileNotFoundError(f"Missing model assets and --no-download was set: {missing}")
+
+    LOGGER.info("Downloading missing pretrained assets from %s", HF_REPO_ID)
+    return download_model_weights(model_path=model_path, config_path=config_path, repo_id=args.repo_id)
+
+
+def load_checkpoint_and_config(model_path: str, config_path: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    checkpoint = torch.load(model_path, map_location="cpu")
+    if isinstance(checkpoint, dict) and "config" in checkpoint:
+        config = checkpoint["config"]
+    else:
+        config = load_config(config_path)
+    return checkpoint, config
+
+
+def load_state_dict(model: torch.nn.Module, checkpoint: dict[str, Any] | Any) -> None:
+    state_dict = checkpoint.get("model", checkpoint) if isinstance(checkpoint, dict) else checkpoint
+    load_result = model.load_state_dict(state_dict, strict=False)
+    missing = list(getattr(load_result, "missing_keys", []))
+    unexpected = list(getattr(load_result, "unexpected_keys", []))
+    if missing:
+        LOGGER.info("Missing checkpoint keys initialized from current model config: %s", missing)
+    if unexpected:
+        LOGGER.warning("Unexpected checkpoint keys skipped: %s", unexpected)
+
+
+def batch_to_device(batch: dict[str, Any], device: torch.device) -> dict[str, Any]:
+    return {key: value.to(device) if isinstance(value, torch.Tensor) else value for key, value in batch.items()}
+
+
+def unpack_loss(loss_result: torch.Tensor | dict[str, torch.Tensor]) -> torch.Tensor:
+    if isinstance(loss_result, dict):
+        return loss_result["total_loss"]
+    return loss_result
+
+
+def train_one_epoch(
+    model: torch.nn.Module,
+    loader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    grad_clip: float,
+) -> float:
+    model.train()
+    losses: list[float] = []
+    for batch in tqdm(loader, desc="train", leave=False):
+        optimizer.zero_grad(set_to_none=True)
+        loss = unpack_loss(model(batch_to_device(batch, device)))
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), grad_clip)
+        optimizer.step()
+        losses.append(float(loss.detach().cpu()))
+    return float(np.mean(losses)) if losses else float("nan")
+
+
+@torch.no_grad()
+def validate(model: torch.nn.Module, loader: DataLoader, device: torch.device) -> float:
+    model.eval()
+    losses: list[float] = []
+    for batch in tqdm(loader, desc="val", leave=False):
+        loss = unpack_loss(model(batch_to_device(batch, device)))
+        losses.append(float(loss.detach().cpu()))
+    return float(np.mean(losses)) if losses else float("nan")
+
+
+def save_checkpoint(
+    path: Path,
+    model: torch.nn.Module,
+    optimizer: torch.optim.Optimizer,
+    config: dict[str, Any],
+    args: argparse.Namespace,
+    epoch: int,
+    train_loss: float,
+    val_loss: float,
+    preprocessing: dict[str, Any],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "model": model.state_dict(),
+            "optimizer": optimizer.state_dict(),
+            "config": config,
+            "epoch": epoch,
+            "train_loss": train_loss,
+            "valid_loss": val_loss,
+            "args": vars(args),
+            "preprocessing": preprocessing,
+        },
+        path,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fine-tune NV-Tesseract AD Diffusion on a CSV dataset.")
+    parser.add_argument("--csv", required=True, help="Training CSV, ideally containing normal behavior.")
+    parser.add_argument("--val-csv", default=None, help="Optional validation CSV. Otherwise --csv is split temporally.")
+    parser.add_argument("--timestamp-col", default="timestamp")
+    parser.add_argument("--label-col", default=None, help="Optional label column to drop from the feature matrix.")
+    parser.add_argument("--drop-cols", default=None, help="Comma-separated extra columns to drop before training.")
+
+    parser.add_argument("--pretrained-model", default=None, help="Pretrained checkpoint. Defaults to final_model.pth.")
+    parser.add_argument("--config", default=None, help="Model config YAML. Defaults to curriculum_medium.yaml.")
+    parser.add_argument("--repo-id", default=HF_REPO_ID)
+    parser.add_argument("--no-download", action="store_true", help="Do not auto-download missing pretrained assets.")
+
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--lr", type=float, default=1e-5)
+    parser.add_argument("--weight-decay", type=float, default=1e-6)
+    parser.add_argument("--grad-clip", type=float, default=1.0)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", default="artifacts/finetune")
+
+    parser.add_argument("--window-length", type=int, default=None)
+    parser.add_argument("--window-stride", type=int, default=1)
+    parser.add_argument("--split", type=int, default=None, help="Number of alternating mask segments per window.")
+    parser.add_argument("--mask-ratio", type=float, default=0.7, help="Random masking ratio used during training.")
+    parser.add_argument("--scale-factor", type=float, default=None)
+    parser.add_argument("--val-ratio", type=float, default=0.1)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    set_seed(args.seed)
+    device = get_device()
+    output_dir = Path(args.output_dir)
+
+    model_path, config_path = resolve_model_assets(args)
+    checkpoint, config = load_checkpoint_and_config(model_path, config_path)
+    target_dim = int(config.get("model", {}).get("target_dim", 40))
+    dataset_config = config.get("dataset", {})
+    window_length = args.window_length or int(dataset_config.get("window_length", 100))
+    split = args.split or int(dataset_config.get("split", 4))
+    scale_factor = args.scale_factor or float(dataset_config.get("scale_factor", 20))
+
+    train_raw, val_raw, columns = split_arrays(args)
+    adapter = FeatureAdapter(target_dim=target_dim, scale_factor=scale_factor, seed=args.seed)
+    adapter.fit(train_raw)
+    train_tensor = adapter.transform(train_raw)
+    val_tensor = adapter.transform(val_raw)
+
+    train_dataset = MaskedWindowDataset(train_tensor, window_length, args.window_stride, split)
+    val_dataset = MaskedWindowDataset(val_tensor, window_length, args.window_stride, split)
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+    )
+
+    LOGGER.info("Device: %s", device)
+    LOGGER.info("Target dimension: %s", target_dim)
+    LOGGER.info("Feature columns: %s", columns)
+    LOGGER.info("Train windows: %s", len(train_dataset))
+    LOGGER.info("Val windows: %s", len(val_dataset))
+
+    model = TSDiffuser_Generic(config, device=device, target_dim=target_dim, ratio=args.mask_ratio).to(device)
+    load_state_dict(model, checkpoint)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+
+    preprocessing = adapter.metadata()
+    preprocessing["columns"] = columns
+    preprocessing["dropped_columns"] = parse_column_list(args.drop_cols)
+
+    best_val = float("inf")
+    metrics: list[dict[str, float]] = []
+    for epoch in range(1, args.epochs + 1):
+        train_loss = train_one_epoch(model, train_loader, optimizer, device, args.grad_clip)
+        val_loss = validate(model, val_loader, device)
+        metrics.append({"epoch": epoch, "train_loss": train_loss, "val_loss": val_loss})
+        LOGGER.info("Epoch %s/%s | train loss %.6f | val loss %.6f", epoch, args.epochs, train_loss, val_loss)
+
+        if val_loss < best_val:
+            best_val = val_loss
+            save_checkpoint(
+                output_dir / "best_finetuned_model.pth",
+                model,
+                optimizer,
+                config,
+                args,
+                epoch,
+                train_loss,
+                val_loss,
+                preprocessing,
+            )
+            LOGGER.info("Saved new best checkpoint to %s", output_dir / "best_finetuned_model.pth")
+
+    save_checkpoint(
+        output_dir / "final_finetuned_model.pth",
+        model,
+        optimizer,
+        config,
+        args,
+        args.epochs,
+        metrics[-1]["train_loss"],
+        metrics[-1]["val_loss"],
+        preprocessing,
+    )
+    with (output_dir / "metrics.json").open("w") as f:
+        json.dump(metrics, f, indent=2)
+    with (output_dir / "finetune_config.yaml").open("w") as f:
+        yaml.safe_dump(config, f)
+
+    LOGGER.info("Fine-tuning complete. Best val loss %.6f", best_val)
+    LOGGER.info("Artifacts written to %s", output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/forecasting/README.md
+++ b/forecasting/README.md
@@ -69,7 +69,7 @@ uv run python sdk/quick_example.py
 
 ## Fine-tuning
 
-Use `examples/finetune_example.py` to fine-tune NV-Tesseract on your own forecasting data. The CSV must include a timestamp column and one or more numeric target columns. By default, the script freezes the pretrained encoder/embedder and trains the forecasting head.
+Use `examples/finetune_example.py` to fine-tune NV-Tesseract on your own forecasting data. The CSV must include a timestamp column and one or more numeric target columns. By default, the script auto-downloads the published NV-Tesseract forecasting checkpoint, freezes the pretrained encoder/embedder, and trains the forecasting head. Pass `--ckpt-init none` if you want to train a fresh head from the base backbone instead.
 
 ```bash
 uv run python examples/finetune_example.py \
@@ -82,7 +82,7 @@ uv run python examples/finetune_example.py \
   --output-dir artifacts/finetune_my_data
 ```
 
-For multivariate channel-mixing fine-tuning, enable the cross-channel layer and optionally warm-start from an existing compatible checkpoint:
+For multivariate channel-mixing fine-tuning, enable the cross-channel layer. With `--ckpt-init auto` (the default), the script warm-starts from the published cross-channel checkpoint:
 
 ```bash
 uv run python examples/finetune_example.py \
@@ -94,7 +94,6 @@ uv run python examples/finetune_example.py \
   --use-cross-channel \
   --cross-channel-heads 8 \
   --cross-channel-dropout 0.1 \
-  --ckpt-init run8_best_model_cr.pt \
   --epochs 5 \
   --output-dir artifacts/finetune_channel_mixing
 ```

--- a/forecasting/README.md
+++ b/forecasting/README.md
@@ -67,6 +67,61 @@ Or run the example:
 uv run python sdk/quick_example.py
 ```
 
+## Fine-tuning
+
+Use `examples/finetune_example.py` to fine-tune NV-Tesseract on your own forecasting data. The CSV must include a timestamp column and one or more numeric target columns. By default, the script freezes the pretrained encoder/embedder and trains the forecasting head.
+
+```bash
+uv run python examples/finetune_example.py \
+  --csv /path/to/your_timeseries.csv \
+  --timestamp-col timestamp \
+  --target-cols target \
+  --seq-len 512 \
+  --forecast-horizon 72 \
+  --epochs 5 \
+  --output-dir artifacts/finetune_my_data
+```
+
+For multivariate channel-mixing fine-tuning, enable the cross-channel layer and optionally warm-start from an existing compatible checkpoint:
+
+```bash
+uv run python examples/finetune_example.py \
+  --csv /path/to/multivariate_timeseries.csv \
+  --timestamp-col timestamp \
+  --target-cols sensor_1,sensor_2,sensor_3 \
+  --seq-len 512 \
+  --forecast-horizon 72 \
+  --use-cross-channel \
+  --cross-channel-heads 8 \
+  --cross-channel-dropout 0.1 \
+  --ckpt-init run8_best_model_cr.pt \
+  --epochs 5 \
+  --output-dir artifacts/finetune_channel_mixing
+```
+
+The output directory contains:
+
+- `best_model.pt` - fine-tuned checkpoint
+- `standardizer.pkl` - training normalization statistics
+- `finetune_metadata.json` - model, data, and training metadata
+- `metrics.json` - training and validation metrics for all epochs
+
+Use the fine-tuned artifacts with the SDK:
+
+```python
+results = perform_forecasting(
+    df=df,
+    timestamp_column="timestamp",
+    target_column="target",
+    seq_len=512,
+    forecast_horizon=72,
+    model_horizon=72,
+    standardizer_pkl="artifacts/finetune_my_data/standardizer.pkl",
+    ckpt="artifacts/finetune_my_data/best_model.pt",
+    use_cross_channel=False,  # set True if trained with --use-cross-channel
+)
+```
+
 ## UV Commands Reference
 
 ### Package Management
@@ -98,6 +153,8 @@ source .venv/bin/activate  # Activate environment (Unix)
 forecasting/
 ├── pyproject.toml         # Project configuration and dependencies
 ├── README.md             # This file
+├── examples/
+│   └── finetune_example.py # CSV fine-tuning example
 ├── sdk/
 │   ├── forecasting.py    # Main forecasting module (with auto-download)
 │   ├── quick_example.py  # Example usage script
@@ -299,4 +356,3 @@ If you see `Interpretability PDF report skipped: matplotlib is not installed.`, 
 ```bash
 uv add matplotlib
 ```
-

--- a/forecasting/examples/finetune_example.py
+++ b/forecasting/examples/finetune_example.py
@@ -42,6 +42,11 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from dataset_longhorizon import CSVLongHorizonDataset, CSVLongHorizonSimpleDataset
 from model import build_model, count_trainable_params
+from sdk.forecasting import (
+    DEFAULT_CHECKPOINT_NAME,
+    DEFAULT_CROSS_CHANNEL_CHECKPOINT_NAME,
+    download_model_weights,
+)
 
 LOGGER = logging.getLogger("forecasting_finetune")
 
@@ -127,12 +132,38 @@ def build_datasets(args: argparse.Namespace) -> tuple[Any, Any]:
     return train_dataset, val_dataset
 
 
+def resolve_checkpoint_init(args: argparse.Namespace) -> str | None:
+    if args.ckpt_init is None or args.ckpt_init.lower() in {"none", "false", "0"}:
+        return None
+    if args.ckpt_init.lower() != "auto":
+        return args.ckpt_init
+
+    ckpt_name = DEFAULT_CROSS_CHANNEL_CHECKPOINT_NAME if args.use_cross_channel else DEFAULT_CHECKPOINT_NAME
+    _, ckpt_path = download_model_weights(
+        standardizer_pkl=args.standardizer_init,
+        ckpt=ckpt_name,
+        repo_id=args.repo_id,
+    )
+    return ckpt_path
+
+
 def load_checkpoint(model: torch.nn.Module, ckpt_path: str, device: torch.device) -> None:
     checkpoint = torch.load(ckpt_path, map_location=device)
     state_dict = checkpoint.get("model", checkpoint) if isinstance(checkpoint, dict) else checkpoint
-    load_result = model.load_state_dict(state_dict, strict=False)
+    model_state = model.state_dict()
+    compatible_state = {}
+    skipped = []
+    for key, value in state_dict.items():
+        if key in model_state and tuple(model_state[key].shape) == tuple(value.shape):
+            compatible_state[key] = value
+        else:
+            skipped.append(key)
+
+    load_result = model.load_state_dict(compatible_state, strict=False)
     missing = list(getattr(load_result, "missing_keys", []))
     unexpected = list(getattr(load_result, "unexpected_keys", []))
+    if skipped:
+        LOGGER.info("Skipped incompatible checkpoint keys: %s", skipped)
     if unexpected:
         LOGGER.warning("Unexpected checkpoint keys: %s", unexpected)
     if missing:
@@ -175,7 +206,9 @@ def train_one_epoch(
 
 
 @torch.no_grad()
-def evaluate(model: torch.nn.Module, loader: DataLoader, criterion: torch.nn.Module, device: torch.device) -> tuple[float, float]:
+def evaluate(
+    model: torch.nn.Module, loader: DataLoader, criterion: torch.nn.Module, device: torch.device
+) -> tuple[float, float]:
     model.eval()
     losses: list[float] = []
     maes: list[float] = []
@@ -237,10 +270,22 @@ def parse_args() -> argparse.Namespace:
     data_group.add_argument("--train-csv", type=str, help="Training CSV. Requires --val-csv.")
     parser.add_argument("--val-csv", type=str, help="Validation CSV when --train-csv is used.")
     parser.add_argument("--timestamp-col", type=str, default="timestamp")
-    parser.add_argument("--target-cols", type=str, default=None, help="Comma-separated numeric columns. Defaults to all numeric columns.")
+    parser.add_argument(
+        "--target-cols",
+        type=str,
+        default=None,
+        help="Comma-separated numeric columns. Defaults to all numeric columns.",
+    )
 
     parser.add_argument("--model-name", type=str, default="AutonLab/MOMENT-1-large")
-    parser.add_argument("--ckpt-init", type=str, default=None, help="Optional checkpoint to warm-start from.")
+    parser.add_argument(
+        "--ckpt-init",
+        type=str,
+        default="auto",
+        help="Checkpoint to warm-start from. Use 'auto' for published NV-Tesseract weights or 'none' for a fresh head.",
+    )
+    parser.add_argument("--standardizer-init", type=str, default="standardizer.pkl")
+    parser.add_argument("--repo-id", type=str, default="nvidia/nv-tesseract-forecasting")
     parser.add_argument("--seq-len", type=int, default=512)
     parser.add_argument("--forecast-horizon", type=int, default=72)
     parser.add_argument("--stride", type=int, default=None)
@@ -315,8 +360,10 @@ def main() -> None:
         local_files_only=args.local_files_only,
         device=str(device),
     )
-    if args.ckpt_init:
-        load_checkpoint(model, args.ckpt_init, device)
+    ckpt_init = resolve_checkpoint_init(args)
+    if ckpt_init:
+        LOGGER.info("Warm-starting from checkpoint: %s", ckpt_init)
+        load_checkpoint(model, ckpt_init, device)
 
     LOGGER.info("Trainable parameters: %s", f"{count_trainable_params(model):,}")
 

--- a/forecasting/examples/finetune_example.py
+++ b/forecasting/examples/finetune_example.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Fine-tune the NV-Tesseract forecasting head on a user CSV.
+
+Run from the forecasting directory:
+    uv run python examples/finetune_example.py \
+        --csv /path/to/timeseries.csv \
+        --timestamp-col timestamp \
+        --target-cols target \
+        --forecast-horizon 72 \
+        --seq-len 512 \
+        --epochs 5 \
+        --output-dir artifacts/finetune_my_data
+
+The CSV must contain a timestamp column and one or more numeric time-series columns.
+By default the script trains the forecasting head while keeping the pretrained
+encoder and embedder frozen.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import sys
+from pathlib import Path
+from typing import Any
+
+import joblib
+import numpy as np
+import torch
+from torch.optim.lr_scheduler import OneCycleLR
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from dataset_longhorizon import CSVLongHorizonDataset, CSVLongHorizonSimpleDataset
+from model import build_model, count_trainable_params
+
+LOGGER = logging.getLogger("forecasting_finetune")
+
+
+def parse_column_list(value: str | None) -> list[str] | None:
+    if value is None or value.strip() == "":
+        return None
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def get_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def build_datasets(args: argparse.Namespace) -> tuple[Any, Any]:
+    target_cols = parse_column_list(args.target_cols)
+
+    if args.csv is not None:
+        train_dataset = CSVLongHorizonDataset(
+            csv_path=args.csv,
+            data_split="train",
+            seq_len=args.seq_len,
+            forecast_horizon=args.forecast_horizon,
+            val_ratio=args.val_ratio,
+            test_ratio=args.test_ratio,
+            random_seed=args.seed,
+            standardize=not args.no_standardize,
+            stride=args.stride,
+            timestamp_col=args.timestamp_col,
+            usecols=target_cols,
+        )
+        val_dataset = CSVLongHorizonDataset(
+            csv_path=args.csv,
+            data_split="val",
+            seq_len=args.seq_len,
+            forecast_horizon=args.forecast_horizon,
+            val_ratio=args.val_ratio,
+            test_ratio=args.test_ratio,
+            random_seed=args.seed,
+            standardize=not args.no_standardize,
+            stride=args.stride,
+            timestamp_col=args.timestamp_col,
+            usecols=target_cols,
+        )
+        return train_dataset, val_dataset
+
+    if args.train_csv is None or args.val_csv is None:
+        raise ValueError("Pass either --csv or both --train-csv and --val-csv.")
+
+    train_dataset = CSVLongHorizonSimpleDataset(
+        csv_path=args.train_csv,
+        data_split="train",
+        seq_len=args.seq_len,
+        forecast_horizon=args.forecast_horizon,
+        standardizer=None,
+        standardize=not args.no_standardize,
+        stride=args.stride,
+        timestamp_col=args.timestamp_col,
+        usecols=target_cols,
+    )
+    val_dataset = CSVLongHorizonSimpleDataset(
+        csv_path=args.val_csv,
+        data_split="val",
+        seq_len=args.seq_len,
+        forecast_horizon=args.forecast_horizon,
+        standardizer=train_dataset.standardizer,
+        standardize=not args.no_standardize,
+        stride=args.stride,
+        timestamp_col=args.timestamp_col,
+        usecols=target_cols,
+    )
+    return train_dataset, val_dataset
+
+
+def load_checkpoint(model: torch.nn.Module, ckpt_path: str, device: torch.device) -> None:
+    checkpoint = torch.load(ckpt_path, map_location=device)
+    state_dict = checkpoint.get("model", checkpoint) if isinstance(checkpoint, dict) else checkpoint
+    load_result = model.load_state_dict(state_dict, strict=False)
+    missing = list(getattr(load_result, "missing_keys", []))
+    unexpected = list(getattr(load_result, "unexpected_keys", []))
+    if unexpected:
+        LOGGER.warning("Unexpected checkpoint keys: %s", unexpected)
+    if missing:
+        LOGGER.info("Missing checkpoint keys initialized from the base model: %s", missing)
+
+
+def train_one_epoch(
+    model: torch.nn.Module,
+    loader: DataLoader,
+    optimizer: torch.optim.Optimizer,
+    scheduler: OneCycleLR,
+    scaler: torch.cuda.amp.GradScaler,
+    criterion: torch.nn.Module,
+    device: torch.device,
+    max_norm: float,
+) -> float:
+    model.train()
+    losses: list[float] = []
+    use_amp = device.type == "cuda"
+
+    for timeseries, forecast, input_mask in tqdm(loader, desc="train", leave=False):
+        timeseries = timeseries.to(device, dtype=torch.float32)
+        forecast = forecast.to(device, dtype=torch.float32)
+        input_mask = input_mask.to(device)
+
+        optimizer.zero_grad(set_to_none=True)
+        with torch.cuda.amp.autocast(enabled=use_amp):
+            output = model(x_enc=timeseries, input_mask=input_mask)
+            loss = criterion(output.forecast, forecast)
+
+        scaler.scale(loss).backward()
+        scaler.unscale_(optimizer)
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
+        scaler.step(optimizer)
+        scaler.update()
+        scheduler.step()
+        losses.append(float(loss.detach().cpu()))
+
+    return float(np.mean(losses)) if losses else float("nan")
+
+
+@torch.no_grad()
+def evaluate(model: torch.nn.Module, loader: DataLoader, criterion: torch.nn.Module, device: torch.device) -> tuple[float, float]:
+    model.eval()
+    losses: list[float] = []
+    maes: list[float] = []
+    use_amp = device.type == "cuda"
+
+    for timeseries, forecast, input_mask in tqdm(loader, desc="val", leave=False):
+        timeseries = timeseries.to(device, dtype=torch.float32)
+        forecast = forecast.to(device, dtype=torch.float32)
+        input_mask = input_mask.to(device)
+
+        with torch.cuda.amp.autocast(enabled=use_amp):
+            output = model(x_enc=timeseries, input_mask=input_mask)
+            loss = criterion(output.forecast, forecast)
+
+        losses.append(float(loss.detach().cpu()))
+        maes.append(float(torch.mean(torch.abs(output.forecast - forecast)).detach().cpu()))
+
+    return (
+        float(np.mean(losses)) if losses else float("nan"),
+        float(np.mean(maes)) if maes else float("nan"),
+    )
+
+
+def save_artifacts(
+    model: torch.nn.Module,
+    output_dir: Path,
+    standardizer: Any,
+    args: argparse.Namespace,
+    channels: list[str],
+    metrics: list[dict[str, float]],
+    best_epoch: int,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), output_dir / "best_model.pt")
+
+    if standardizer is not None:
+        joblib.dump({"mean": standardizer.mean, "std": standardizer.std}, output_dir / "standardizer.pkl")
+
+    metadata = {
+        "best_epoch": best_epoch,
+        "seq_len": args.seq_len,
+        "forecast_horizon": args.forecast_horizon,
+        "model_name": args.model_name,
+        "channels": channels,
+        "use_cross_channel": args.use_cross_channel,
+        "cross_channel_heads": args.cross_channel_heads,
+        "cross_channel_dropout": args.cross_channel_dropout,
+        "args": vars(args),
+        "metrics": metrics,
+    }
+    with (output_dir / "finetune_metadata.json").open("w") as f:
+        json.dump(metadata, f, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fine-tune NV-Tesseract forecasting on a CSV dataset.")
+    data_group = parser.add_mutually_exclusive_group(required=True)
+    data_group.add_argument("--csv", type=str, help="Single CSV to split temporally into train/val/test.")
+    data_group.add_argument("--train-csv", type=str, help="Training CSV. Requires --val-csv.")
+    parser.add_argument("--val-csv", type=str, help="Validation CSV when --train-csv is used.")
+    parser.add_argument("--timestamp-col", type=str, default="timestamp")
+    parser.add_argument("--target-cols", type=str, default=None, help="Comma-separated numeric columns. Defaults to all numeric columns.")
+
+    parser.add_argument("--model-name", type=str, default="AutonLab/MOMENT-1-large")
+    parser.add_argument("--ckpt-init", type=str, default=None, help="Optional checkpoint to warm-start from.")
+    parser.add_argument("--seq-len", type=int, default=512)
+    parser.add_argument("--forecast-horizon", type=int, default=72)
+    parser.add_argument("--stride", type=int, default=None)
+    parser.add_argument("--val-ratio", type=float, default=0.1)
+    parser.add_argument("--test-ratio", type=float, default=0.0)
+    parser.add_argument("--no-standardize", action="store_true")
+
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--weight-decay", type=float, default=0.0)
+    parser.add_argument("--head-dropout", type=float, default=0.1)
+    parser.add_argument("--max-norm", type=float, default=5.0)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--seed", type=int, default=13)
+    parser.add_argument("--output-dir", type=str, default="artifacts/finetune")
+    parser.add_argument("--local-files-only", action="store_true")
+
+    parser.add_argument("--unfreeze-encoder", action="store_true")
+    parser.add_argument("--unfreeze-embedder", action="store_true")
+    parser.add_argument("--use-cross-channel", action="store_true")
+    parser.add_argument("--cross-channel-heads", type=int, default=8)
+    parser.add_argument("--cross-channel-dropout", type=float, default=0.1)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    set_seed(args.seed)
+    device = get_device()
+    output_dir = Path(args.output_dir)
+
+    train_dataset, val_dataset = build_datasets(args)
+    if len(train_dataset) == 0:
+        raise ValueError("No training windows were created. Reduce --seq-len/--forecast-horizon or use more data.")
+    if len(val_dataset) == 0:
+        raise ValueError("No validation windows were created. Reduce --seq-len/--forecast-horizon or use more data.")
+
+    LOGGER.info("Device: %s", device)
+    LOGGER.info("Train windows: %s", len(train_dataset))
+    LOGGER.info("Val windows: %s", len(val_dataset))
+    LOGGER.info("Channels: %s", train_dataset.channels)
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=device.type == "cuda",
+    )
+
+    model = build_model(
+        model_name=args.model_name,
+        forecast_horizon=args.forecast_horizon,
+        seq_len=args.seq_len,
+        head_dropout=args.head_dropout,
+        weight_decay=args.weight_decay,
+        freeze_encoder=not args.unfreeze_encoder,
+        freeze_embedder=not args.unfreeze_embedder,
+        freeze_head=False,
+        use_cross_channel=args.use_cross_channel,
+        cross_channel_heads=args.cross_channel_heads,
+        cross_channel_dropout=args.cross_channel_dropout,
+        local_files_only=args.local_files_only,
+        device=str(device),
+    )
+    if args.ckpt_init:
+        load_checkpoint(model, args.ckpt_init, device)
+
+    LOGGER.info("Trainable parameters: %s", f"{count_trainable_params(model):,}")
+
+    criterion = torch.nn.MSELoss().to(device)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    scheduler = OneCycleLR(
+        optimizer,
+        max_lr=args.lr,
+        total_steps=max(1, len(train_loader) * args.epochs),
+        pct_start=0.3,
+    )
+    scaler = torch.cuda.amp.GradScaler(enabled=device.type == "cuda")
+
+    metrics: list[dict[str, float]] = []
+    best_val = float("inf")
+    best_epoch = -1
+
+    for epoch in range(1, args.epochs + 1):
+        train_mse = train_one_epoch(model, train_loader, optimizer, scheduler, scaler, criterion, device, args.max_norm)
+        val_mse, val_mae = evaluate(model, val_loader, criterion, device)
+        row = {"epoch": epoch, "train_mse": train_mse, "val_mse": val_mse, "val_mae": val_mae}
+        metrics.append(row)
+        LOGGER.info(
+            "Epoch %s/%s | train MSE %.6f | val MSE %.6f | val MAE %.6f",
+            epoch,
+            args.epochs,
+            train_mse,
+            val_mse,
+            val_mae,
+        )
+
+        if val_mse < best_val:
+            best_val = val_mse
+            best_epoch = epoch
+            save_artifacts(
+                model=model,
+                output_dir=output_dir,
+                standardizer=getattr(train_dataset, "standardizer", None),
+                args=args,
+                channels=train_dataset.channels,
+                metrics=metrics,
+                best_epoch=best_epoch,
+            )
+            LOGGER.info("Saved new best checkpoint to %s", output_dir / "best_model.pt")
+
+    LOGGER.info("Fine-tuning complete. Best val MSE %.6f at epoch %s", best_val, best_epoch)
+    with (output_dir / "metrics.json").open("w") as f:
+        json.dump(metrics, f, indent=2)
+    LOGGER.info("Artifacts written to %s", output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added two sample fine-tuning scripts to enable fine-tuning.
Users can run them as-is if they have:

  - dependencies installed with uv sync
  - Hugging Face access/token for the published weights
  - CSVs with enough rows for seq_len + forecast_horizon in forecasting, or window_length in AD
  - numeric feature columns; AD inference should drop timestamp/label metadata before calling the SDK