### PR TITLE
[codex] fix Ad thresholding and packaging

### DIFF
--- a/ad_diffusion/examples/quick_example.py
+++ b/ad_diffusion/examples/quick_example.py
@@ -96,6 +96,7 @@ def create_synthetic_dataset(n_samples: int = 1000, n_features: int = 5, anomaly
     # Add anomalies
     n_anomalies = int(n_samples * anomaly_rate)
     anomaly_indices = np.random.choice(n_samples, n_anomalies, replace=False)
+    ground_truth = np.zeros(n_samples)
 
     # Create different types of anomalies
     for idx in anomaly_indices:
@@ -104,18 +105,22 @@ def create_synthetic_dataset(n_samples: int = 1000, n_features: int = 5, anomaly
         if anomaly_type == "spike":
             # Sharp spike anomaly
             data[idx] += np.random.uniform(3, 5, n_features) * np.sign(np.random.randn(n_features))
+            ground_truth[idx] = 1
         elif anomaly_type == "dip":
             # Sharp dip anomaly
             data[idx] -= np.random.uniform(2, 4, n_features)
+            ground_truth[idx] = 1
         elif anomaly_type == "shift":
             # Level shift anomaly
             shift_duration = min(10, n_samples - idx)
             shift_magnitude = np.random.uniform(1.5, 3, n_features)
             data[idx : idx + shift_duration] += shift_magnitude
+            ground_truth[idx : idx + shift_duration] = 1
         elif anomaly_type == "noise":
             # High noise anomaly
             noise_duration = min(5, n_samples - idx)
             data[idx : idx + noise_duration] += np.random.randn(noise_duration, n_features) * 2
+            ground_truth[idx : idx + noise_duration] = 1
 
     # Create DataFrame with meaningful column names
     columns = [f"sensor_{i + 1}" for i in range(n_features)]
@@ -125,8 +130,6 @@ def create_synthetic_dataset(n_samples: int = 1000, n_features: int = 5, anomaly
     df["timestamp"] = pd.date_range("2024-01-01", periods=n_samples, freq="1H")
 
     # Add ground truth anomaly labels for evaluation
-    ground_truth = np.zeros(n_samples)
-    ground_truth[anomaly_indices] = 1
     df["is_anomaly"] = ground_truth
 
     return df

--- a/ad_diffusion/pyproject.toml
+++ b/ad_diffusion/pyproject.toml
@@ -42,3 +42,12 @@ ignore = ["E501"]  # line too long (handled by line-length)
 [tool.pytest.ini_options]
 addopts = "--disable-warnings -v"
 python_files = ["test*.py", "*_test.py"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["sdk*", "models*", "utils*"]
+namespaces = true

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -111,6 +111,16 @@ def perform_anomaly_analysis_with_diffusion(
     # Get target data for advanced thresholding methods
     target_data = results["target"]
 
+    # Model evaluation works on fixed-size windows and may append padded rows to
+    # the final window. Align outputs before threshold calibration so synthetic
+    # padding cannot change the thresholds used for real input rows.
+    original_length = len(df)
+    if len(residual_scores) != original_length:
+        logger.info(f"Aligning lengths: residual_scores={len(residual_scores)}, original_data={original_length}")
+        residual_scores = residual_scores[:original_length]
+    if len(target_data) != original_length:
+        target_data = target_data[:original_length]
+
     # Apply thresholding strategy
     if threshold_strategy == "scs":
         # Use actual target data from the model results
@@ -121,19 +131,10 @@ def perform_anomaly_analysis_with_diffusion(
     else:
         raise ValueError(f"Unknown threshold strategy: {threshold_strategy}")
 
-    # Create result dataframe
+    # Create result dataframe. A thresholder may return a longer mask than the
+    # score array, so keep assignment aligned with the input rows as well.
     result_df = df.copy()
-
-    # Ensure consistent lengths - model outputs may be padded
-    original_length = len(df)
-    if len(residual_scores) != original_length:
-        logger.info(f"Aligning lengths: residual_scores={len(residual_scores)}, original_data={original_length}")
-        # Truncate all arrays to match original dataframe length
-        residual_scores = residual_scores[:original_length]
-        anomalies = anomalies[:original_length]
-        # Also truncate target_data if it's used later
-        if len(target_data) > original_length:
-            target_data = target_data[:original_length]
+    anomalies = anomalies[:original_length]
 
     result_df["Anomaly"] = anomalies
     result_df["MAE"] = residual_scores  # Using residual (MAE) as anomaly score

--- a/ad_diffusion/sdk/tests/test_anomaly_analysis.py
+++ b/ad_diffusion/sdk/tests/test_anomaly_analysis.py
@@ -149,3 +149,6 @@ def test_perform_anomaly_analysis_truncates_long_model_outputs(monkeypatch, nume
 
     assert len(result) == len(numeric_df)
     assert result["MAE"].tolist() == [0.1, 0.2, 0.3, 0.4, 0.5]
+    threshold_args, _ = mock_thresholder.detect_anomalies.call_args
+    assert len(threshold_args[0]) == len(numeric_df)
+    assert len(threshold_args[1]) == len(numeric_df)


### PR DESCRIPTION
## Summary

This fixes three issues found during a focused review of the Ad Diffusion module.

The anomaly-analysis API previously calibrated SCS/MACS thresholds on fixed-window model output before trimming padded rows back to the caller's input length. For inputs whose length is not a multiple of the model window size, repeated padding values could affect threshold selection and anomaly flags. The API now aligns residual and target arrays before threshold calibration and keeps the returned anomaly mask aligned as well.

The Ad package's documented `pip install -e .` path failed because setuptools discovered the `sdk`, `models`, and `utils` namespace packages without explicit build/package configuration. This change adds setuptools build metadata and explicit namespace package discovery, allowing editable installation and imports from outside the repository.

The synthetic quick example also labeled only the first row of multi-row shift/noise anomalies. Ground truth now marks the complete injected duration, so its evaluation metrics reflect the generated data.

## Validation

- `uv run pytest -q` in `ad_diffusion`: 9 passed
- `uv run pytest -q` in `forecasting`: 42 passed
- `uv pip install -e . --python ad_diffusion/.venv/bin/python`: passed
- Importing `sdk.anomaly_analysis` from outside the repository: passed
- `git diff --check`: passed
- Real CPU smoke tests completed for forecasting, DARR forecasting, and Ad diffusion

GPU-specific multi-process inference was not exercised because the review environment has no visible NVIDIA GPU.
