### PR TITLE
Fix DARR retrieval forecasts beyond the native horizon

### DIFF
--- a/forecasting/sdk/README.md
+++ b/forecasting/sdk/README.md
@@ -100,7 +100,7 @@ result = perform_forecasting(df=df, context_df=context_df, ...)
 **Requirements**:
 - Both datasets must have the same `timestamp_column` and `target_column`
 - At least one common feature column must exist (besides the target)
-- Context dataset must have at least `seq_len + model_horizon` rows
+- Context dataset must have at least `seq_len + max(model_horizon, forecast_horizon)` rows so DARR can retrieve the full requested continuation
 
 For this release, the blending weight `alpha` defaults to `0.01` and can be adjusted via the `alpha` parameter—the hybrid forecast uses that value to combine direct predictions with context-derived neighbors (`alpha * direct + (1 - alpha) * kNN`).
 
@@ -274,7 +274,7 @@ Warning: Column mismatch detected between input and context datasets
 | `ValueError: No common numeric columns found between input and context datasets` | Datasets share no feature columns (only target) | Ensure context dataset has at least one feature column in common with input |
 | `ValueError: Shape mismatch between direct and kNN predictions` | Column alignment failed internally | Check that both datasets have valid numeric columns |
 | `ValueError: DataFrame has X rows but seq_len requires at least Y rows` | Insufficient data points | Provide more data or reduce `seq_len` |
-| `ValueError: Context DataFrame has X rows but requires at least Y rows` | Context dataset too small | Context needs `seq_len + model_horizon` rows minimum |
+| `ValueError: Context DataFrame has X rows but requires at least Y rows` | Context dataset too small | Context needs `seq_len + max(model_horizon, forecast_horizon)` rows minimum |
 | `ValueError: forecast_horizon must be <= 512` | Forecast horizon too large | Reduce `forecast_horizon` or make multiple calls |
 | `ValueError: Target column 'X' not found in DataFrame` | Missing target column | Verify column name or use `target_column` parameter |
 | `ValueError: interpretability_output must be one of None, 'json', 'pdf'` | Bad value for the artifact selector | Use `None`, `"json"`, or `"pdf"` |

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -1550,6 +1550,12 @@ def perform_forecasting(
     if forecast_horizon > MAX_FORECAST_HORIZON:
         raise ValueError(f"forecast_horizon must be <= {MAX_FORECAST_HORIZON}, got {forecast_horizon}")
 
+    # The model's native horizon limits direct predictions, but DARR retrieves
+    # observed continuations from context data. Keep the existing native-sized
+    # context windows for shorter requests while retaining the full retrieval
+    # trajectory whenever callers ask for a longer forecast.
+    darr_context_horizon = max(model_horizon, forecast_horizon)
+
     # Input validation
     if df is None or df.empty:
         raise ValueError("Input DataFrame is required and cannot be empty")
@@ -1662,11 +1668,12 @@ def perform_forecasting(
                 raise ValueError(f"Context DataFrame missing target column '{target_column}'")
 
             # Validate context DataFrame has enough rows for at least one window
-            min_context_rows = seq_len + model_horizon
+            min_context_rows = seq_len + darr_context_horizon
             if len(context_df) < min_context_rows:
                 raise ValueError(
                     f"Context DataFrame has {len(context_df)} rows but requires at least "
-                    f"{min_context_rows} rows (seq_len={seq_len} + model_horizon={model_horizon})"
+                    f"{min_context_rows} rows "
+                    f"(seq_len={seq_len} + context_horizon={darr_context_horizon})"
                 )
 
             # Process context DataFrame similarly to main DataFrame
@@ -1796,12 +1803,14 @@ def perform_forecasting(
         if mode == "darr":
             # Context-Enhanced Forecasting (DARR Mode)
 
-            # Create context dataset with model_horizon (needs ground truth)
+            # Retrieve observed context continuations for the entire requested
+            # horizon. The native model horizon only constrains the direct
+            # component, which is extended autoregressively below.
             context_dataset = CSVLongHorizonSimpleDataset(
                 csv_path=context_csv_path,
                 data_split="train",
                 seq_len=seq_len,
-                forecast_horizon=model_horizon,  # Use model's native horizon
+                forecast_horizon=darr_context_horizon,
                 standardizer=None,
                 standardize=False,
                 stride=context_stride,
@@ -1813,7 +1822,8 @@ def perform_forecasting(
                 context_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True
             )
 
-            # Build context memory (using model_horizon)
+            # Build context memory with observed continuations long enough for
+            # the requested retrieval forecast.
             DB_E, DB_Y = build_context_memory(model, context_loader, device, cosine=True)
             # print(f"Context memory built: {DB_E.shape} embeddings, {DB_Y.shape} futures")
 
@@ -1842,18 +1852,8 @@ def perform_forecasting(
             preds_direct = np.concatenate(preds_direct, axis=0)
 
             # kNN retrieval forecast
-            preds_knn_base = knn_forecast(DB_E, DB_Y, Q_E, k=k, temperature=temperature)
-
-            # If forecast_horizon > model_horizon, extend kNN predictions
-            if forecast_horizon > model_horizon:
-                B, C, H = preds_knn_base.shape
-                preds_knn = np.zeros((B, C, forecast_horizon), dtype=np.float32)
-                preds_knn[:, :, :H] = preds_knn_base
-                # Extend with last value
-                for h in range(H, forecast_horizon):
-                    preds_knn[:, :, h] = preds_knn_base[:, :, -1]
-            else:
-                preds_knn = preds_knn_base[:, :, :forecast_horizon]
+            preds_knn = knn_forecast(DB_E, DB_Y, Q_E, k=k, temperature=temperature)
+            preds_knn = preds_knn[:, :, :forecast_horizon]
 
             # Validate shapes before combining predictions
             if preds_direct.shape != preds_knn.shape:

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -413,6 +413,50 @@ def test_perform_forecasting_darr_mode_forecast_horizon_larger_than_model_horizo
     assert result["target_forecast"].notna().all()
 
 
+def test_perform_forecasting_darr_mode_retrieves_full_requested_horizon():
+    """DARR retrieval keeps the historical continuation beyond the model's native horizon."""
+    df = make_timeseries(num_rows=12)
+    context_df = make_timeseries(num_rows=12)
+
+    result = forecasting.perform_forecasting(
+        df,
+        seq_len=5,
+        forecast_horizon=6,
+        model_horizon=2,
+        context_df=context_df,
+        alpha=0.0,
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        seed=42,
+    )
+
+    # There is exactly one six-step context continuation: target values 5..10.
+    # The old implementation retrieved only 5..6, then repeated 6 for steps 3..6.
+    np.testing.assert_allclose(result["target_forecast"], np.arange(5, 11, dtype=np.float32))
+
+
+def test_perform_forecasting_darr_mode_blends_full_retrieval_horizon():
+    """The hybrid output uses the complete retrieval trajectory for long forecasts."""
+    df = make_timeseries(num_rows=12)
+    context_df = make_timeseries(num_rows=12)
+
+    result = forecasting.perform_forecasting(
+        df,
+        seq_len=5,
+        forecast_horizon=6,
+        model_horizon=2,
+        context_df=context_df,
+        alpha=0.25,
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        seed=42,
+    )
+
+    # DummyModel forecasts ones, while the retrieved continuation is 5..10.
+    expected = 0.25 + 0.75 * np.arange(5, 11, dtype=np.float32)
+    np.testing.assert_allclose(result["target_forecast"], expected)
+
+
 def test_perform_forecasting_darr_mode_forecast_horizon_much_larger_than_model_horizon():
     """DARR mode works with many autoregressive iterations."""
     df = make_timeseries(num_rows=15)
@@ -633,7 +677,7 @@ def test_perform_forecasting_darr_mode_custom_target_column():
 
 
 def test_perform_forecasting_darr_mode_context_df_insufficient_rows():
-    """DARR mode raises error when context_df has fewer than seq_len + model_horizon rows."""
+    """DARR mode raises when context_df cannot provide its required continuation."""
     df = make_timeseries(num_rows=10)
     # context_df with 6 rows, but seq_len=5 + model_horizon=3 = 8 rows needed
     context_df = make_timeseries(num_rows=6)
@@ -644,6 +688,24 @@ def test_perform_forecasting_darr_mode_context_df_insufficient_rows():
             seq_len=5,
             forecast_horizon=2,
             model_horizon=3,
+            context_df=context_df,
+            standardizer_pkl="fake_std.pkl",
+            ckpt="fake_ckpt.pt",
+            seed=42,
+        )
+
+
+def test_perform_forecasting_darr_mode_requires_full_retrieval_horizon():
+    """Long DARR forecasts require context through the requested retrieval horizon."""
+    df = make_timeseries(num_rows=12)
+    context_df = make_timeseries(num_rows=10)
+
+    with pytest.raises(ValueError, match=r"seq_len=5 \+ context_horizon=6"):
+        forecasting.perform_forecasting(
+            df,
+            seq_len=5,
+            forecast_horizon=6,
+            model_horizon=2,
             context_df=context_df,
             standardizer_pkl="fake_std.pkl",
             ckpt="fake_ckpt.pt",


### PR DESCRIPTION
## Summary

- Build DARR context memory with observed continuations long enough for the requested forecast.
- Remove last-value padding from kNN retrieval forecasts beyond the model's native horizon.
- Validate and document the context length required for long-horizon DARR retrieval.
- Add regressions for pure retrieval, hybrid blending, and insufficient long-horizon context.

## Root cause

DARR previously created context windows with `forecast_horizon=model_horizon`. When callers requested a longer forecast, the direct component was extended autoregressively, but the retrieval component was extended by repeating its final native-horizon value. For `alpha < 1`, that synthetic constant tail was blended into the public forecast.

The model's native horizon constrains direct model output; it does not constrain the length of observed historical continuations available from `context_df`.

## Behavior

For a deterministic linear context target `0..11`, `seq_len=5`, `model_horizon=2`, `forecast_horizon=6`, and `alpha=0.0`:

| | Retrieval forecast |
| --- | --- |
| Before | `[7.0, 8.0, 8.0, 8.0, 8.0, 8.0]` |
| After | `[5.0, 6.0, 7.0, 8.0, 9.0, 10.0]` |

For requests no longer than `model_horizon`, the existing native-sized context behavior is preserved. Longer DARR requests now require `context_df` to contain at least `seq_len + max(model_horizon, forecast_horizon)` rows so the full observed continuation can be retrieved.

## Validation

- `make spdx-check`
- `make lint`
- `cd forecasting && pytest -q sdk/tests/test_forecasting.py` (`41 passed`)

Fixes #27
