### PR TITLE
Forecasting: isolate temporary CSVs across concurrent calls

### DIFF
--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -330,6 +330,14 @@ def l2_normalize(a: np.ndarray, eps: float = 1e-12) -> np.ndarray:
     return a / np.maximum(n, eps)
 
 
+def _create_temp_csv_path(prefix: str) -> str:
+    """Return an exclusively created temporary CSV path for one forecasting call."""
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=".csv")
+    # pandas writes by path; keep the file but release mkstemp's creator handle.
+    os.close(fd)
+    return path
+
+
 @torch.no_grad()
 def embed_batch(model, x_enc, input_mask):
     """Generate embeddings for a batch"""
@@ -1640,9 +1648,9 @@ def perform_forecasting(
     temp_context_csv = None
 
     try:
-        # Create temporary CSV from DataFrame for processing
-        temp_dir = tempfile.gettempdir()
-        temp_test_csv = os.path.join(temp_dir, f"temp_test_{os.getpid()}.csv")
+        # Create a unique CSV for this invocation. PID-only names collide when
+        # multiple requests run concurrently in one service process.
+        temp_test_csv = _create_temp_csv_path("nv_tesseract_test_")
 
         # Save only the necessary columns (timestamp + value columns)
         csv_df = working_df[[timestamp_column] + columns_to_process].copy()
@@ -1652,7 +1660,7 @@ def perform_forecasting(
 
         # Handle context DataFrame if provided for DARR mode
         if context_df is not None:
-            temp_context_csv = os.path.join(temp_dir, f"temp_context_{os.getpid()}.csv")
+            temp_context_csv = _create_temp_csv_path("nv_tesseract_context_")
 
             # Validate context DataFrame columns
             if timestamp_column not in context_df.columns:
@@ -1943,7 +1951,6 @@ def perform_forecasting(
 
     finally:
         # Clean up temporary files
-        if temp_test_csv and os.path.exists(temp_test_csv):
-            Path(temp_test_csv).unlink()
-        if temp_context_csv and os.path.exists(temp_context_csv):
-            Path(temp_context_csv).unlink()
+        for temp_csv in (temp_test_csv, temp_context_csv):
+            if temp_csv:
+                Path(temp_csv).unlink(missing_ok=True)

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import numpy as np
@@ -101,6 +103,76 @@ def test_perform_forecasting_generates_forecast_when_horizon_exceeds_model_horiz
     assert "target_forecast" in result.columns
     assert len(result) == 3
     assert result["target_forecast"].tolist() == [1.0, 1.0, 1.0]
+
+
+def test_perform_forecasting_uses_distinct_temp_csvs_for_concurrent_calls(monkeypatch):
+    """Same-process calls must not select the same temporary input path."""
+
+    class StopAfterTempCsvError(RuntimeError):
+        pass
+
+    paths = []
+    paths_lock = threading.Lock()
+    both_calls_reached_csv = threading.Barrier(2)
+
+    def capture_temp_csv(self, path, *args: object, **kwargs: object):
+        with paths_lock:
+            paths.append(str(path))
+        both_calls_reached_csv.wait(timeout=5)
+        raise StopAfterTempCsvError
+
+    def invoke(_):
+        with pytest.raises(StopAfterTempCsvError):
+            forecasting.perform_forecasting(
+                make_timeseries(num_rows=10),
+                seq_len=5,
+                forecast_horizon=2,
+                model_horizon=2,
+                standardizer_pkl="fake_std.pkl",
+                ckpt="fake_ckpt.pt",
+            )
+
+    monkeypatch.setattr(pd.DataFrame, "to_csv", capture_temp_csv)
+    monkeypatch.setattr(
+        forecasting,
+        "download_model_weights",
+        lambda standardizer_pkl, ckpt: (standardizer_pkl, ckpt),
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(invoke, range(2)))
+
+    assert len(paths) == 2
+    assert len(set(paths)) == 2
+
+
+@pytest.mark.parametrize("with_context, expected_temp_files", [(False, 1), (True, 2)])
+def test_perform_forecasting_uses_and_cleans_owned_temp_csvs(monkeypatch, tmp_path, with_context, expected_temp_files):
+    """Standard and DARR calls clean up every unique CSV allocated for them."""
+    created_paths = []
+
+    def create_temp_csv_path(prefix: str) -> str:
+        path = tmp_path / f"{prefix}{len(created_paths)}.csv"
+        path.touch()
+        created_paths.append(path)
+        return str(path)
+
+    monkeypatch.setattr(forecasting, "_create_temp_csv_path", create_temp_csv_path)
+
+    result = forecasting.perform_forecasting(
+        make_timeseries(num_rows=10),
+        context_df=make_timeseries(num_rows=10) if with_context else None,
+        seq_len=5,
+        forecast_horizon=2,
+        model_horizon=2,
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        num_workers=0,
+    )
+
+    assert len(result) == 2
+    assert len(created_paths) == expected_temp_files
+    assert all(not path.exists() for path in created_paths)
 
 
 def test_perform_forecasting_uses_cross_channel_model_by_default(patch_external_dependencies):


### PR DESCRIPTION
## Summary

- Replace PID-only temporary CSV names with exclusively created per-call paths.
- Isolate both standard input CSVs and DARR context CSVs across concurrent requests in one process.
- Make temporary-file cleanup idempotent.
- Add regression coverage for same-process concurrency and standard/DARR cleanup.

## Root cause

`perform_forecasting()` previously derived temporary filenames only from `os.getpid()`. Concurrent requests handled by different threads in the same service process therefore used the same `temp_test_<pid>.csv` and `temp_context_<pid>.csv` paths. One request could overwrite another request's inputs or remove the shared file while the other request was still using it.

## Behavior

Temporary CSV paths are now allocated with `tempfile.mkstemp()`, which atomically creates a unique file for each invocation. pandas subsequently writes to that owned path, and the `finally` block removes only the paths allocated by that invocation using idempotent cleanup.

The regression test was also run against the pre-fix base revision `54863a2`. Two concurrent calls selected the same path and failed the uniqueness assertion:

```text
assert len(set(paths)) == 2
E assert 1 == 2
E {'/tmp/temp_test_<pid>.csv'}
```

The same regression passes with this change.

## Validation

- `make spdx-check`
- `make lint`
- `cd forecasting && pytest -q sdk/tests/test_forecasting.py` (`41 passed`)
- `git diff --check`


Fixes #35

