### PR TITLE
feat: add feature axis interpretability

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ darr_result = perform_forecasting(
 
 #### Interpretability
 
-Forecasting includes a model-agnostic **interpretability** framework that explains *why* a forecast looks the way it does — without modifying the underlying model. Pass `interpretability=True` to write an explanation bundle alongside the forecast: input attributions per horizon, semantic-flow magnitudes in latent space, forecast-vs-history diagnostic ratios, and latent trajectory stability metrics (JSON, CSVs, and optional PDF report):
+Forecasting includes a model-agnostic **interpretability** framework that explains *why* a forecast looks the way it does — without modifying the underlying model. Pass `interpretability=True` to write an explanation bundle alongside the forecast: temporal lag × horizon attributions (which past step drives each forecast step), feature-axis channel × horizon attributions for multivariate inputs (which input channel drives each forecast step), semantic-flow magnitudes in latent space, forecast-vs-history diagnostic ratios, and latent trajectory stability metrics (JSON, CSVs, and optional PDF report):
 
 ```python
 results = perform_forecasting(

--- a/forecasting/README.md
+++ b/forecasting/README.md
@@ -159,7 +159,7 @@ forecasting/
 │   ├── quick_example.py  # Example usage script
 │   └── tests/            # Test files and datasets
 ├── dataset_longhorizon.py # Dataset utilities
-├── interpretability.py   # Model-agnostic explanation engine (lag x horizon)
+├── interpretability.py   # Model-agnostic explanation engine (lag x horizon + feature axis)
 ├── model.py              # Model building utilities
 ├── standardizer.pkl      # Normalization params (auto-downloaded on first use)
 └── moment_head_512_6hr.pt  # Head checkpoint (auto-downloaded on first use)
@@ -222,9 +222,15 @@ The framework's core component is the **Lag–Horizon Attribution Engine**, whic
 
 Internally `F` is computed by composing the model's consecutive flow operators along the latent path from each past input to each future prediction; per horizon, the scores are softmax-normalized into attributions.
 
+### The Feature Axis (channel × horizon)
+
+For multivariate inputs the same latent semantic flow is decomposed along a second axis — the **feature axis**. The scalar flow magnitude of each latent transition (`|| Z_{t+1} − Z_t ||`) is split into per-channel contributions using a fast, model-agnostic first-order (Jacobian-flow) estimator. Aggregated across lags per horizon, this yields a **channel × horizon attribution matrix** answering *which input channel drives each forecast step* — the feature-axis complement to the lag × horizon (temporal-axis) matrix. 
+
+By default the flow is measured in the model's latent space (output-agnostic "semantic flow"). Passing `channel_output_aware=True` to `perform_forecasting` instead measures it on the **target channel's forecast**, so the attribution answers *which input channel drives the target's prediction* directly — using only the black-box forecast interface (no embedding access). This is more interpretable for a single target at the cost of extra forward passes.
+
 ### What the SDK gives you
 
-When you call `perform_forecasting(..., interpretability=True)` the SDK runs the same loaded model on the trailing window and writes a self-contained explanation bundle: the K×H matrix as wide and long CSVs, a heatmap PNG, a per-transition `semantic_flow.csv` with a `history`/`forecast` segment label, a full `explanation.json` (baseline forecast, lag×horizon scores and attributions, latent trajectory, semantic-flow magnitudes, diagnostic ratios that flag whether the forecast segment is volatile relative to history, and a `trajectory_stability` block with temporal-smoothness metrics over the context window), and a multi-page PDF report whose final pages surface (a) the semantic-flow time series with a history/forecast split chart, per-segment summary statistics, and the forecast-vs-history diagnostic ratios, and (b) the latent-trajectory stability metrics. See the **Interpretability (Lag x Horizon Explanations)** example below for the call shape and `sdk/README.md` for the full parameter reference and on-disk artifact catalogue.
+When you call `perform_forecasting(..., interpretability=True)` the SDK runs the same loaded model on the trailing window and writes a self-contained explanation bundle: the K×H matrix as wide and long CSVs, a heatmap PNG, a per-transition `semantic_flow.csv` with a `history`/`forecast` segment label, a full `explanation.json` (baseline forecast, lag×horizon scores and attributions, latent trajectory, semantic-flow magnitudes, diagnostic ratios that flag whether the forecast segment is volatile relative to history, and a `trajectory_stability` block with temporal-smoothness metrics over the context window), and a multi-page PDF report whose final pages surface (a) the semantic-flow time series with a history/forecast split chart, per-segment summary statistics, and the forecast-vs-history diagnostic ratios, and (b) the latent-trajectory stability metrics. For **multivariate inputs** the bundle additionally includes the feature-axis outputs: a `channel_horizon_attributions.csv` (and `channel_horizon_heatmap.png`), a `feature_axis` block in `explanation.json`, and a dedicated channel × horizon page in the PDF report. See the **Interpretability (Lag x Horizon Explanations)** example below for the call shape and `sdk/README.md` for the full parameter reference and on-disk artifact catalogue.
 
 ## Usage Examples
 

--- a/forecasting/interpretability.py
+++ b/forecasting/interpretability.py
@@ -35,10 +35,13 @@ Stability / quality notes:
 
 import warnings
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
 
 import numpy as np
 import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 Array = np.ndarray
 
@@ -181,6 +184,22 @@ class ForecastExplanation:
       - curvature_ratio_forecast_vs_history: compares second-difference energy of Z in forecast vs history.
       - latent_diag_mahalanobis_ratio_forecast_vs_history: compares a diagonal-Mahalanobis latent distance
         in forecast vs history (OOD shift indicator).
+
+    Feature-axis (v2) outputs (populated only when ``explain_forecast`` is
+    called with ``channel_axis=True`` on a multivariate input):
+      - per_channel_flow: [T-1, C] -- per-channel decomposition of latent
+        flow (phi_tau(c)).
+      - lag_channel_horizon_scores: [K, C, H] -- joint score tensor before
+        normalization.
+      - lag_channel_horizon_attributions: [K, C, H] -- softmax-normalized
+        joint lag x channel x horizon attribution.
+      - channel_horizon_attributions: [C, H] -- channel-marginal of the joint
+        attribution; which input channel drives each forecast step.
+      - channel_flow_method: which estimator produced the above ("jacobian").
+      - channel_flow_residual_ratio_mean / _p95: trust-region diagnostic for
+        the Jacobian estimator. ``|| Delta Z - sum_c Delta Z^(c) || / ||Delta Z||``
+        averaged over transitions; lower means the first-order decomposition
+        explains more of the latent step.
     """
 
     baseline_forecast: Array
@@ -195,6 +214,14 @@ class ForecastExplanation:
     flow_variance_ratio_forecast_vs_history: float | None = None
     curvature_ratio_forecast_vs_history: float | None = None
     latent_diag_mahalanobis_ratio_forecast_vs_history: float | None = None
+    # v2 feature-axis outputs (None when channel_axis=False)
+    per_channel_flow: Array | None = None
+    lag_channel_horizon_scores: Array | None = None
+    lag_channel_horizon_attributions: Array | None = None
+    channel_horizon_attributions: Array | None = None
+    channel_flow_method: str | None = None
+    channel_flow_residual_ratio_mean: float | None = None
+    channel_flow_residual_ratio_p95: float | None = None
 
 
 def _flow_segment_ratios(
@@ -1321,6 +1348,426 @@ def fit_horizon_surrogates(
     return coef, intercept, feature_layout
 
 
+# ---------------------------------------------------------------------------
+# Feature-axis (v2): per-channel semantic-flow decomposition
+# ---------------------------------------------------------------------------
+#
+# The temporal-axis engine above decomposes a forecast along *when* the model
+# looked (the lag axis). For multivariate inputs we can also ask *which input
+# channel* drove each latent step -- the feature axis. We decompose the scalar
+# flow magnitude ``m_tau = || Z_{tau+1} - Z_tau ||_2`` into per-channel
+# contributions ``phi_tau(c)`` via a first-order (Jacobian-flow) estimator: a
+# symmetric ``+/- s * Delta_x`` secant probe measures each channel's
+# directional effect on the latent step at O(C) extra forward passes per
+# transition, and reports an analytic trust ratio
+# ``|| Delta Z - sum_c Delta Z^(c) || / || Delta Z ||``.
+
+
+@dataclass(frozen=True)
+class ChannelFlowConfig:
+    """Configuration for the per-channel (feature-axis) flow decomposition.
+
+    Args:
+      jacobian_secant_scale: Multiplicative scale applied to the per-channel
+        input increment when computing the central-difference probe. Smaller
+        values approach the analytic Jacobian-vector product (lower bias,
+        higher variance from float noise); larger values measure a finite
+        secant (lower variance, higher bias). The default of 0.5 corresponds
+        to a symmetric ``+/- 0.5 * Delta_x`` probe centered on the window.
+      time_indices: Optional explicit list of trajectory transition indices at
+        which to compute the per-channel flow. ``None`` (the default)
+        processes every consecutive transition in the rolling-window
+        trajectory.
+      batch_size: Number of probe windows evaluated per forward pass.
+      transition_batch: Number of transitions whose probe windows are stacked
+        into a single embed call before being chunked by ``batch_size``.
+        Values > 1 amortise per-call overhead across transitions.
+    """
+
+    jacobian_secant_scale: float = 0.5
+    time_indices: Sequence[int] | None = None
+    batch_size: int = 32
+    transition_batch: int = 1
+
+
+@dataclass(frozen=True)
+class ChannelFlowReport:
+    """Per-channel flow decomposition outputs.
+
+    Shapes:
+      - per_channel_flow: [T-1, C] -- ``phi_tau(c)`` for each transition.
+      - flow_total: [T-1] -- the scalar magnitude ``m_tau = || Delta Z_tau ||_2``
+        for cross-checking against the temporal-axis flow.
+      - residual_ratio_per_step: [T-1] -- ``|| Delta Z_tau - sum_c Delta Z^(c) ||
+        / || Delta Z_tau ||``. NaN means the flow was numerically zero.
+    """
+
+    method: str
+    per_channel_flow: Array
+    flow_total: Array
+    residual_ratio_per_step: Array | None = None
+    residual_ratio_mean: float | None = None
+    residual_ratio_p95: float | None = None
+    n_time_steps: int = 0
+    n_channels: int = 0
+
+
+def _resolve_step_indices(
+    *,
+    time_indices: Sequence[int] | None,
+    n_windows: int,
+) -> np.ndarray:
+    """Return the array of trajectory transition indices to evaluate.
+
+    A "transition" at index ``tau`` is the pair ``(tau, tau+1)``; the valid
+    range is ``[0, n_windows - 2]``.
+    """
+    if n_windows < 2:
+        raise ValueError(f"Need at least 2 rolling windows for flow, got {n_windows}")
+    if time_indices is None:
+        return np.arange(n_windows - 1, dtype=np.int64)
+    arr = np.asarray(time_indices, dtype=np.int64).reshape(-1)
+    if arr.size == 0:
+        raise ValueError("`time_indices` must contain at least one transition index.")
+    invalid = (arr < 0) | (arr >= n_windows - 1)
+    if np.any(invalid):
+        raise ValueError(f"`time_indices` contains values outside [0, {n_windows - 2}]: {arr[invalid].tolist()}")
+    return np.unique(arr)
+
+
+def _embed_windows_batched(
+    model: ForecastModel,
+    windows: Array,
+    masks: Array,
+    *,
+    device: torch.device,
+    batch_size: int,
+) -> Array:
+    """Batched embedding of a stack of ``[N, C, L]`` windows.
+
+    NaN/inf in the model's embedding output are replaced with zero, mirroring
+    the sanitization that :func:`extract_latent_trajectory` applies to the
+    temporal-axis path (out-of-distribution forecast-extension windows can
+    otherwise emit non-finite activations that corrupt ``per_channel_flow``).
+    """
+    n = int(windows.shape[0])
+    if n == 0:
+        return np.zeros((0, 0), dtype=np.float32)
+    out_chunks: list[Array] = []
+    for i in range(0, n, batch_size):
+        x = torch.from_numpy(np.ascontiguousarray(windows[i : i + batch_size])).to(device=device, dtype=torch.float32)
+        m = torch.from_numpy(np.ascontiguousarray(masks[i : i + batch_size])).to(device=device, dtype=torch.long)
+        out_chunks.append(_embed_batch(model, x, m))
+    z = np.concatenate(out_chunks, axis=0)
+    if np.any(~np.isfinite(z)):
+        z = np.nan_to_num(z, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32, copy=False)
+    return z
+
+
+# Signature shared by the value function the flow estimator consumes:
+# ``(model, windows[N,C,L], masks[N,L], *, device, batch_size) -> [N, Dv]``.
+# The default (:func:`_embed_windows_batched`) measures flow in the latent
+# embedding space (output-agnostic "semantic flow", ``Dv == D``). The
+# output-aware variant below instead returns the *target channel's forecast*
+# (``Dv == H``), so the per-channel flow measures each input channel's effect
+# on the target prediction.
+ValueFn = Callable[..., Array]
+
+
+def make_target_forecast_value_fn(
+    *,
+    target_channel: int,
+    model_horizon: int,
+    forecast_horizon: int,
+) -> ValueFn:
+    """Value function mapping a window stack to the target channel's forecast.
+
+    Passing this to :func:`compute_per_channel_flow` (or, more conveniently,
+    calling ``explain_forecast(channel_output_aware=True, channel_target=...)``)
+    turns the per-channel flow from an *output-agnostic* latent-movement
+    decomposition (``|| Delta Z ||``) into an *output-aware* one: the flow is
+    measured on the target channel's ``H``-step forecast, so ``phi_tau(c)`` is
+    channel ``c``'s contribution to the change in the target's prediction. It
+    uses only the black-box ``forecast`` interface (no embedding / decoder
+    Jacobian), so it stays model-agnostic.
+    """
+
+    def _value_fn(model: ForecastModel, windows: Array, masks: Array, *, device: torch.device, batch_size: int) -> Array:
+        n = int(windows.shape[0])
+        if n == 0:
+            return np.zeros((0, int(forecast_horizon)), dtype=np.float32)
+        out_chunks: list[Array] = []
+        for i in range(0, n, int(batch_size)):
+            xb = torch.from_numpy(np.ascontiguousarray(windows[i : i + int(batch_size)])).to(
+                device=device, dtype=torch.float32
+            )
+            mb = torch.from_numpy(np.ascontiguousarray(masks[i : i + int(batch_size)])).to(
+                device=device, dtype=torch.long
+            )
+            y = _forecast_autoregressive(
+                model, xb, mb, model_horizon=int(model_horizon), target_horizon=int(forecast_horizon)
+            )  # numpy [B, C, H]
+            out_chunks.append(np.asarray(y[:, int(target_channel), :], dtype=np.float32))
+        z = np.concatenate(out_chunks, axis=0)  # [N, H]
+        if np.any(~np.isfinite(z)):
+            z = np.nan_to_num(z, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32, copy=False)
+        return z
+
+    return _value_fn
+
+
+@torch.no_grad()
+def compute_per_channel_flow(
+    model: ForecastModel,
+    series_ct: Array,  # [C, T]
+    *,
+    seq_len: int,
+    input_mask_t: Array | None = None,
+    device: torch.device,
+    cfg: ChannelFlowConfig | None = None,
+    value_fn: ValueFn | None = None,
+) -> ChannelFlowReport:
+    """First-order per-channel decomposition of latent flow (Jacobian-flow).
+
+    For each transition ``tau -> tau+1`` we approximate
+
+        Delta Z_tau^(c) ~= [ embed(X_tau + s * bump_c) - embed(X_tau - s * bump_c) ] / (2s)
+
+    where ``bump_c`` shifts only channel ``c`` by the per-channel increment
+    ``Delta x_tau^(c) = X_{tau+1}[c] - X_tau[c]`` and ``s`` is
+    ``cfg.jacobian_secant_scale``. The per-channel flow magnitude is
+    ``phi_tau(c) = || Delta Z_tau^(c) ||_2`` and the residual
+    ``r_tau = Delta Z_tau - sum_c Delta Z_tau^(c)`` populates the trust ratio.
+
+    By default the flow is measured in the latent embedding space
+    (output-agnostic). Pass ``value_fn`` (e.g. from
+    :func:`make_target_forecast_value_fn`) to measure it in another space, such
+    as the target channel's forecast (output-aware), in which case
+    ``phi_tau(c)`` and the trust ratio are computed on that value function's
+    output instead of the embedding.
+
+    Cost: one batched forward of ``2C + 2`` probe windows per transition
+    (``Z_tau``, ``Z_{tau+1}``, and the ``+/- s`` bumps for each channel).
+    """
+    cfg = cfg or ChannelFlowConfig()
+    vf = value_fn if value_fn is not None else _embed_windows_batched
+
+    xw_view, m_view, T = _rolling_window_sources(series_ct, seq_len=seq_len, input_mask_t=input_mask_t)
+    if T < 2:
+        raise ValueError(f"Need at least 2 time steps for flow decomposition, got T={T}")
+    transitions = _resolve_step_indices(time_indices=cfg.time_indices, n_windows=T)
+
+    C = int(np.asarray(series_ct).shape[0])
+    L = int(seq_len)
+    s = float(cfg.jacobian_secant_scale)
+    if s <= 0:
+        raise ValueError(f"jacobian_secant_scale must be > 0, got {s}")
+
+    phi = np.full((T - 1, C), np.nan, dtype=np.float32)
+    flow_total = np.full((T - 1,), np.nan, dtype=np.float32)
+    residual = np.full((T - 1,), np.nan, dtype=np.float32)
+
+    # Probe windows per transition: Z_tau, Z_{tau+1}, and the +/- bumps.
+    probes_per_trans = 2 + 2 * C
+    trans_batch = max(1, int(cfg.transition_batch))
+
+    for chunk_start in range(0, len(transitions), trans_batch):
+        chunk = transitions[chunk_start : chunk_start + trans_batch]
+        m_chunk = len(chunk)
+
+        starts = chunk.astype(np.int64)
+        win_a = np.asarray(xw_view[starts], dtype=np.float32)  # [m, C, L]
+        win_b = np.asarray(xw_view[starts + 1], dtype=np.float32)  # [m, C, L]
+        mask_a = np.asarray(m_view[starts], dtype=np.int64)  # [m, L]
+        mask_b = np.asarray(m_view[starts + 1], dtype=np.int64)  # [m, L]
+        delta_cl = (win_b - win_a).astype(np.float32, copy=False)  # [m, C, L]
+
+        # Build the [m, probes_per_trans, C, L] probe stack. Per transition the
+        # layout is [a, b, +probe_0..+probe_{C-1}, -probe_0..-probe_{C-1}].
+        stack = np.empty((m_chunk, probes_per_trans, C, L), dtype=np.float32)
+        stack[:, 0] = win_a
+        stack[:, 1] = win_b
+
+        # Bumps reuse window A except on the bumped channel row (c, c), which
+        # is shifted by +/- s * delta_x.
+        plus = np.broadcast_to(win_a[:, None, :, :], (m_chunk, C, C, L)).copy()
+        minus = plus.copy()
+        diag_idx = np.arange(C)
+        plus[:, diag_idx, diag_idx, :] = win_a[:, diag_idx, :] + s * delta_cl[:, diag_idx, :]
+        minus[:, diag_idx, diag_idx, :] = win_a[:, diag_idx, :] - s * delta_cl[:, diag_idx, :]
+        stack[:, 2 : 2 + C] = plus
+        stack[:, 2 + C :] = minus
+
+        # Mask discipline: position 1 (Z_{tau+1}) uses window B's mask; every
+        # other probe uses window A's mask, matching extract_latent_trajectory.
+        masks_full = np.broadcast_to(mask_a[:, None, :], (m_chunk, probes_per_trans, L)).copy()
+        masks_full[:, 1] = mask_b
+
+        flat_stack = stack.reshape(m_chunk * probes_per_trans, C, L)
+        flat_masks = masks_full.reshape(m_chunk * probes_per_trans, L)
+
+        z_flat = vf(
+            model,
+            flat_stack,
+            flat_masks,
+            device=device,
+            batch_size=int(cfg.batch_size),
+        )  # [m * probes_per_trans, Dv]
+        D = int(z_flat.shape[1])
+        z = z_flat.reshape(m_chunk, probes_per_trans, D)
+
+        delta_z = z[:, 1, :] - z[:, 0, :]  # [m, D]
+        # Central-secant per-channel directional derivative: (z_+ - z_-) / (2s).
+        delta_z_per_chan = (z[:, 2 : 2 + C, :] - z[:, 2 + C :, :]) / (2.0 * s)  # [m, C, D]
+
+        for k, tau in enumerate(chunk):
+            dz_k = delta_z[k]  # [D]
+            dzpc_k = delta_z_per_chan[k]  # [C, D]
+            phi[int(tau)] = np.linalg.norm(dzpc_k, ord=2, axis=1).astype(np.float32)
+            total_k = float(np.linalg.norm(dz_k, ord=2))
+            flow_total[int(tau)] = total_k
+            r_k = dz_k - dzpc_k.sum(axis=0)
+            residual[int(tau)] = float(np.linalg.norm(r_k, ord=2)) / (total_k + 1e-12)
+
+    finite = np.isfinite(residual)
+    res_mean = float(np.nanmean(residual[finite])) if np.any(finite) else None
+    res_p95 = float(np.nanpercentile(residual[finite], 95)) if np.any(finite) else None
+
+    return ChannelFlowReport(
+        method="jacobian",
+        per_channel_flow=phi,
+        flow_total=flow_total,
+        residual_ratio_per_step=residual,
+        residual_ratio_mean=res_mean,
+        residual_ratio_p95=res_p95,
+        n_time_steps=int(T - 1),
+        n_channels=C,
+    )
+
+
+def lag_channel_horizon_attribution(
+    per_channel_flow: Array,  # [T-1, C]
+    *,
+    t_index: int,
+    n_lags: int,
+    horizon: int,
+    softmax_tau: float = 1.0,
+    horizon_kernel: Literal["exp", "none"] = "exp",
+    kernel_min_scale: float = 4.0,
+    kernel_max_scale: float | None = None,
+    normalize: Literal["joint", "per_channel", "none"] = "joint",
+) -> tuple[Array, Array]:
+    """Joint lag x channel x horizon attribution.
+
+    This is the natural generalisation of :func:`lag_horizon_attribution` to a
+    per-channel flow input. The lag-horizon kernel ``w_h(a) = exp(-a / s_h)`` is
+    reused unchanged; the cumulative kernel-weighted sum is taken per channel,
+    producing a ``[K, C, H]`` score tensor instead of the ``[K, H]`` matrix.
+
+    The ``normalize`` flag controls the softmax over the score tensor:
+
+    * ``"joint"`` (default): softmax over the joint ``(lag, channel)`` axis for
+      each horizon. Marginalising over channels recovers the temporal-axis
+      lag-horizon attribution; marginalising over lags gives a per-channel
+      per-horizon attribution.
+    * ``"per_channel"``: softmax over the lag axis, separately for each
+      ``(channel, horizon)`` pair.
+    * ``"none"``: raw scores without softmax normalization.
+
+    Returns:
+      scores: [K, C, H]
+      attributions: [K, C, H]
+    """
+    flow_tc = np.asarray(per_channel_flow, dtype=np.float32)
+    if flow_tc.ndim != 2:
+        raise ValueError(f"Expected per_channel_flow shape [T-1, C], got {flow_tc.shape}")
+    flow_tc = np.where(np.isfinite(flow_tc), flow_tc, 0.0).astype(np.float32)
+
+    Tm1, C = flow_tc.shape
+    K = int(n_lags)
+    H = int(horizon)
+    if K <= 0 or H <= 0:
+        raise ValueError("n_lags and horizon must be positive")
+    if not (1 <= int(t_index) <= Tm1):
+        raise ValueError(f"t_index must be in [1, {Tm1}], got {t_index}")
+    if int(t_index) < K:
+        raise ValueError(f"n_lags must be <= t_index={int(t_index)}, got {K}")
+
+    # Most-recent-first slice of history flow per channel.
+    hist_tail = flow_tc[max(0, int(t_index) - K) : int(t_index), :]  # [<=K, C]
+    hist_rev = hist_tail[::-1, :]  # most recent first
+    Lh = hist_rev.shape[0]
+
+    min_s = float(kernel_min_scale)
+    max_s = float(kernel_max_scale) if kernel_max_scale is not None else float(K)
+    if min_s <= 0 or max_s <= 0:
+        raise ValueError("kernel scales must be positive")
+    max_s = max(max_s, min_s)
+    if H == 1:
+        scales_h = np.array([min_s], dtype=np.float32)
+    else:
+        u_h = np.arange(H, dtype=np.float32) / float(H - 1)
+        scales_h = (min_s + u_h * (max_s - min_s)).astype(np.float32)
+
+    scores = np.zeros((K, C, H), dtype=np.float32)
+    if horizon_kernel == "none":
+        csum = np.cumsum(hist_rev, axis=0, dtype=np.float32)  # [Lh, C]
+        scores[:Lh, :, :] = csum[:, :, None]
+    elif horizon_kernel == "exp":
+        ages_l = np.arange(Lh, dtype=np.float32)[:, None]  # [Lh, 1]
+        target_bytes = 64 * 1024 * 1024
+        bytes_per_h = max(1, Lh * C * 4)
+        chunk = max(1, min(H, target_bytes // bytes_per_h))
+        for h0 in range(0, H, chunk):
+            h1 = min(H, h0 + chunk)
+            sc = np.maximum(scales_h[h0:h1][None, :], np.float32(1e-6))
+            w_lh = np.exp(-ages_l / sc).astype(np.float32)  # [Lh, chunk]
+            hw_lhc = hist_rev[:, :, None] * w_lh[:, None, :]  # [Lh, C, chunk]
+            csum = np.cumsum(hw_lhc, axis=0, dtype=np.float32)  # [Lh, C, chunk]
+            scores[:Lh, :, h0:h1] = csum
+    else:
+        raise ValueError(f"Unsupported horizon_kernel={horizon_kernel!r}")
+
+    tau = max(float(softmax_tau), 1e-6)
+    if normalize == "none":
+        return scores, scores.copy()
+    if normalize == "per_channel":
+        attrib = np.empty_like(scores)
+        for c in range(C):
+            for h in range(H):
+                col = scores[:, c, h]
+                if not np.any(col):
+                    attrib[:, c, h] = 1.0 / float(K)
+                else:
+                    e = np.exp((col - col.max()) / tau)
+                    ssum = e.sum()
+                    attrib[:, c, h] = e / ssum if ssum > 0 else 1.0 / float(K)
+        return scores, attrib
+    if normalize != "joint":
+        raise ValueError(f"Unsupported normalize={normalize!r}")
+
+    # Joint softmax over (lag, channel) per horizon.
+    attrib = np.empty_like(scores)
+    flat = scores.reshape(K * C, H)
+    for h in range(H):
+        col = flat[:, h]
+        if not np.any(col):
+            attrib[:, :, h] = 1.0 / float(K * C)
+            continue
+        e = np.exp((col - col.max()) / tau)
+        ssum = e.sum()
+        if ssum <= 0:
+            attrib[:, :, h] = 1.0 / float(K * C)
+        else:
+            attrib[:, :, h] = (e / ssum).reshape(K, C)
+    return scores, attrib
+
+
+def channel_horizon_marginal(attribution_kch: Array) -> Array:
+    """Sum a ``[K, C, H]`` attribution tensor over the lag axis -> ``[C, H]``."""
+    return np.asarray(attribution_kch, dtype=np.float32).sum(axis=0).astype(np.float32)
+
+
 def explain_forecast(
     model: ForecastModel,
     *,
@@ -1336,6 +1783,12 @@ def explain_forecast(
     pert_cfg: PerturbationConfig | None = None,
     surr_cfg: SurrogateConfig | None = None,
     latent_batch_size: int = 32,
+    # v2 feature-axis switches
+    channel_axis: bool = False,
+    chan_cfg: ChannelFlowConfig | None = None,
+    channel_softmax_tau: float | None = None,
+    channel_output_aware: bool = False,
+    channel_target: int | None = None,
 ) -> ForecastExplanation:
     """
     End-to-end interpretability pipeline:
@@ -1344,6 +1797,24 @@ def explain_forecast(
       3) Semantic flow magnitudes
       4) Lag x Horizon attribution matrix + horizon-wise softmax
       5) Optional horizon-specific local surrogates with structure-preserving perturbations
+
+    When ``channel_axis=True`` (and the input has C > 1 channels) we additionally
+    run the feature-axis stages: per-channel flow decomposition followed by the
+    joint lag x channel x horizon attribution (see :func:`compute_per_channel_flow`
+    and :func:`lag_channel_horizon_attribution`).
+
+    Pass ``chan_cfg`` to tune the per-channel flow estimator; when it is None we
+    default to ``ChannelFlowConfig()``, the fast O(C) Jacobian estimator.
+
+    By default the feature-axis flow is measured in the latent embedding space
+    (output-agnostic "semantic flow"). Set ``channel_output_aware=True`` with a
+    ``channel_target`` to instead measure it on that target channel's forecast,
+    so the attribution answers "which input channel drives the target's
+    prediction" directly (uses only the black-box forecast interface). This is
+    more interpretable for a single target but costs extra forward passes (each
+    probe window is forecast rather than embedded). Non-target channels only
+    receive attribution if the model couples channels; otherwise only the target
+    contributes.
     """
     flow_cfg = flow_cfg or SemanticFlowConfig()
     pert_cfg = pert_cfg or PerturbationConfig()
@@ -1433,6 +1904,57 @@ def explain_forecast(
             surr_cfg=surr_cfg,
         )
 
+    # --- 6) feature-axis stages (optional; multivariate inputs only) ---
+    per_chan_flow = None
+    lag_chan_scores = None
+    lag_chan_attrib = None
+    chan_horizon_attrib = None
+    chan_method = None
+    chan_resid_mean = None
+    chan_resid_p95 = None
+    if channel_axis:
+        chan_cfg_eff = chan_cfg if chan_cfg is not None else ChannelFlowConfig()
+        # Select the flow's value function: the default latent embedding
+        # (output-agnostic) or the target channel's forecast (output-aware).
+        chan_value_fn = None
+        if channel_output_aware:
+            if channel_target is None:
+                raise ValueError(
+                    "channel_output_aware=True requires channel_target (the forecast "
+                    "channel whose prediction the attribution should explain)."
+                )
+            chan_value_fn = make_target_forecast_value_fn(
+                target_channel=int(channel_target),
+                model_horizon=int(model_horizon),
+                forecast_horizon=int(forecast_horizon),
+            )
+        # Channel-flow operates on the same extended series so lag indices match
+        # the temporal-axis attribution above.
+        report = compute_per_channel_flow(
+            model,
+            series_ext,
+            seq_len=L,
+            input_mask_t=mask_ext,
+            device=device,
+            cfg=chan_cfg_eff,
+            value_fn=chan_value_fn,
+        )
+        per_chan_flow = report.per_channel_flow
+        chan_method = report.method
+        chan_resid_mean = report.residual_ratio_mean
+        chan_resid_p95 = report.residual_ratio_p95
+
+        chan_tau = float(channel_softmax_tau) if channel_softmax_tau is not None else float(softmax_tau)
+        lag_chan_scores, lag_chan_attrib = lag_channel_horizon_attribution(
+            per_chan_flow,
+            t_index=t_index,
+            n_lags=K,
+            horizon=int(forecast_horizon),
+            softmax_tau=chan_tau,
+            normalize="joint",
+        )
+        chan_horizon_attrib = channel_horizon_marginal(lag_chan_attrib)
+
     return ForecastExplanation(
         baseline_forecast=base,
         lag_horizon_scores=scores,
@@ -1446,4 +1968,11 @@ def explain_forecast(
         flow_variance_ratio_forecast_vs_history=flow_var_ratio,
         curvature_ratio_forecast_vs_history=curvature_ratio,
         latent_diag_mahalanobis_ratio_forecast_vs_history=maha_ratio,
+        per_channel_flow=per_chan_flow,
+        lag_channel_horizon_scores=lag_chan_scores,
+        lag_channel_horizon_attributions=lag_chan_attrib,
+        channel_horizon_attributions=chan_horizon_attrib,
+        channel_flow_method=chan_method,
+        channel_flow_residual_ratio_mean=chan_resid_mean,
+        channel_flow_residual_ratio_p95=chan_resid_p95,
     )

--- a/forecasting/sdk/README.md
+++ b/forecasting/sdk/README.md
@@ -1,6 +1,6 @@
 # Tesseract Forecasting SDK
 
-Programmatic entry point for running `perform_forecasting()` on pandas DataFrames. Supports multivariate forecasting, context-enhanced (DARR) predictions, and model-agnostic interpretability with horizon-specific lag attributions.
+Programmatic entry point for running `perform_forecasting()` on pandas DataFrames. Supports multivariate forecasting, context-enhanced (DARR) predictions, and model-agnostic interpretability with horizon-specific lag (temporal-axis) and channel (feature-axis) attributions.
 
 ## Features
 
@@ -10,7 +10,8 @@ Programmatic entry point for running `perform_forecasting()` on pandas DataFrame
 - **Robust preprocessing**: Converts timestamps, fills numeric NULLs with zeros, enforces minimum sequence length (`seq_len`), and standardizes input using saved standardizer metadata.
 - **Column alignment**: Automatically handles datasets with different feature sets by aligning to common columns, preventing broadcasting errors.
 - **Diverse output**: Produces hybrid, direct, and kNN forecasts when context is provided; otherwise returns only the direct forecast column.
-- **Built-in interpretability**: Opt-in `interpretability=True` flag produces a horizon-resolved lag attribution matrix, supporting CSVs / heatmap PNG, a `semantic_flow.csv` of per-transition latent flow magnitudes labeled by history/forecast segment, an `explanation.json` (lag×horizon, latent trajectory, semantic-flow magnitudes, forecast-vs-history diagnostics, and a `trajectory_stability` block of temporal-smoothness metrics), and a self-contained PDF report whose final pages cover semantic-flow magnitudes (line chart over the history/forecast split with per-segment summary statistics and the four forecast-vs-history diagnostic ratios) and latent-trajectory stability. Output format is selectable via `interpretability_output` (`"json"`, `"pdf"`, or `None` for both).
+- **Built-in interpretability**: Opt-in `interpretability=True` flag produces a horizon-resolved lag attribution matrix, supporting CSVs / heatmap PNG, a `semantic_flow.csv` of per-transition latent flow magnitudes labeled by history/forecast segment, an `explanation.json` (lag×horizon, latent trajectory, semantic-flow magnitudes, forecast-vs-history diagnostics, a `trajectory_stability` block of temporal-smoothness metrics, and — for multivariate inputs — a `feature_axis` block), and a self-contained PDF report whose final pages cover semantic-flow magnitudes (line chart over the history/forecast split with per-segment summary statistics and the four forecast-vs-history diagnostic ratios), latent-trajectory stability, and the feature-axis attribution. Output format is selectable via `interpretability_output` (`"json"`, `"pdf"`, or `None` for both).
+- **Feature-axis attribution**: For multivariate inputs (more than one numeric column), the interpretability run additionally decomposes the forecast along the *feature axis*, reporting a channel × horizon attribution matrix (which input channel drives each forecast step) as `channel_horizon_attributions.csv`, a `channel_horizon_heatmap.png`, and a dedicated PDF page. Computed with a fast first-order (Jacobian-flow) estimator that carries an analytic trust ratio.
 
 ## Installation
 
@@ -129,10 +130,12 @@ interp_result = perform_forecasting(
 | Value | Files written under `<interpretability_out_dir>/run_<UTC>/` |
 |-------|-------------------------------------------------------------|
 | `"json"` | `forecast.csv`, `explanation.json` |
-| `"pdf"` | `forecast.csv`, `lag_horizon_attributions.csv`, `lag_horizon_long.csv`, `lag_horizon_heatmap.png`, `semantic_flow.csv`, `explanation_report.pdf` |
+| `"pdf"` | `forecast.csv`, `lag_horizon_attributions.csv`, `lag_horizon_long.csv`, `lag_horizon_heatmap.png`, `semantic_flow.csv`, `explanation_report.pdf` (plus `channel_horizon_attributions.csv` and `channel_horizon_heatmap.png` for multivariate inputs) |
 | `None`  | All of the above |
 
 The returned DataFrame is the explanation-aligned forecast (single forward pass, so it lines up 1:1 with the attribution matrix). PDF / heatmap require `matplotlib`; if it's missing, those steps are skipped with a warning while JSON output continues to work.
+
+If the input DataFrame has more than one numeric column, the feature-axis decomposition runs automatically (no extra flag): the report gains a channel × horizon attribution page and `channel_horizon_*` artifacts alongside the temporal lag × horizon outputs. By default this is measured in latent space (output-agnostic); set `channel_output_aware=True` to instead attribute the target channel's forecast directly (see the parameter table below).
 
 ## Function signature
 
@@ -178,6 +181,7 @@ perform_forecasting(
     interpretability_dataset_name: Optional[str] = None,
     n_lags: int = 128,
     softmax_tau: float = 1.0,
+    channel_output_aware: bool = False,
 ) -> pd.DataFrame
 ```
 
@@ -206,6 +210,7 @@ perform_forecasting(
 | `interpretability_dataset_name` | Free-form label embedded in the JSON metadata and the PDF cover page |
 | `n_lags` | Number of past steps the lag-attribution matrix resolves (default `128`) |
 | `softmax_tau` | Temperature applied when softmaxing scores into per-horizon attribution |
+| `channel_output_aware` | Feature-axis only (multivariate inputs). When `False` (default), channel attributions are measured in latent space (output-agnostic "semantic flow"). When `True`, they are measured on the target channel's forecast, so the channel × horizon page answers "which input channel drives the *target's* prediction". More interpretable for a single target, but costs extra forward passes (each probe window is forecast rather than embedded). Requires channel coupling (`use_cross_channel=True`, the default) to attribute non-target channels; otherwise only the target contributes |
 
 ## Preprocessing expectations
 
@@ -234,12 +239,14 @@ When `interpretability=True`, the run directory contains the following files (se
 | File | Written when | Contents |
 |------|--------------|----------|
 | `forecast.csv` | json, pdf, both | The returned forecast DataFrame |
-| `explanation.json` | json, both | Forecast + full explanation payload (baseline forecast, lag×horizon scores and attributions, latent trajectory, semantic-flow magnitudes, `diagnostics` block including `latent_trajectory_shape` and the forecast-vs-history ratios, `trajectory_stability` block with temporal-smoothness metrics over the context window, and dataset metadata) |
+| `explanation.json` | json, both | Forecast + full explanation payload (baseline forecast, lag×horizon scores and attributions, latent trajectory, semantic-flow magnitudes, `diagnostics` block including `latent_trajectory_shape` and the forecast-vs-history ratios, `trajectory_stability` block with temporal-smoothness metrics over the context window, a `feature_axis` block for multivariate inputs (estimator method, channel×horizon attributions, Jacobian trust ratios, and the per-channel flow), and dataset metadata) |
 | `lag_horizon_attributions.csv` | pdf, both | Wide K×H attribution matrix |
 | `lag_horizon_long.csv` | pdf, both | Tidy `(lag, horizon, attribution[, score])` table |
 | `lag_horizon_heatmap.png` | pdf, both *(needs matplotlib)* | Visual heatmap, viridis cmap |
 | `semantic_flow.csv` | pdf, both | Tidy `(transition_index, segment, flow_magnitude)` table, where `segment` is `history` for transitions fully inside the input window, `forecast` for transitions whose window extends into the model-generated future, and `tail` for any trailing transitions outside both segments |
-| `explanation_report.pdf` | pdf, both *(needs matplotlib)* | Multi-page report: (1) cover with metadata, (2) forecast preview, (3) lag×horizon heatmap, (4) top-`interpretability_top_k` lag-step tables, (5) semantic-flow magnitudes page with the per-transition flow time series (history/forecast split annotated), a per-segment summary (mean / median / p95 / max / variance / transition count) and the four forecast-vs-history diagnostic ratios (`flow_ratio`, `flow_variance_ratio`, `curvature_ratio`, `latent_diag_mahalanobis_ratio`), (6) latent-trajectory stability table with per-dimension zero-crossing / direction-flip / relative-jitter (mean & p95) and occupancy metrics |
+| `channel_horizon_attributions.csv` | pdf, both *(multivariate only)* | Wide `[C × H]` channel × horizon attribution matrix (first column is the channel label); each horizon column sums to 1 over channels |
+| `channel_horizon_heatmap.png` | pdf, both *(multivariate, needs matplotlib)* | Feature-axis heatmap: rows are input channels, columns are forecast steps, brighter = that channel matters more there |
+| `explanation_report.pdf` | pdf, both *(needs matplotlib)* | Multi-page report: (1) cover with metadata, (2) forecast preview, (3) lag×horizon heatmap, (4) top-`interpretability_top_k` lag-step tables, (5) semantic-flow magnitudes page with the per-transition flow time series (history/forecast split annotated), a per-segment summary (mean / median / p95 / max / variance / transition count) and the four forecast-vs-history diagnostic ratios (`flow_ratio`, `flow_variance_ratio`, `curvature_ratio`, `latent_diag_mahalanobis_ratio`), (6) latent-trajectory stability table with per-dimension zero-crossing / direction-flip / relative-jitter (mean & p95) and occupancy metrics, and (7) feature-axis attribution page (multivariate inputs only) with the channel × horizon heatmap, a per-channel importance bar, and the Jacobian trust ratio |
 
 The run directory path is printed on stdout when the call completes.
 

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -883,6 +883,156 @@ def _semantic_flow_page(
     plt.close(fig)
 
 
+def _save_channel_axis_artifacts(
+    out_dir: Path,
+    channel_horizon_attributions: np.ndarray,
+    channel_labels: list[str] | None = None,
+    *,
+    na_rep: str = "nan",
+) -> Path | None:
+    """Write the [C, H] channel x horizon attribution CSV and a heatmap PNG.
+
+    Returns the path to the heatmap PNG if matplotlib is available, else None.
+    """
+    A = np.asarray(channel_horizon_attributions, dtype=np.float32)
+    if A.ndim != 2:
+        return None
+    C, H = A.shape
+    labels = channel_labels if (channel_labels and len(channel_labels) == C) else [f"channel_{c}" for c in range(C)]
+
+    df = pd.DataFrame(A, columns=[f"horizon_{h}" for h in range(H)])
+    df.insert(0, "channel", labels)
+    df.to_csv(out_dir / "channel_horizon_attributions.csv", index=False, na_rep=na_rep)
+
+    try:
+        import matplotlib as mpl
+
+        mpl.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return None
+
+    fig, ax = plt.subplots(figsize=(max(8, H * 0.15), max(4, C * 0.4)))
+    im = ax.imshow(A, aspect="auto", cmap="viridis", interpolation="nearest")
+    ax.set_xlabel("Forecast horizon")
+    ax.set_ylabel("Input channel")
+    ax.set_yticks(range(C))
+    ax.set_yticklabels(labels, fontsize=8)
+    xt = np.linspace(0, H - 1, min(12, H), dtype=int)
+    ax.set_xticks(xt)
+    ax.set_xticklabels(xt)
+    plt.colorbar(im, ax=ax, label="Attribution")
+    plt.tight_layout()
+    heatmap_path = out_dir / "channel_horizon_heatmap.png"
+    plt.savefig(heatmap_path, dpi=120)
+    plt.close(fig)
+    return heatmap_path
+
+
+def _channel_axis_page(
+    pdf: Any,
+    plt: Any,
+    *,
+    explanation: ForecastExplanation,
+    channel_labels: list[str] | None = None,
+) -> None:
+    """Append one PDF page for the feature-axis (channel x horizon) attribution.
+
+    Primary visual: a [C, H] heatmap of how much each input channel contributes to
+    each forecast step. A side bar summarizes each channel's total attribution
+    (summed over horizons) as a single feature-importance score.
+    """
+    A = getattr(explanation, "channel_horizon_attributions", None)
+    if A is None:
+        return
+    A = np.asarray(A, dtype=np.float32)
+    if A.ndim != 2 or A.shape[0] < 1 or A.shape[1] < 1:
+        return
+    C, H = A.shape
+    labels = channel_labels if (channel_labels and len(channel_labels) == C) else [f"channel_{c}" for c in range(C)]
+    importance = A.sum(axis=1)
+    method = getattr(explanation, "channel_flow_method", None) or "jacobian"
+    resid = getattr(explanation, "channel_flow_residual_ratio_mean", None)
+
+    fig = plt.figure(figsize=(11, 8.5))
+    fig.text(
+        0.5,
+        0.95,
+        "Feature-axis attribution (channel x horizon)",
+        ha="center",
+        fontsize=14,
+        fontweight="bold",
+    )
+    fig.text(
+        0.06,
+        0.90,
+        "Which input channel (feature) drives each forecast step. The model's response is\n"
+        "decomposed along the feature axis into per-channel contributions, then aggregated\n"
+        "per horizon. Rows are input channels, columns are forecast steps; brighter = that\n"
+        "channel matters more there.",
+        ha="left",
+        va="top",
+        fontsize=9,
+        color="gray",
+    )
+
+    ax = fig.add_axes((0.08, 0.40, 0.56, 0.42))
+    im = ax.imshow(A, aspect="auto", cmap="viridis", interpolation="nearest")
+    ax.set_xlabel("Forecast horizon (0 = first predicted step)")
+    ax.set_ylabel("Input channel")
+    ax.set_yticks(range(C))
+    ax.set_yticklabels(labels, fontsize=8)
+    xt = np.linspace(0, H - 1, min(12, H), dtype=int)
+    ax.set_xticks(xt)
+    ax.set_xticklabels(xt)
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label="Attribution")
+
+    axb = fig.add_axes((0.72, 0.40, 0.22, 0.42))
+    y = np.arange(C)
+    axb.barh(y, importance, color="#1f77b4")
+    axb.set_yticks(y)
+    axb.set_yticklabels([])
+    axb.invert_yaxis()  # channel 0 at top, aligned with the heatmap rows
+    axb.set_title("Channel importance\n(sum over horizons)", fontsize=9)
+    axb.set_xlabel("Total attribution", fontsize=8)
+    axb.tick_params(axis="both", labelsize=7)
+
+    top_c = int(np.argmax(importance))
+    resid_line = (
+        f"  - Estimator: {method}. Jacobian trust ratio (mean residual): {resid:.3f}\n"
+        "    (lower = more reliable first-order split; high values flag strong\n"
+        "    cross-channel interaction the first-order decomposition cannot capture).\n"
+        if resid is not None
+        else f"  - Estimator: {method}.\n"
+    )
+    note = (
+        "How to read this page\n"
+        "---------------------\n"
+        "  - Heatmap cell (channel c, horizon h): share of the forecast at step h\n"
+        "    attributable to input channel c (each horizon column sums to 1 over channels).\n"
+        "  - Right bar: each channel's total attribution summed across horizons -- a single\n"
+        "    feature-importance score per input channel.\n"
+        f"  - Most influential channel overall: {labels[top_c]}.\n"
+        + resid_line
+        + "\n"
+        "Full [C x H] values are exported as channel_horizon_attributions.csv."
+    )
+    fig.text(
+        0.06,
+        0.30,
+        note,
+        ha="left",
+        va="top",
+        fontsize=9,
+        family="monospace",
+        color="#333333",
+        linespacing=1.05,
+    )
+
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
 def _build_pdf_report(
     pdf_path: Path,
     *,
@@ -897,6 +1047,7 @@ def _build_pdf_report(
     trajectory_report: TrajectoryStabilityReport | None = None,
     context_len: int | None = None,
     forecast_horizon: int | None = None,
+    channel_labels: list[str] | None = None,
 ) -> Path | None:
     """Compose a multi-page PDF with the forecast and attribution heatmap."""
     try:
@@ -952,6 +1103,8 @@ def _build_pdf_report(
             "   forecast-vs-history diagnostics.",
             "5. Latent trajectory stability: temporal-smoothness metrics",
             "   over the context window.",
+            "6. Feature-axis attribution: which input channel drives each",
+            "   forecast step (multivariate inputs only).",
         ]
         fig.text(0.08, 0.85, "\n".join(summary), ha="left", va="top", fontsize=10, family="monospace")
         pdf.savefig(fig)
@@ -1182,6 +1335,19 @@ def _build_pdf_report(
             pdf.savefig(fig)
             plt.close(fig)
 
+        # Feature-axis page last (and only for multivariate inputs), matching
+        # its position in the cover summary.
+        if getattr(explanation, "channel_horizon_attributions", None) is not None:
+            try:
+                _channel_axis_page(
+                    pdf,
+                    plt,
+                    explanation=explanation,
+                    channel_labels=channel_labels,
+                )
+            except Exception as e:
+                print(f"Feature-axis page skipped: {e}")
+
     return pdf_path
 
 
@@ -1285,6 +1451,19 @@ def _explanation_to_dict(
         "trajectory_stability": _trajectory_report_to_dict(trajectory_report),
     }
 
+    # Feature-axis (channel) attribution -- only present for multivariate inputs.
+    chan_attrib = getattr(explanation, "channel_horizon_attributions", None)
+    if chan_attrib is not None:
+        feature_axis: dict[str, Any] = {
+            "method": getattr(explanation, "channel_flow_method", None),
+            "channel_horizon_attributions": _array_to_jsonable(np.asarray(chan_attrib)),
+            "residual_ratio_mean": _scalar_to_jsonable(explanation.channel_flow_residual_ratio_mean),
+            "residual_ratio_p95": _scalar_to_jsonable(explanation.channel_flow_residual_ratio_p95),
+        }
+        if include_full_arrays and getattr(explanation, "per_channel_flow", None) is not None:
+            feature_axis["per_channel_flow"] = _array_to_jsonable(np.asarray(explanation.per_channel_flow))
+        explanation_block["feature_axis"] = feature_axis
+
     if include_full_arrays:
         explanation_block["flow_magnitudes"] = _array_to_jsonable(explanation.flow_magnitudes)
         explanation_block["latent_trajectory"] = _array_to_jsonable(explanation.latent_trajectory)
@@ -1351,6 +1530,7 @@ def _run_interpretability(
     interpretability_run_name: str | None,
     interpretability_top_k: int,
     dataset_name: str | None,
+    channel_output_aware: bool = False,
 ) -> tuple[pd.DataFrame, Path]:
     """Generate the lag x horizon explanation, write artifacts, return (forecast_df, run_dir).
 
@@ -1367,6 +1547,13 @@ def _run_interpretability(
     x_context_ct = np.swapaxes(series_lc, 0, 1).copy()
     input_mask_l = np.ones((seq_len,), dtype=np.int64)
 
+    # Feature-axis (channel) attribution only makes sense for multivariate inputs.
+    n_channels = int(x_context_ct.shape[0])
+    channel_axis = n_channels > 1
+    # The target column is always channel 0 of columns_to_process, so output-aware
+    # attribution explains the target's own forecast.
+    output_aware = bool(channel_output_aware) and channel_axis
+
     model.eval()
     explanation = explain_forecast(
         model,
@@ -1378,6 +1565,9 @@ def _run_interpretability(
         n_lags=n_lags,
         softmax_tau=softmax_tau,
         surrogate=False,
+        channel_axis=channel_axis,
+        channel_output_aware=output_aware,
+        channel_target=0 if output_aware else None,
     )
 
     base_std = explanation.baseline_forecast
@@ -1439,6 +1629,15 @@ def _run_interpretability(
                 )
             except Exception as e:
                 print(f"semantic_flow.csv skipped: {e}")
+        if getattr(explanation, "channel_horizon_attributions", None) is not None:
+            try:
+                _save_channel_axis_artifacts(
+                    run_dir,
+                    np.asarray(explanation.channel_horizon_attributions, dtype=np.float32),
+                    channel_labels=columns_to_process,
+                )
+            except Exception as e:
+                print(f"channel_horizon artifacts skipped: {e}")
 
     trajectory_report: TrajectoryStabilityReport | None = None
     try:
@@ -1479,6 +1678,7 @@ def _run_interpretability(
             trajectory_report=trajectory_report,
             context_len=seq_len,
             forecast_horizon=forecast_horizon,
+            channel_labels=columns_to_process,
         )
         if produced is None:
             print("Interpretability PDF report skipped: matplotlib is not installed.")
@@ -1527,6 +1727,7 @@ def perform_forecasting(
     interpretability_dataset_name: str | None = None,
     n_lags: int = 128,
     softmax_tau: float = 1.0,
+    channel_output_aware: bool = False,
 ) -> pd.DataFrame:
     """
     Perform time series forecasting using NV-Tesseract with optional context-enhanced mode (DARR).
@@ -1785,6 +1986,7 @@ def perform_forecasting(
                 interpretability_run_name=interpretability_run_name,
                 interpretability_top_k=interpretability_top_k,
                 dataset_name=interpretability_dataset_name,
+                channel_output_aware=channel_output_aware,
             )
             print(f"\nInterpretability bundle written to: {run_dir}")
             if save_preds:

--- a/forecasting/sdk/quick_example.py
+++ b/forecasting/sdk/quick_example.py
@@ -9,7 +9,8 @@ This example demonstrates:
 1. Auto-downloading model weights from Hugging Face (on first run)
 2. Standard forecasting mode
 3. DARR mode (context-enhanced forecasting)
-4. Interpretability mode (lag x horizon attributions, JSON + PDF report)
+4. Interpretability mode (temporal lag x horizon attributions plus, for
+   multivariate inputs, feature-axis channel x horizon attributions; JSON + PDF)
 
 Make sure you're authenticated with Hugging Face for the private repo:
     huggingface-cli login
@@ -86,9 +87,26 @@ if __name__ == "__main__":
     #   - "json" -> writes only forecast.csv + explanation.json
     #   - "pdf"  -> writes forecast.csv + lag_horizon_*.csv/png + explanation_report.pdf
     #   - None   -> writes both (full bundle)
+    #
+    # Feature axis: when the input has more than one numeric column (a
+    # multivariate frame), the SDK also decomposes the forecast along the
+    # *feature axis*. The report gains a channel x horizon attribution page
+    # (which input channel drives each forecast step) and writes
+    # channel_horizon_attributions.csv / channel_horizon_heatmap.png. Below we
+    # derive two extra channels from the target so the feature-axis page is
+    # produced; swap in your own feature columns for a real multivariate signal.
+    # (By default the feature-axis attribution is measured in latent space; pass
+    # channel_output_aware=True to attribute the target channel's forecast
+    # directly instead, at the cost of extra forward passes.)
+    multivariate_df = df.copy()
+    multivariate_df[f"{target_col}_diff"] = multivariate_df[target_col].diff().fillna(0.0)
+    multivariate_df[f"{target_col}_roll12"] = (
+        multivariate_df[target_col].rolling(window=12, min_periods=1).mean()
+    )
+
     interp_out_dir = Path(__file__).resolve().parent / "interpretability_output"
     interp_df = perform_forecasting(
-        df=df,
+        df=multivariate_df,
         seq_len=seq_len,
         forecast_horizon=forecast_horizon,
         timestamp_column=timestamp_col,
@@ -105,3 +123,4 @@ if __name__ == "__main__":
     print(f"\nInterpretability forecast (single-window baseline in '{target_col}_forecast' column):")
     print(interp_df.head().to_string(index=False))
     print(f"\nReport bundle written under: {interp_out_dir}")
+    print("Multivariate input -> the report includes a feature-axis (channel x horizon) page.")


### PR DESCRIPTION
## Summary

Extends the model-agnostic interpretability framework and its SDK report from the
temporal (lag × horizon) axis to a second **feature axis**: a channel × horizon
attribution that answers *which input channel drives each forecast step*. For
multivariate inputs this runs automatically; univariate behavior is unchanged.

Attribution uses a fast, first-order **Jacobian-flow** estimator (O(C) extra
forward passes per transition) that decomposes each semantic-flow step into
per-channel contributions and carries an analytic trust ratio. An opt-in
`channel_output_aware` mode instead attributes the target channel's forecast
directly.

## Public API changes

`forecasting/interpretability.py`
- New engine: `ChannelFlowConfig`, `ChannelFlowReport`, `compute_per_channel_flow`,
  `lag_channel_horizon_attribution`, `channel_horizon_marginal`, and
  `make_target_forecast_value_fn` (output-aware value function).
- `explain_forecast(...)` gains `channel_axis`, `chan_cfg`, `channel_softmax_tau`,
  `channel_output_aware`, `channel_target` (all default off / None — backward
  compatible).
- `ForecastExplanation` gains `channel_horizon_attributions` `[C × H]`,
  `channel_flow_method`, `channel_flow_residual_ratio_mean`,
  `channel_flow_residual_ratio_p95`.

`forecasting/sdk/forecasting.py`
- `perform_forecasting(...)` gains `channel_output_aware: bool = False`.
- Feature-axis decomposition runs automatically when the input has >1 numeric
  column.
- New artifacts: `channel_horizon_attributions.csv`, `channel_horizon_heatmap.png`,
  a `feature_axis` block in `explanation.json`, and a dedicated feature-axis page
  in `explanation_report.pdf` (rendered last, multivariate inputs only).

## Behavior notes

- **Default is output-agnostic** (flow measured in latent space); this always
  yields distinct per-channel values.
- **`channel_output_aware=True`** measures flow on the target channel's forecast
  (more interpretable for a single target, extra forward passes). Non-target
  channels only receive attribution if the model couples channels
  (`use_cross_channel=True`, the default); with a channel-independent model only
  the target contributes.

## Docs / examples

- `quick_example.py`: multivariate demo that triggers the feature-axis page, with
  discoverability comments for `channel_output_aware`.
- Updated root / `forecasting` / `sdk` READMEs: artifact catalogue, PDF page list,
  the `channel_output_aware` parameter, and the cross-channel caveat.
