### PR TITLE
Align AD inference with training normalization

### DIFF
--- a/ad_diffusion/models/main_model.py
+++ b/ad_diffusion/models/main_model.py
@@ -307,19 +307,7 @@ class TSDiffuser_base(nn.Module):
         # Clamp alpha to prevent numerical issues
         current_alpha = torch.clamp(current_alpha, min=1e-6, max=1.0 - 1e-6)
 
-        # Add input validation and normalization
-        if torch.isnan(observed_data).any():
-            print("WARNING: NaN detected in observed_data!")
-            observed_data = torch.nan_to_num(observed_data, nan=0.0)
-
-        # Normalize input data to prevent extreme values
-        # Use instance normalization to handle each sample independently
-        data_mean = observed_data.mean(dim=(1, 2), keepdim=True)
-        data_std = observed_data.std(dim=(1, 2), keepdim=True) + 1e-5
-        observed_data = (observed_data - data_mean) / data_std
-
-        # Final safety clamp after normalization
-        observed_data = torch.clamp(observed_data, min=-10.0, max=10.0)
+        observed_data, _, _ = self._normalize_observed_data(observed_data)
 
         # Generate noise with slight reduction to prevent overflow
         noise = torch.randn_like(observed_data) * 0.999
@@ -417,6 +405,24 @@ class TSDiffuser_base(nn.Module):
             }
         total_loss = loss
         return total_loss
+
+    @staticmethod
+    def _normalize_observed_data(observed_data):
+        """Apply the per-window scale used by diffusion training."""
+        if torch.isnan(observed_data).any():
+            print("WARNING: NaN detected in observed_data!")
+            observed_data = torch.nan_to_num(observed_data, nan=0.0)
+
+        data_mean = observed_data.mean(dim=(1, 2), keepdim=True)
+        data_std = observed_data.std(dim=(1, 2), keepdim=True) + 1e-5
+        normalized_data = (observed_data - data_mean) / data_std
+        normalized_data = torch.clamp(normalized_data, min=-10.0, max=10.0)
+        return normalized_data, data_mean, data_std
+
+    @staticmethod
+    def _denormalize_samples(samples, data_mean, data_std):
+        """Return generated samples to the input scale used by SDK residuals."""
+        return samples * data_std.unsqueeze(1) + data_mean.unsqueeze(1)
 
     def set_input_to_diffmodel(self, noisy_data, observed_data, cond_mask):
         if self.is_unconditional:
@@ -759,7 +765,9 @@ class TSDiffuser_base(nn.Module):
 
             side_info = self.get_side_info(observed_tp, cond_mask)
 
-            samples = self.impute(observed_data, cond_mask, side_info, n_samples, strategy_type)
+            normalized_data, data_mean, data_std = self._normalize_observed_data(observed_data)
+            samples = self.impute(normalized_data, cond_mask, side_info, n_samples, strategy_type)
+            samples = self._denormalize_samples(samples, data_mean, data_std)
 
             for i in range(len(cut_length)):  # to avoid double evaluation
                 target_mask[i, ..., 0 : cut_length[i].item()] = 0
@@ -797,10 +805,12 @@ class TSDiffuser_base(nn.Module):
 
             side_info = self.get_side_info(observed_tp, cond_mask)
 
+            normalized_data, data_mean, data_std = self._normalize_observed_data(observed_data)
             # Use DPM-Solver for fast sampling
             samples = self.dpm_solver_impute(
-                observed_data, cond_mask, side_info, n_samples, strategy_type, num_steps=dpm_steps
+                normalized_data, cond_mask, side_info, n_samples, strategy_type, num_steps=dpm_steps
             )
+            samples = self._denormalize_samples(samples, data_mean, data_std)
 
             for i in range(len(cut_length)):  # to avoid double evaluation
                 target_mask[i, ..., 0 : cut_length[i].item()] = 0

--- a/ad_diffusion/sdk/tests/test_inference_scale_contract.py
+++ b/ad_diffusion/sdk/tests/test_inference_scale_contract.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import MethodType
+
+import pytest
+import torch
+from torch import nn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from models.main_model import TSDiffuser_base
+
+
+def _observed_window() -> torch.Tensor:
+    return torch.tensor(
+        [[[0.0, 5.0, 10.0, 15.0], [20.0, 25.0, 30.0, 35.0]]],
+        dtype=torch.float32,
+    )
+
+
+def _expected_training_scale(observed_data: torch.Tensor) -> torch.Tensor:
+    mean = observed_data.mean(dim=(1, 2), keepdim=True)
+    std = observed_data.std(dim=(1, 2), keepdim=True) + 1e-5
+    return torch.clamp((observed_data - mean) / std, min=-10.0, max=10.0)
+
+
+def _bare_model() -> TSDiffuser_base:
+    model = TSDiffuser_base.__new__(TSDiffuser_base)
+    nn.Module.__init__(model)
+    model.device = torch.device("cpu")
+    model.num_steps = 1
+    model.is_unconditional = False
+    model.use_aux_loss = False
+    model.alpha_torch = torch.tensor([[[0.9]]], dtype=torch.float32)
+    model.alpha_hat = torch.tensor([0.9], dtype=torch.float32)
+    model.alpha = torch.tensor([0.9], dtype=torch.float32)
+    model.beta = torch.tensor([0.1], dtype=torch.float32)
+    return model
+
+
+class RecordingDiffModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.inputs: list[torch.Tensor] = []
+
+    def forward(self, total_input, _side_info, _t, _strategy_type):
+        self.inputs.append(total_input.detach().clone())
+        return torch.zeros_like(total_input[:, 0])
+
+
+def test_training_and_evaluation_present_the_same_conditioning_scale_to_denoiser() -> None:
+    observed_data = _observed_window()
+    observed_mask = torch.ones_like(observed_data)
+    cond_mask = torch.tensor(
+        [[[1.0, 0.0, 1.0, 0.0], [1.0, 0.0, 1.0, 0.0]]],
+        dtype=torch.float32,
+    )
+    strategy_type = torch.zeros(1, dtype=torch.long)
+    side_info = torch.empty(1)
+    recorder = RecordingDiffModel()
+    model = _bare_model()
+    model.diffmodel = recorder
+
+    model.calc_loss(
+        observed_data,
+        cond_mask,
+        observed_mask,
+        side_info,
+        is_train=1,
+        strategy_type=strategy_type,
+    )
+
+    def process_data(_self, _batch):
+        return (
+            observed_data,
+            observed_mask,
+            torch.zeros(1, observed_data.shape[-1]),
+            cond_mask,
+            observed_mask,
+            torch.zeros(1, dtype=torch.long),
+            strategy_type,
+        )
+
+    model.process_data = MethodType(process_data, model)
+    model.get_side_info = MethodType(lambda _self, *_args: side_info, model)
+    model.evaluate({}, n_samples=1)
+
+    training_conditioning = recorder.inputs[0][:, 0]
+    evaluation_conditioning = recorder.inputs[1][:, 0]
+
+    assert torch.allclose(evaluation_conditioning, training_conditioning)
+
+
+@pytest.mark.parametrize(
+    ("evaluate_name", "impute_name"),
+    [
+        ("evaluate", "impute"),
+        ("evaluate_with_dpm", "dpm_solver_impute"),
+    ],
+)
+def test_evaluation_normalizes_model_input_and_denormalizes_returned_samples(
+    evaluate_name: str,
+    impute_name: str,
+) -> None:
+    observed_data = _observed_window()
+    observed_mask = torch.ones_like(observed_data)
+    cond_mask = torch.ones_like(observed_data)
+    strategy_type = torch.zeros(1, dtype=torch.long)
+    expected_model_input = _expected_training_scale(observed_data)
+    captured: dict[str, torch.Tensor] = {}
+    model = _bare_model()
+
+    def process_data(_self, _batch):
+        return (
+            observed_data,
+            observed_mask,
+            torch.zeros(1, observed_data.shape[-1]),
+            cond_mask,
+            observed_mask,
+            torch.zeros(1, dtype=torch.long),
+            strategy_type,
+        )
+
+    def fake_impute(
+        _self: TSDiffuser_base,
+        model_input: torch.Tensor,
+        *_args: object,
+        **_kwargs: object,
+    ) -> torch.Tensor:
+        captured["model_input"] = model_input.detach().clone()
+        return model_input.unsqueeze(1)
+
+    model.process_data = MethodType(process_data, model)
+    model.get_side_info = MethodType(lambda _self, *_args: torch.empty(1), model)
+    setattr(model, impute_name, MethodType(fake_impute, model))
+
+    samples, returned_target, *_ = getattr(model, evaluate_name)({}, n_samples=1)
+
+    assert torch.allclose(captured["model_input"], expected_model_input)
+    assert torch.allclose(samples[:, 0], observed_data)
+    assert torch.equal(returned_target, observed_data)


### PR DESCRIPTION
Fixes #40

## Summary

- Reuse the per-window normalization already used by `calc_loss()` for both standard and DPM-Solver inference.
- Denormalize generated samples before returning them so SDK residuals continue comparing reconstructions and targets in the same external scale.
- Add regression coverage for the denoiser-boundary scale contract and returned reconstruction scale.

## Root cause

`TSDiffuser_base.calc_loss()` standardizes each observed window before constructing the conditioned/noisy denoiser input, but `evaluate()` and `evaluate_with_dpm()` previously passed raw SDK-preprocessed values directly into `impute()` and `dpm_solver_impute()`.

As a result, the same observation reached the denoiser in different numerical distributions during training and inference. The mismatch happened before residual scoring or thresholding and affected both inference implementations.

## Implementation

The change extracts the existing training transform into `_normalize_observed_data()` and uses it in all three paths. Inference retains the per-window mean/std and applies `_denormalize_samples()` before returning generated samples. This preserves the public SDK contract: `recon` and `target` remain directly comparable in the preprocessed target scale.

## Public reconstruction benchmark

To avoid threshold-strategy effects, reconstruction quality was measured directly from `inference["recon"]` against `inference["target"]`:

```python
error = recon - target
mae = np.abs(error).mean()
mse = np.square(error).mean()
rmse = np.sqrt(mse)
```

Protocol:

- Public complete TSB-AD-M series: `002_MSL_id_1_Sensor_tr_500_1st_900.csv` and `144_SMAP_id_1_Sensor_tr_2052_1st_5300.csv`.
- Published NV-Tesseract AD checkpoint and `curriculum_medium.yaml`.
- Fixed seed `2026`, `nsample=1`, DPM-Solver with 5 steps.
- No SCS/MACS thresholding, point adjustment, top-k selection, or anomaly-label-dependent threshold.
- `PR #39` denotes the complementary-mask aggregation fix; `both` applies that change together with this PR.

| Dataset | Variant | MAE | MSE | RMSE | MAE reduction vs baseline | MSE reduction vs baseline |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| MSL | baseline | 2.982 | 14.157 | 3.763 | — | — |
| MSL | this PR | 0.968 | 1.484 | 1.218 | 67.6% | 89.5% |
| MSL | PR #39 | 0.339 | 0.784 | 0.886 | 88.6% | 94.5% |
| MSL | both | 0.184 | 0.165 | 0.407 | 93.8% | 98.8% |
| SMAP | baseline | 2.869 | 12.989 | 3.604 | — | — |
| SMAP | this PR | 0.253 | 0.133 | 0.365 | 91.2% | 99.0% |
| SMAP | PR #39 | 0.405 | 1.170 | 1.082 | 85.9% | 91.0% |
| SMAP | both | 0.050 | 0.022 | 0.149 | 98.3% | 99.8% |

The improvement also holds when errors are separated by labeled timestamp type:

| Dataset | Variant | Normal MAE | Normal MSE | Anomaly MAE | Anomaly MSE |
| --- | --- | ---: | ---: | ---: | ---: |
| MSL | baseline | 2.983 | 14.161 | 2.896 | 13.493 |
| MSL | this PR | 0.968 | 1.484 | 0.918 | 1.392 |
| MSL | PR #39 | 0.340 | 0.786 | 0.306 | 0.554 |
| MSL | both | 0.184 | 0.166 | 0.174 | 0.144 |
| SMAP | baseline | 2.869 | 12.996 | 2.867 | 12.948 |
| SMAP | this PR | 0.248 | 0.130 | 0.289 | 0.153 |
| SMAP | PR #39 | 0.404 | 1.165 | 0.411 | 1.201 |
| SMAP | both | 0.049 | 0.022 | 0.057 | 0.025 |

Residual-based anomaly precision/recall/F1 are intentionally not used as the reconstruction-quality acceptance criterion here because they depend on downstream score separation and threshold calibration.

## Validation

- `make lint`
- `make spdx-check`
- `OAIPKG_DISABLE_META_MISSING=1 PYTHONPATH=$PWD/ad_diffusion python -m pytest -q sdk/tests` (`8 passed`)
- Combined regression run with this PR and PR #39 tests (`6 passed`)
