### PR TITLE
Prepare v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to NV-Tesseract are documented in this file.
+
+## v0.1.0 - 2026-07-07
+
+First public release of NV-Tesseract.
+
+### Added
+
+- Forecasting package with DataFrame-first inference, DARR context-enhanced forecasting, cross-channel forecasting support, and Hugging Face weight loading.
+- Forecasting interpretability framework with input attributions, semantic-flow diagnostics, forecast-vs-history ratios, trajectory stability metrics, and optional PDF/JSON artifacts.
+- AD Diffusion package for multivariate anomaly detection with SCS and MACS adaptive thresholding, DPM-Solver inference, and Hugging Face weight loading.
+- Fine-tuning examples for both forecasting and AD Diffusion.
+- Lightweight CI covering linting, SPDX checks, forecasting tests, AD Diffusion tests, and example tests.
+- Public documentation for installation, examples, dataset expectations, model assets, contribution flow, security reporting, and third-party notices.
+
+### Changed
+
+- Raised the PyTorch dependency floor to `torch>=2.7.0` for Blackwell GPU support.
+- Removed unused forecasting audio/vision PyTorch dependencies and the legacy `mac-mps` extra.
+- Switched user-facing progress output from direct `print` calls to logging where appropriate.
+- Updated documentation to reference public Hugging Face model repositories.
+
+### Fixed
+
+- Fixed DARR retrieval behavior when forecast horizons exceed the model horizon.
+- Fixed AD Diffusion complementary mask aggregation so each target mask selects reconstructions from its own strategy.
+- Fixed AD thresholding, packaging, and README examples.
+- Fixed pandas frequency deprecation warnings in README examples.
+
+### Notes
+
+- Repository release version: `v0.1.0`.
+- Package metadata versions at this release: `forecasting` is `0.1.0`; `ad-diffusion-oss` is `1.0.0`.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ results = perform_anomaly_analysis_with_diffusion(
 ## Requirements
 
 - Python 3.12+
-- PyTorch 2.0+
+- PyTorch 2.7+
 - pandas, numpy
 - Pretrained model weights (auto-downloaded from Hugging Face)
 - GPU recommended (CUDA or Apple MPS); falls back to CPU automatically


### PR DESCRIPTION
  Prepare first public release v0.1.0.

  Changes:
  - Add CHANGELOG.md for v0.1.0
  - Fix top-level README PyTorch requirement to 2.7+

  Validation:
  - make lint
  - make spdx-check
  - forecasting tests: 45 passed
  - AD diffusion tests: 12 passed