### PR TITLE
Replay fine-tune preprocessing during AD inference

### DIFF
--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -236,7 +236,12 @@ The output directory contains:
 - `metrics.json` - training and validation losses
 - `finetune_config.yaml` - model configuration used for fine-tuning
 
-Run anomaly detection with the fine-tuned checkpoint. Pass only numeric analysis columns to `df`; drop timestamp, label, and other metadata columns before calling the SDK.
+Fine-tuned checkpoints contain the fitted feature-column order, min-max statistics, PCA projection (when used),
+scale factor, and window settings. The SDK replays that preprocessing automatically instead of fitting a new
+transform on each inference batch. Extra columns are ignored, while missing training features produce a clear error.
+
+Run anomaly detection with the fine-tuned checkpoint. The SDK selects the feature columns recorded during fine-tuning;
+dropping timestamp, label, and other metadata columns explicitly is still recommended for clarity.
 
 ```python
 analysis_df = df.select_dtypes(include="number").drop(columns=["is_anomaly"], errors="ignore")

--- a/ad_diffusion/examples/finetune_example.py
+++ b/ad_diffusion/examples/finetune_example.py
@@ -32,7 +32,6 @@ import numpy as np
 import pandas as pd
 import torch
 import yaml
-from sklearn.decomposition import PCA
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 
@@ -40,6 +39,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from models.main_model import TSDiffuser_Generic
+from sdk.feature_adapter import FeatureAdapter
 from sdk.inference_ad import (
     DEFAULT_CONFIG_FILENAME,
     DEFAULT_MODEL_FILENAME,
@@ -49,64 +49,6 @@ from sdk.inference_ad import (
 )
 
 LOGGER = logging.getLogger("ad_diffusion_finetune")
-
-
-class FeatureAdapter:
-    """Fit train-time dimensionality adaptation and min-max scaling."""
-
-    def __init__(self, target_dim: int, scale_factor: float, seed: int) -> None:
-        self.target_dim = target_dim
-        self.scale_factor = scale_factor
-        self.seed = seed
-        self.pca: PCA | None = None
-        self.min_: np.ndarray | None = None
-        self.max_: np.ndarray | None = None
-        self.input_dim: int | None = None
-
-    def fit(self, data: np.ndarray) -> None:
-        self.input_dim = int(data.shape[1])
-        if data.shape[1] > self.target_dim:
-            if data.shape[0] < self.target_dim:
-                raise ValueError(
-                    f"PCA needs at least target_dim rows; got {data.shape[0]} rows for target_dim={self.target_dim}."
-                )
-            self.pca = PCA(n_components=self.target_dim, random_state=self.seed)
-            data = self.pca.fit_transform(data)
-        elif data.shape[1] < self.target_dim:
-            data = self._pad(data)
-
-        self.min_ = data.min(axis=0)
-        self.max_ = data.max(axis=0)
-
-    def transform(self, data: np.ndarray) -> torch.Tensor:
-        if self.min_ is None or self.max_ is None:
-            raise RuntimeError("FeatureAdapter.fit must be called before transform.")
-
-        if self.pca is not None:
-            data = self.pca.transform(data)
-        elif data.shape[1] < self.target_dim:
-            data = self._pad(data)
-        elif data.shape[1] > self.target_dim:
-            data = data[:, : self.target_dim]
-
-        denom = np.where((self.max_ - self.min_) == 0, 1.0, self.max_ - self.min_)
-        data = (data - self.min_) / denom
-        data = np.nan_to_num(data, nan=0.0, posinf=1.0, neginf=0.0)
-        return torch.tensor(data, dtype=torch.float32) * self.scale_factor
-
-    def metadata(self) -> dict[str, Any]:
-        return {
-            "target_dim": self.target_dim,
-            "input_dim": self.input_dim,
-            "scale_factor": self.scale_factor,
-            "uses_pca": self.pca is not None,
-            "min": self.min_.tolist() if self.min_ is not None else None,
-            "max": self.max_.tolist() if self.max_ is not None else None,
-        }
-
-    def _pad(self, data: np.ndarray) -> np.ndarray:
-        pad_width = self.target_dim - data.shape[1]
-        return np.pad(data, ((0, 0), (0, pad_width)), mode="constant", constant_values=0.0)
 
 
 class MaskedWindowDataset(Dataset):
@@ -359,10 +301,13 @@ def main() -> None:
     model_path, config_path = resolve_model_assets(args)
     checkpoint, config = load_checkpoint_and_config(model_path, config_path)
     target_dim = int(config.get("model", {}).get("target_dim", 40))
-    dataset_config = config.get("dataset", {})
+    dataset_config = config.setdefault("dataset", {})
     window_length = args.window_length or int(dataset_config.get("window_length", 100))
     split = args.split or int(dataset_config.get("split", 4))
     scale_factor = args.scale_factor or float(dataset_config.get("scale_factor", 20))
+    dataset_config["window_length"] = window_length
+    dataset_config["split"] = split
+    dataset_config["scale_factor"] = scale_factor
 
     train_raw, val_raw, columns = split_arrays(args)
     adapter = FeatureAdapter(target_dim=target_dim, scale_factor=scale_factor, seed=args.seed)
@@ -400,6 +345,9 @@ def main() -> None:
     preprocessing = adapter.metadata()
     preprocessing["columns"] = columns
     preprocessing["dropped_columns"] = parse_column_list(args.drop_cols)
+    preprocessing["window_length"] = window_length
+    preprocessing["window_stride"] = args.window_stride
+    preprocessing["split"] = split
 
     best_val = float("inf")
     metrics: list[dict[str, float]] = []

--- a/ad_diffusion/pyproject.toml
+++ b/ad_diffusion/pyproject.toml
@@ -38,6 +38,9 @@ indent-width = 4
 select = ["E", "F", "W", "I"]
 ignore = ["E501"]  # line too long (handled by line-length)
 
+[tool.ruff.lint.per-file-ignores]
+"examples/finetune_example.py" = ["E402"]  # Imports follow the direct-script sys.path setup.
+
 # Basic test configuration (for future use)
 [tool.pytest.ini_options]
 addopts = "--disable-warnings -v"

--- a/ad_diffusion/sdk/feature_adapter.py
+++ b/ad_diffusion/sdk/feature_adapter.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serializable feature preprocessing shared by AD fine-tuning and inference."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.decomposition import PCA
+
+
+class FeatureAdapter:
+    """Fit and replay dimensionality adaptation plus min-max scaling."""
+
+    METADATA_VERSION = 1
+
+    def __init__(self, target_dim: int, scale_factor: float, seed: int) -> None:
+        if target_dim <= 0:
+            raise ValueError("target_dim must be positive.")
+        if not np.isfinite(scale_factor):
+            raise ValueError("scale_factor must be finite.")
+        self.target_dim = target_dim
+        self.scale_factor = scale_factor
+        self.seed = seed
+        self.pca: PCA | None = None
+        self.pca_components_: np.ndarray | None = None
+        self.pca_mean_: np.ndarray | None = None
+        self.min_: np.ndarray | None = None
+        self.max_: np.ndarray | None = None
+        self.input_dim: int | None = None
+        self.dtype_: np.dtype | None = None
+
+    @property
+    def uses_pca(self) -> bool:
+        return self.pca is not None or self.pca_components_ is not None
+
+    def fit(self, data: np.ndarray) -> None:
+        data = self._validate_array(data)
+        self.input_dim = int(data.shape[1])
+        if self.input_dim > self.target_dim:
+            if data.shape[0] < self.target_dim:
+                raise ValueError(
+                    f"PCA needs at least target_dim rows; got {data.shape[0]} rows for target_dim={self.target_dim}."
+                )
+            self.pca = PCA(n_components=self.target_dim, random_state=self.seed)
+            data = self.pca.fit_transform(data)
+            self.pca_components_ = np.asarray(self.pca.components_)
+            self.pca_mean_ = np.asarray(self.pca.mean_)
+        elif self.input_dim < self.target_dim:
+            data = self._pad(data)
+
+        self.dtype_ = data.dtype
+        self.min_ = data.min(axis=0)
+        self.max_ = data.max(axis=0)
+
+    def transform(self, data: np.ndarray) -> torch.Tensor:
+        if self.input_dim is None or self.dtype_ is None or self.min_ is None or self.max_ is None:
+            raise RuntimeError("FeatureAdapter.fit must be called before transform.")
+
+        data = self._validate_array(data).astype(self.dtype_, copy=False)
+        if data.shape[1] != self.input_dim:
+            raise ValueError(f"Expected {self.input_dim} input features, got {data.shape[1]}.")
+
+        if self.pca is not None:
+            data = self.pca.transform(data)
+        elif self.pca_components_ is not None and self.pca_mean_ is not None:
+            data = (data - self.pca_mean_) @ self.pca_components_.T
+        elif self.input_dim < self.target_dim:
+            data = self._pad(data)
+
+        denom = np.where((self.max_ - self.min_) == 0, 1.0, self.max_ - self.min_)
+        data = (data - self.min_) / denom
+        data = np.nan_to_num(data, nan=0.0, posinf=1.0, neginf=0.0)
+        return torch.tensor(data, dtype=torch.float32) * self.scale_factor
+
+    def metadata(self) -> dict[str, Any]:
+        if self.input_dim is None or self.dtype_ is None or self.min_ is None or self.max_ is None:
+            raise RuntimeError("FeatureAdapter.fit must be called before metadata serialization.")
+
+        return {
+            "version": self.METADATA_VERSION,
+            "target_dim": self.target_dim,
+            "input_dim": self.input_dim,
+            "dtype": self.dtype_.name,
+            "scale_factor": self.scale_factor,
+            "seed": self.seed,
+            "uses_pca": self.uses_pca,
+            "min": self.min_.tolist(),
+            "max": self.max_.tolist(),
+            "pca_components": self.pca_components_.tolist() if self.pca_components_ is not None else None,
+            "pca_mean": self.pca_mean_.tolist() if self.pca_mean_ is not None else None,
+        }
+
+    @classmethod
+    def from_metadata(cls, metadata: dict[str, Any]) -> FeatureAdapter:
+        version = metadata.get("version")
+        if version is not None and version != cls.METADATA_VERSION:
+            raise ValueError(f"Unsupported checkpoint preprocessing metadata version: {version!r}")
+        required = ("target_dim", "input_dim", "scale_factor", "min", "max", "uses_pca")
+        missing = [key for key in required if metadata.get(key) is None]
+        if missing:
+            raise ValueError(f"Checkpoint preprocessing metadata is missing: {', '.join(missing)}")
+
+        adapter = cls(
+            target_dim=int(metadata["target_dim"]),
+            scale_factor=float(metadata["scale_factor"]),
+            seed=int(metadata.get("seed", 42)),
+        )
+        adapter.input_dim = int(metadata["input_dim"])
+        if adapter.input_dim <= 0:
+            raise ValueError("Checkpoint preprocessing input_dim must be positive.")
+        try:
+            # Legacy checkpoints came from load_numeric_frame(), which always emits float32.
+            adapter.dtype_ = np.dtype(metadata.get("dtype", "float32"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Checkpoint preprocessing dtype is invalid: {metadata.get('dtype')!r}") from exc
+        if adapter.dtype_.kind != "f":
+            raise ValueError(f"Checkpoint preprocessing dtype must be floating point, got {adapter.dtype_.name}.")
+        adapter.min_ = np.asarray(metadata["min"], dtype=adapter.dtype_)
+        adapter.max_ = np.asarray(metadata["max"], dtype=adapter.dtype_)
+
+        if adapter.min_.shape != (adapter.target_dim,) or adapter.max_.shape != (adapter.target_dim,):
+            raise ValueError("Checkpoint preprocessing min/max shapes do not match target_dim.")
+        if not np.all(np.isfinite(adapter.min_)) or not np.all(np.isfinite(adapter.max_)):
+            raise ValueError("Checkpoint preprocessing min/max values must be finite.")
+
+        uses_pca = metadata["uses_pca"]
+        if not isinstance(uses_pca, (bool, np.bool_)):
+            raise ValueError("Checkpoint preprocessing uses_pca must be boolean.")
+        if uses_pca:
+            components = metadata.get("pca_components")
+            mean = metadata.get("pca_mean")
+            if components is None or mean is None:
+                raise ValueError(
+                    "This checkpoint used PCA but does not contain the fitted PCA state. "
+                    "Re-run fine-tuning with the current FeatureAdapter format."
+                )
+            adapter.pca_components_ = np.asarray(components, dtype=adapter.dtype_)
+            adapter.pca_mean_ = np.asarray(mean, dtype=adapter.dtype_)
+            if adapter.pca_components_.shape != (adapter.target_dim, adapter.input_dim):
+                raise ValueError("Checkpoint PCA component shape does not match target_dim and input_dim.")
+            if adapter.pca_mean_.shape != (adapter.input_dim,):
+                raise ValueError("Checkpoint PCA mean shape does not match input_dim.")
+            if not np.all(np.isfinite(adapter.pca_components_)) or not np.all(np.isfinite(adapter.pca_mean_)):
+                raise ValueError("Checkpoint PCA state must be finite.")
+        elif adapter.input_dim > adapter.target_dim:
+            raise ValueError("Checkpoint preprocessing cannot reduce input_dim without fitted PCA state.")
+
+        return adapter
+
+    def _pad(self, data: np.ndarray) -> np.ndarray:
+        pad_width = self.target_dim - data.shape[1]
+        return np.pad(data, ((0, 0), (0, pad_width)), mode="constant", constant_values=0.0)
+
+    @staticmethod
+    def _validate_array(data: np.ndarray) -> np.ndarray:
+        array = np.asarray(data)
+        if array.ndim != 2:
+            raise ValueError(f"Expected a 2D feature array, got shape {array.shape}.")
+        if array.shape[1] == 0:
+            raise ValueError("Feature array has no columns.")
+        if not np.issubdtype(array.dtype, np.floating):
+            array = array.astype(np.float64)
+        return array
+
+
+def transform_dataframe_from_metadata(data: pd.DataFrame, metadata: dict[str, Any]) -> torch.Tensor:
+    """Apply a fine-tuned checkpoint's fitted preprocessing to an inference frame."""
+    adapter = FeatureAdapter.from_metadata(metadata)
+    columns = metadata.get("columns")
+    if columns is not None:
+        if not isinstance(columns, list) or not all(isinstance(column, str) for column in columns):
+            raise ValueError("Checkpoint preprocessing columns must be a list of strings.")
+    if columns:
+        if len(columns) != adapter.input_dim:
+            raise ValueError("Checkpoint preprocessing column count does not match input_dim.")
+        if len(set(columns)) != len(columns):
+            raise ValueError("Checkpoint preprocessing columns must be unique.")
+        missing = [column for column in columns if column not in data.columns]
+        if missing:
+            raise ValueError(f"Inference data is missing fine-tuning feature columns: {missing}")
+        feature_frame = data.loc[:, columns].copy()
+    else:
+        feature_frame = data.select_dtypes(include=[np.number]).copy()
+
+    if feature_frame.empty:
+        raise ValueError("Inference data has no numeric feature columns.")
+    non_numeric = [
+        column for column in feature_frame.columns if not pd.api.types.is_numeric_dtype(feature_frame[column])
+    ]
+    if non_numeric:
+        raise ValueError(f"Fine-tuning feature columns must be numeric: {non_numeric}")
+
+    feature_frame = feature_frame.replace([np.inf, -np.inf], np.nan).ffill().bfill().fillna(0.0)
+    return adapter.transform(feature_frame.to_numpy(dtype=adapter.dtype_))

--- a/ad_diffusion/sdk/inference_ad.py
+++ b/ad_diffusion/sdk/inference_ad.py
@@ -79,6 +79,7 @@ except ImportError:
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from models.main_model import TSDiffuser_Generic
 from models.utils import evaluate
+from sdk.feature_adapter import transform_dataframe_from_metadata
 from utils.tsb_ad_preprocessor import preprocess_for_inference
 
 # DEVICE configuration - simplified for standalone use
@@ -591,6 +592,64 @@ def preprocess_dataframe(
     return torch.tensor(data, dtype=torch.float32) * scale_factor
 
 
+def _get_checkpoint_preprocessing(checkpoint: object) -> dict | None:
+    if not isinstance(checkpoint, dict):
+        return None
+    preprocessing = checkpoint.get("preprocessing")
+    return preprocessing if isinstance(preprocessing, dict) and preprocessing else None
+
+
+def _get_finetune_window_settings(
+    preprocessing: dict,
+    checkpoint: dict,
+    config: dict,
+) -> tuple[int, int]:
+    checkpoint_args = checkpoint.get("args", {})
+    if not isinstance(checkpoint_args, dict):
+        checkpoint_args = {}
+    dataset_config = config.get("dataset", {})
+    if not isinstance(dataset_config, dict):
+        dataset_config = {}
+
+    window_length = (
+        preprocessing.get("window_length")
+        or checkpoint_args.get("window_length")
+        or dataset_config.get("window_length", 100)
+    )
+    split = preprocessing.get("split") or checkpoint_args.get("split") or dataset_config.get("split", 4)
+    window_length = int(window_length)
+    split = int(split)
+    if window_length <= 0 or split <= 0:
+        raise ValueError("Checkpoint preprocessing window_length and split must be positive.")
+    if window_length % split != 0:
+        raise ValueError("Checkpoint preprocessing window_length must be divisible by split.")
+    return window_length, split
+
+
+def _apply_checkpoint_preprocessing(
+    data: pd.DataFrame,
+    checkpoint: object,
+    config: dict,
+    target_dim: int,
+    preprocess_model_dir: str | None,
+) -> tuple[torch.Tensor, int, int, float] | None:
+    """Replay fine-tuning preprocessing unless the caller explicitly supplied another preprocessor."""
+    preprocessing = _get_checkpoint_preprocessing(checkpoint)
+    if preprocessing is None or preprocess_model_dir is not None:
+        return None
+
+    metadata_target_dim = int(preprocessing.get("target_dim", target_dim))
+    if metadata_target_dim != target_dim:
+        raise ValueError(
+            f"Checkpoint preprocessing target_dim={metadata_target_dim} does not match model target_dim={target_dim}."
+        )
+
+    preprocessed = transform_dataframe_from_metadata(data, preprocessing)
+    window_length, split = _get_finetune_window_settings(preprocessing, checkpoint, config)
+    scale_factor = float(preprocessing.get("scale_factor", config.get("dataset", {}).get("scale_factor", 1.0)))
+    return preprocessed, window_length, split, scale_factor
+
+
 def _build_window_indexes(total_rows: int, window_length: int, window_split: int) -> list[int]:
     step = max(1, window_length // max(1, window_split))
     if total_rows < window_length:
@@ -1042,7 +1101,8 @@ def inference_ad_tesseract2(
         config_path: Path to config file. Optional if the config is embedded in the
             checkpoint; otherwise ``curriculum_medium.yaml`` is downloaded from HF.
         nsample: Number of samples for diffusion model inference
-        preprocess_model_dir: Directory containing preprocessing model (optional)
+        preprocess_model_dir: Directory containing an external preprocessing model (optional). When omitted,
+            fitted preprocessing embedded in a fine-tuned checkpoint is replayed automatically.
         use_dpm_solver: If True, use DPM-Solver for 50-100x faster inference
         dpm_steps: Number of DPM-Solver steps (10-50, default: 20)
 
@@ -1084,10 +1144,25 @@ def inference_ad_tesseract2(
     model.eval()
 
     scale_factor = config.get("dataset", {}).get("scale_factor", 1.0)
-
-    test_loader1, test_loader2 = get_dataloader(
-        data, target_dim, scale_factor=scale_factor, model_dir=preprocess_model_dir
+    checkpoint_data = _apply_checkpoint_preprocessing(
+        data,
+        checkpoint,
+        config,
+        target_dim,
+        preprocess_model_dir,
     )
+
+    if checkpoint_data is not None:
+        preprocessed, window_length, split, _ = checkpoint_data
+        test_loader1, test_loader2 = get_dataloader_from_array(
+            preprocessed,
+            window_length=window_length,
+            split=split,
+        )
+    else:
+        test_loader1, test_loader2 = get_dataloader(
+            data, target_dim, scale_factor=scale_factor, model_dir=preprocess_model_dir
+        )
 
     # Run inference with DPM support
     results = evaluate_ad_tesseract2(
@@ -1132,7 +1207,8 @@ def inference_ad_tesseract2_mp(
         config_path: Path to config file. Optional if the config is embedded in the
             checkpoint; otherwise ``curriculum_medium.yaml`` is downloaded from HF.
         nsample: Number of diffusion samples per window.
-        preprocess_model_dir: Directory containing preprocessing model (optional).
+        preprocess_model_dir: Directory containing an external preprocessing model (optional). When omitted,
+            fitted preprocessing embedded in a fine-tuned checkpoint is replayed automatically.
         num_processes: Number of GPU worker processes (defaults to len(gpu_ids)).
         gpu_ids: List of GPU ids to use (defaults to all visible GPUs).
         seed: Random seed for reproducibility.
@@ -1199,13 +1275,23 @@ def inference_ad_tesseract2_mp(
     window_length = config.get("dataset", {}).get("window_length", 100)
     window_split = 1
     split = config.get("dataset", {}).get("split", 4)
-
-    preprocessed = preprocess_dataframe(
+    checkpoint_data = _apply_checkpoint_preprocessing(
         data,
+        checkpoint,
+        config,
         target_dim,
-        scale_factor=scale_factor,
-        model_dir=preprocess_model_dir,
+        preprocess_model_dir,
     )
+
+    if checkpoint_data is not None:
+        preprocessed, window_length, split, scale_factor = checkpoint_data
+    else:
+        preprocessed = preprocess_dataframe(
+            data,
+            target_dim,
+            scale_factor=scale_factor,
+            model_dir=preprocess_model_dir,
+        )
     num_rows = len(preprocessed)
     begin_indexes = _build_window_indexes(num_rows, window_length, window_split)
     window_tensor = _build_window_tensor(preprocessed.cpu().numpy(), begin_indexes, window_length)

--- a/ad_diffusion/sdk/tests/test_finetune_preprocessing.py
+++ b/ad_diffusion/sdk/tests/test_finetune_preprocessing.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from examples import finetune_example
+from sdk import inference_ad
+from sdk.feature_adapter import FeatureAdapter, transform_dataframe_from_metadata
+
+
+def test_checkpoint_transform_preserves_training_scale_on_shifted_serving_batch() -> None:
+    train = np.array(
+        [[0.0, 0.0], [5.0, 10.0], [10.0, 20.0]],
+        dtype=np.float32,
+    )
+    serving = pd.DataFrame(
+        {
+            "is_anomaly": [0, 1, 0],
+            "sensor_b": [200.0, 210.0, 220.0],
+            "sensor_a": [100.0, 105.0, 110.0],
+        }
+    )
+
+    adapter = FeatureAdapter(target_dim=2, scale_factor=20.0, seed=42)
+    adapter.fit(train)
+    metadata = adapter.metadata()
+    metadata["columns"] = ["sensor_a", "sensor_b"]
+
+    expected = adapter.transform(serving[["sensor_a", "sensor_b"]].to_numpy(dtype=np.float32))
+    replayed = transform_dataframe_from_metadata(serving, metadata)
+    batch_refit = inference_ad.preprocess_dataframe(
+        serving[["sensor_a", "sensor_b"]],
+        target_dim=2,
+        scale_factor=20.0,
+    )
+
+    assert torch.equal(replayed, expected)
+    assert torch.max(torch.abs(batch_refit - expected)).item() == 200.0
+
+
+def test_checkpoint_transform_exactly_replays_pca_with_reordered_and_extra_columns() -> None:
+    rng = np.random.default_rng(42)
+    train = rng.normal(size=(64, 5)).astype(np.float32)
+    serving_array = rng.normal(loc=3.0, size=(8, 5)).astype(np.float32)
+    columns = [f"sensor_{index}" for index in range(5)]
+
+    adapter = FeatureAdapter(target_dim=3, scale_factor=20.0, seed=42)
+    adapter.fit(train)
+    metadata = adapter.metadata()
+    metadata["columns"] = columns
+
+    serving = pd.DataFrame(serving_array, columns=columns)
+    serving.insert(0, "numeric_label", np.ones(len(serving)))
+    serving = serving[["numeric_label", *reversed(columns)]]
+
+    expected = adapter.transform(serving[columns].to_numpy(dtype=np.float32))
+    replayed = transform_dataframe_from_metadata(serving, metadata)
+
+    assert torch.allclose(replayed, expected, rtol=1e-5, atol=1e-5)
+    assert replayed.shape == (len(serving), 3)
+
+
+def test_metadata_replay_matches_fitted_adapter_across_dimension_modes() -> None:
+    for input_dim, target_dim in ((2, 4), (4, 4), (7, 3)):
+        for seed in range(5):
+            rng = np.random.default_rng(seed)
+            train = rng.normal(size=(64, input_dim)).astype(np.float32)
+            serving_array = rng.normal(loc=3.0, size=(17, input_dim)).astype(np.float32)
+            columns = [f"sensor_{index}" for index in range(input_dim)]
+
+            adapter = FeatureAdapter(target_dim=target_dim, scale_factor=20.0, seed=seed)
+            adapter.fit(train)
+            metadata = adapter.metadata()
+            metadata["columns"] = columns
+
+            expected = adapter.transform(serving_array)
+            replayed = transform_dataframe_from_metadata(pd.DataFrame(serving_array, columns=columns), metadata)
+
+            assert torch.allclose(replayed, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_legacy_non_pca_metadata_remains_replayable() -> None:
+    train = np.array([[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]], dtype=np.float32)
+    adapter = FeatureAdapter(target_dim=4, scale_factor=20.0, seed=42)
+    adapter.fit(train)
+    metadata = adapter.metadata()
+    for key in ("version", "dtype", "seed", "pca_components", "pca_mean"):
+        metadata.pop(key)
+    metadata["columns"] = ["sensor_a", "sensor_b"]
+
+    serving = pd.DataFrame({"sensor_a": [1.5, 2.5], "sensor_b": [15.0, 25.0]})
+
+    assert torch.equal(
+        transform_dataframe_from_metadata(serving, metadata),
+        adapter.transform(serving.to_numpy(dtype=np.float32)),
+    )
+
+
+def test_legacy_pca_metadata_fails_instead_of_silently_refitting() -> None:
+    train = np.arange(48, dtype=np.float32).reshape(12, 4)
+    adapter = FeatureAdapter(target_dim=2, scale_factor=20.0, seed=42)
+    adapter.fit(train)
+    metadata = adapter.metadata()
+    metadata["pca_components"] = None
+    metadata["pca_mean"] = None
+
+    with pytest.raises(ValueError, match="used PCA.*Re-run fine-tuning"):
+        FeatureAdapter.from_metadata(metadata)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("version", 99, "Unsupported checkpoint preprocessing metadata version"),
+        ("uses_pca", "false", "uses_pca must be boolean"),
+        ("min", [np.nan, 0.0], "min/max values must be finite"),
+    ],
+)
+def test_invalid_checkpoint_metadata_fails_closed(field, value, message) -> None:
+    adapter = FeatureAdapter(target_dim=2, scale_factor=20.0, seed=42)
+    adapter.fit(np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32))
+    metadata = adapter.metadata()
+    metadata[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        FeatureAdapter.from_metadata(metadata)
+
+
+def test_checkpoint_metadata_survives_serialization_and_rejects_missing_features(tmp_path) -> None:
+    train = np.array([[0.0, 10.0], [5.0, 15.0], [10.0, 20.0]], dtype=np.float32)
+    adapter = FeatureAdapter(target_dim=2, scale_factor=20.0, seed=42)
+    adapter.fit(train)
+    metadata = adapter.metadata()
+    metadata["columns"] = ["sensor_a", "sensor_b"]
+
+    checkpoint_path = tmp_path / "fine-tuned.pth"
+    model = torch.nn.Linear(2, 2)
+    optimizer = torch.optim.AdamW(model.parameters())
+    finetune_example.save_checkpoint(
+        checkpoint_path,
+        model,
+        optimizer,
+        config={"model": {"target_dim": 2}},
+        args=SimpleNamespace(seed=42),
+        epoch=1,
+        train_loss=0.2,
+        val_loss=0.1,
+        preprocessing=metadata,
+    )
+    restored_metadata = torch.load(checkpoint_path, map_location="cpu", weights_only=False)["preprocessing"]
+
+    serving = pd.DataFrame({"sensor_a": [2.5], "sensor_b": [12.5]})
+    assert torch.equal(
+        transform_dataframe_from_metadata(serving, restored_metadata),
+        adapter.transform(serving.to_numpy(dtype=np.float32)),
+    )
+
+    with pytest.raises(ValueError, match="missing fine-tuning feature columns.*sensor_b"):
+        transform_dataframe_from_metadata(serving.drop(columns="sensor_b"), restored_metadata)
+
+
+def test_explicit_external_preprocessor_overrides_checkpoint_metadata() -> None:
+    adapter = FeatureAdapter(target_dim=2, scale_factor=20.0, seed=42)
+    adapter.fit(np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32))
+    checkpoint = {"preprocessing": adapter.metadata()}
+
+    assert (
+        inference_ad._apply_checkpoint_preprocessing(
+            pd.DataFrame({"sensor_a": [1.0], "sensor_b": [2.0]}),
+            checkpoint,
+            config={"dataset": {}},
+            target_dim=2,
+            preprocess_model_dir="external/preprocessor",
+        )
+        is None
+    )
+
+
+def test_public_inference_automatically_uses_checkpoint_transform(monkeypatch) -> None:
+    train = np.array([[0.0, 0.0], [5.0, 10.0], [10.0, 20.0]], dtype=np.float32)
+    serving = pd.DataFrame(
+        {
+            "sensor_b": [200.0, 210.0, 220.0],
+            "sensor_a": [100.0, 105.0, 110.0],
+            "numeric_label": [0, 1, 0],
+        }
+    )
+    adapter = FeatureAdapter(target_dim=2, scale_factor=20.0, seed=42)
+    adapter.fit(train)
+    preprocessing = adapter.metadata()
+    preprocessing.update({"columns": ["sensor_a", "sensor_b"], "window_length": 2, "split": 2})
+    checkpoint = {
+        "model": {},
+        "config": {"model": {"target_dim": 2}, "dataset": {"scale_factor": 999.0}},
+        "preprocessing": preprocessing,
+    }
+
+    class DummyModel:
+        def load_state_dict(self, _state):
+            return None
+
+        def to(self, _device):
+            return self
+
+        def eval(self):
+            return self
+
+    captured: dict[str, object] = {}
+
+    def fake_evaluate(_model, loader1, _loader2, **_kwargs):
+        captured["data"] = loader1.dataset.data.clone()
+        captured["window_length"] = loader1.dataset.window_length
+        captured["split"] = loader1.dataset.split
+        return {"residual": np.zeros(len(serving))}
+
+    monkeypatch.setattr(inference_ad, "_resolve_model_paths", lambda *_args: ("fine-tuned.pth", ""))
+    monkeypatch.setattr(inference_ad.torch, "load", lambda *_args, **_kwargs: checkpoint)
+    monkeypatch.setattr(inference_ad, "TSDiffuser_Generic", lambda *_args, **_kwargs: DummyModel())
+    monkeypatch.setattr(inference_ad, "evaluate_ad_tesseract2", fake_evaluate)
+    monkeypatch.setattr(
+        inference_ad,
+        "get_dataloader",
+        lambda *_args, **_kwargs: pytest.fail("generic batch-fitted preprocessing should not be used"),
+    )
+
+    result = inference_ad.inference_ad_tesseract2(serving, model_path="fine-tuned.pth")
+
+    expected = adapter.transform(serving[["sensor_a", "sensor_b"]].to_numpy(dtype=np.float32))
+    assert torch.equal(captured["data"], expected)
+    assert captured["window_length"] == 2
+    assert captured["split"] == 2
+    assert result["target_dim"] == 2
+
+
+def test_public_inference_without_metadata_keeps_generic_preprocessing(monkeypatch) -> None:
+    checkpoint = {
+        "model": {},
+        "config": {"model": {"target_dim": 2}, "dataset": {"scale_factor": 7.0}},
+    }
+
+    class DummyModel:
+        def load_state_dict(self, _state):
+            return None
+
+        def to(self, _device):
+            return self
+
+        def eval(self):
+            return self
+
+    captured: dict[str, object] = {}
+
+    def fake_get_dataloader(*args: object, **kwargs: object):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return object(), object()
+
+    monkeypatch.setattr(inference_ad, "_resolve_model_paths", lambda *_args: ("pretrained.pth", ""))
+    monkeypatch.setattr(inference_ad.torch, "load", lambda *_args, **_kwargs: checkpoint)
+    monkeypatch.setattr(inference_ad, "TSDiffuser_Generic", lambda *_args, **_kwargs: DummyModel())
+    monkeypatch.setattr(inference_ad, "get_dataloader", fake_get_dataloader)
+    monkeypatch.setattr(inference_ad, "evaluate_ad_tesseract2", lambda *_args, **_kwargs: {})
+
+    data = pd.DataFrame({"sensor_a": [1.0], "sensor_b": [2.0]})
+    result = inference_ad.inference_ad_tesseract2(data, model_path="pretrained.pth")
+
+    assert captured["args"] == (data, 2)
+    assert captured["kwargs"] == {"scale_factor": 7.0, "model_dir": None}
+    assert result["target_dim"] == 2


### PR DESCRIPTION
Fixes #31

## Summary

- Add a shared, serializable `FeatureAdapter` for AD fine-tuning and inference.
- Persist the fitted dtype, min/max statistics, PCA components/mean, feature-column order, scale factor, window length, and split in fine-tuned checkpoints.
- Replay embedded checkpoint preprocessing automatically in single- and multi-GPU inference when no explicit external preprocessor is supplied.
- Preserve the existing generic preprocessing path for pretrained checkpoints without embedded metadata.
- Add regression coverage for shifted serving ranges, PCA replay, checkpoint serialization, reordered/extra columns, missing columns, legacy compatibility, explicit overrides, and public SDK routing.

## Root cause

Fine-tuning fit preprocessing on the training split, but SDK inference ignored the checkpoint's `preprocessing` field and fit a fresh dimensionality transform/min-max scaler on each inference batch. The model could therefore receive a different feature representation from the one used during fine-tuning. PCA checkpoints were particularly affected because the fitted PCA components and mean were not saved.

## Impact

Fine-tuned models now receive stable, training-consistent inputs at inference time. A serving-range shift remains visible relative to the training distribution instead of being normalized back into the batch's local range. Stored feature names/order also prevent extra numeric metadata columns from changing the model input.

Malformed metadata and legacy PCA checkpoints that lack fitted PCA state fail clearly rather than silently producing an incorrect transform. Older non-PCA fine-tuned checkpoints remain replayable. Passing `preprocess_model_dir` explicitly still overrides embedded metadata.

## Validation

- `make lint`
- `PYTHONPATH=. python -m pytest sdk/tests examples/tests -q --tb=short` in `ad_diffusion` — 21 passed
- `PYTHONPATH=. python -m pytest sdk/tests examples/tests -q --tb=short` in `forecasting` — 42 passed
- AD-specific Ruff check and format check
- `python examples/finetune_example.py --help`
- 60 randomized adapter-vs-replay comparisons across padding, equal-dimension, and PCA paths; worst PCA difference `7.629e-6`, below the `1e-5` tolerance

This PR fixes the preprocessing contract. A downstream ROC-AUC/F1 comparison should still be measured separately with a controlled old-vs-new inference A/B using the same fine-tuned checkpoint and labeled holdout data.
