### PR TITLE
Fix DARR channel misalignment when input and context column orders differ

### DIFF
--- a/forecasting/sdk/README.md
+++ b/forecasting/sdk/README.md
@@ -239,6 +239,7 @@ perform_forecasting(
 - Timestamp column must be parseable by pandas and free of NULLs.
 - Target column must be numeric; NULLs are filled with zeros.
 - All numeric features are automatically included; NULLs become zeros.
+- Numeric feature columns should match the set and order the checkpoint/standardizer was trained with; a different order silently misattributes forecasts, and a different column count fails at standardization with a broadcasting error.
 - Input length must be at least `seq_len`; otherwise `ValueError` is raised.
 
 ## Outputs
@@ -248,6 +249,8 @@ perform_forecasting(
 - **Interpretability mode**: Returns the explanation-aligned forecast in `{target_column}_forecast` and writes the artifact bundle to `<interpretability_out_dir>/run_<UTC>/`.
 
 With `return_all_channels=True`, the single `{target_column}_forecast` column is replaced by one `{column}_forecast` column per processed channel (target column first, then the remaining numeric features in input-column order). Each forward pass already predicts every channel, so this avoids re-running the SDK once per column when downstream code needs multivariate forecasts. Autoregressive extension (`forecast_horizon > model_horizon`) and DARR blending apply to every channel the same way they apply to the target column; in DARR mode with mismatched input/context columns, only the aligned common columns are forecast (see Column Mismatch Handling).
+
+> **Channel order matters.** The checkpoint and standardizer are trained against a specific channel layout. At inference time the numeric columns of the input DataFrame should match the training-time set and order. With the same columns in a different order the model still runs, but the forecasts can be semantically wrong — especially visible with `return_all_channels=True`, where every channel becomes an output column. With extra or missing numeric columns the channel count no longer matches the standardizer, and the call fails at standardization with a broadcasting error before inference runs.
 
 ### Output DataFrame structure
 
@@ -313,13 +316,14 @@ The SDK automatically detects and handles column mismatches between input and co
 Warning: Column mismatch detected between input and context datasets
   Input dataset columns: ['HUFL', 'HULL', 'MUFL', 'MULL', 'LUFL', 'OT']
   Context dataset columns: ['HULL', 'MULL', 'LUFL']
-  Common columns: ['HULL', 'MULL', 'LUFL']
+  Common columns (input order): ['HULL', 'MULL', 'LUFL']
   Using only common columns for consistent predictions: ['HULL', 'MULL', 'LUFL']
 ```
 
 **Behavior**:
 - **Automatic detection**: Identifies when datasets have different feature sets
-- **Intelligent alignment**: Uses intersection of feature columns for consistent shapes
+- **Order-sensitive alignment**: Realignment also triggers when both datasets contain the same columns in a different order — otherwise the direct and kNN predictions would blend mismatched channels
+- **One canonical order**: Both temporary datasets are rewritten with the common feature columns in input-DataFrame order (target column first), so the caller-facing channel layout is preserved for the channels that remain
 - **Clear warnings**: Reports what columns are being used and why
 - **Graceful fallback**: Prevents cryptic NumPy broadcasting errors
 

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -1922,40 +1922,52 @@ def perform_forecasting(
                 context_numeric.remove(target_column)
 
             # COLUMN COMPATIBILITY CHECK AND ALIGNMENT
-            # Find intersection of numeric columns between main and context datasets
-            main_numeric_set = set(numeric_columns)
+            # Common feature columns in input-DataFrame order (target excluded;
+            # it is always included first). The canonical channel order is
+            # anchored to the input DataFrame so the caller/checkpoint-facing
+            # layout is preserved for the channels that remain. The context CSV
+            # always follows this canonical order (when the column lists already
+            # match, common_columns == context_numeric).
             context_numeric_set = set(context_numeric)
+            common_columns = [col for col in numeric_columns if col in context_numeric_set]
+            context_columns_to_use = [timestamp_column, target_column] + common_columns
 
-            # Common columns (excluding target which is always included)
-            common_columns = main_numeric_set.intersection(context_numeric_set)
-
-            # Check if we have column compatibility issues
-            if len(main_numeric_set) != len(context_numeric_set) or main_numeric_set != context_numeric_set:
-                logger.warning("Column mismatch detected between input and context datasets")
-                logger.warning("  Input dataset columns: %s", sorted(main_numeric_set))
-                logger.warning("  Context dataset columns: %s", sorted(context_numeric_set))
-                logger.warning("  Common columns: %s", sorted(common_columns))
-
-                if len(common_columns) == 0:
-                    raise ValueError(
-                        f"No common numeric columns found between input and context datasets.\n"
-                        f"Input dataset has: {sorted(main_numeric_set)}\n"
-                        f"Context dataset has: {sorted(context_numeric_set)}\n"
-                        f"For DARR mode to work, both datasets must share at least some numeric columns."
+            # Realign whenever the context column list differs from the input
+            # list. A set comparison is not enough: the same columns in a
+            # different order pass the downstream shape checks but blend
+            # mismatched channels in the hybrid output.
+            if numeric_columns != context_numeric:
+                if set(numeric_columns) == context_numeric_set:
+                    # Order-only difference: every column is kept. The main CSV
+                    # is already written in the canonical (input) order, so only
+                    # the context CSV needs realigning.
+                    logger.warning(
+                        "Context dataset lists the same numeric columns in a different order; "
+                        "realigning the context to the input column order: %s",
+                        common_columns,
                     )
+                else:
+                    logger.warning("Column mismatch detected between input and context datasets")
+                    logger.warning("  Input dataset columns: %s", numeric_columns)
+                    logger.warning("  Context dataset columns: %s", context_numeric)
+                    logger.warning("  Common columns (input order): %s", common_columns)
 
-                logger.warning("  Using only common columns for consistent predictions: %s", sorted(common_columns))
+                    if len(common_columns) == 0:
+                        raise ValueError(
+                            f"No common numeric columns found between input and context datasets.\n"
+                            f"Input dataset has: {numeric_columns}\n"
+                            f"Context dataset has: {context_numeric}\n"
+                            f"For DARR mode to work, both datasets must share at least some numeric columns."
+                        )
 
-                # Update both datasets to use only common columns
-                columns_to_process = [target_column] + sorted(common_columns)
-                context_columns_to_use = [timestamp_column, target_column] + sorted(common_columns)
+                    logger.warning("  Using only common columns for consistent predictions: %s", common_columns)
 
-                # Re-save the main CSV with aligned columns
-                csv_df = working_df[[timestamp_column] + columns_to_process].copy()
-                csv_df.rename(columns={timestamp_column: "timestamp"}, inplace=True)
-                csv_df.to_csv(temp_test_csv, index=False)
-            else:
-                context_columns_to_use = [timestamp_column, target_column] + context_numeric
+                    # The channel set narrowed: rewrite the main CSV in the same
+                    # canonical order as the context CSV.
+                    columns_to_process = [target_column] + common_columns
+                    csv_df = working_df[[timestamp_column] + columns_to_process].copy()
+                    csv_df.rename(columns={timestamp_column: "timestamp"}, inplace=True)
+                    csv_df.to_csv(temp_test_csv, index=False)
 
             # Create CSV with selected columns
             context_csv_df = context_working[context_columns_to_use].copy()

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
@@ -48,6 +49,19 @@ class ChannelIndexedModel(DummyModel):
         return SimpleNamespace(forecast=forecast)
 
 
+class LastValueModel(DummyModel):
+    """DummyModel variant that repeats each channel's last observed value.
+
+    Makes the direct-prediction path sensitive to the channel layout of the
+    (rewritten) input CSV: each forecast channel reproduces the constant of
+    the input channel it was built from.
+    """
+
+    def __call__(self, x_enc: torch.Tensor, input_mask: torch.Tensor):
+        forecast = x_enc[:, :, -1:].repeat(1, 1, self.model_horizon)
+        return SimpleNamespace(forecast=forecast)
+
+
 @pytest.fixture(autouse=True)
 def patch_external_dependencies(monkeypatch):
     build_calls = []
@@ -81,6 +95,25 @@ def make_timeseries(num_rows: int = 10) -> pd.DataFrame:
             "feature": np.linspace(0.0, 1.0, num_rows, dtype=np.float32),
         }
     )
+
+
+def make_constant_feature_df(num_rows: int, feature_values: dict[str, float]) -> pd.DataFrame:
+    """Create a timeseries DataFrame whose feature columns are constants.
+
+    With uniform stub embeddings, the kNN retrieval forecast is the mean of the
+    context continuations, so each forecast channel reproduces the constant of
+    the context channel it was built from — which makes channel misalignment
+    observable as a wrong constant in the output. Column order follows the
+    insertion order of ``feature_values``.
+    """
+    timestamps = pd.date_range("2024-01-01", periods=num_rows, freq="h")
+    data = {
+        "timestamp": timestamps,
+        "target": np.zeros(num_rows, dtype=np.float32),
+    }
+    for name, value in feature_values.items():
+        data[name] = np.full(num_rows, value, dtype=np.float32)
+    return pd.DataFrame(data)
 
 
 def make_timeseries_with_columns(num_rows: int = 10, columns: list[str] | None = None) -> pd.DataFrame:
@@ -1033,3 +1066,119 @@ def test_perform_forecasting_darr_mode_column_alignment_with_autoregression():
 
     assert len(result) == 6
     assert result["target_forecast"].notna().all()
+
+
+def test_perform_forecasting_darr_mode_same_columns_different_order(caplog):
+    """An order-only difference must trigger realignment of the context CSV.
+
+    The target channel is first in both layouts, so this test observes the
+    realignment through the warning log; the value-level alignment is covered
+    by the return_all_channels tests below.
+    """
+    df = make_constant_feature_df(12, {"f1": 10.0, "f2": 20.0})
+    context_df = make_constant_feature_df(12, {"f2": 20.0, "f1": 10.0})
+
+    with caplog.at_level(logging.WARNING):
+        result = forecasting.perform_forecasting(
+            df,
+            seq_len=5,
+            forecast_horizon=3,
+            model_horizon=3,
+            context_df=context_df,
+            alpha=0.0,  # pure kNN: forecasts reproduce the context channel constants
+            standardizer_pkl="fake_std.pkl",
+            ckpt="fake_ckpt.pt",
+            seed=42,
+        )
+
+    assert len(result) == 3
+    assert result["target_forecast"].tolist() == pytest.approx([0.0, 0.0, 0.0])
+    # A set-based comparison would treat the two layouts as identical and skip
+    # realignment silently; the order-only warning proves the branch fired.
+    assert any("same numeric columns in a different order" in rec.getMessage() for rec in caplog.records)
+
+
+def test_perform_forecasting_darr_mode_different_order_return_all_channels_aligned():
+    """With return_all_channels=True, every output column must carry the value of
+    its own channel even when the context lists the same columns in another order."""
+    df = make_constant_feature_df(12, {"f1": 10.0, "f2": 20.0})
+    context_df = make_constant_feature_df(12, {"f2": 20.0, "f1": 10.0})
+
+    result = forecasting.perform_forecasting(
+        df,
+        seq_len=5,
+        forecast_horizon=3,
+        model_horizon=3,
+        context_df=context_df,
+        alpha=0.0,  # pure kNN: forecasts reproduce the context channel constants
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        seed=42,
+        return_all_channels=True,
+    )
+
+    assert list(result.columns) == ["timestamp", "target_forecast", "f1_forecast", "f2_forecast"]
+    # A channel mix-up would surface the other channel's constant here.
+    assert result["f1_forecast"].tolist() == pytest.approx([10.0, 10.0, 10.0])
+    assert result["f2_forecast"].tolist() == pytest.approx([20.0, 20.0, 20.0])
+
+
+def test_perform_forecasting_darr_mode_column_mismatch_uses_input_order_common_subset():
+    """Missing/extra context features fall back to the aligned common subset,
+    anchored to the input-DataFrame column order (not sorted order)."""
+    # Input feature order [zz, beta, alpha] differs from sorted order; the
+    # context is missing `zz` and lists the common features in another order.
+    df = make_constant_feature_df(12, {"zz": 30.0, "beta": 20.0, "alpha": 10.0})
+    context_df = make_constant_feature_df(12, {"alpha": 10.0, "beta": 20.0})
+
+    result = forecasting.perform_forecasting(
+        df,
+        seq_len=5,
+        forecast_horizon=3,
+        model_horizon=3,
+        context_df=context_df,
+        alpha=0.0,  # pure kNN: forecasts reproduce the context channel constants
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        seed=42,
+        return_all_channels=True,
+    )
+
+    # Only the aligned common subset survives, in input-DataFrame order.
+    assert list(result.columns) == ["timestamp", "target_forecast", "beta_forecast", "alpha_forecast"]
+    assert result["beta_forecast"].tolist() == pytest.approx([20.0, 20.0, 20.0])
+    assert result["alpha_forecast"].tolist() == pytest.approx([10.0, 10.0, 10.0])
+
+
+def test_perform_forecasting_darr_mode_column_mismatch_direct_predictions_aligned(monkeypatch):
+    """With alpha=1.0 (pure direct) the forecasts come from the rewritten input
+    CSV, so this guards the main-CSV side of the canonical-order rewrite (the
+    kNN-side tests above run with alpha=0.0 and cannot observe it)."""
+    monkeypatch.setattr(
+        forecasting,
+        "build_model",
+        lambda *, forecast_horizon, **kwargs: LastValueModel(model_horizon=forecast_horizon),
+    )
+    forecasting.clear_model_cache()
+
+    df = make_constant_feature_df(12, {"zz": 30.0, "beta": 20.0, "alpha": 10.0})
+    context_df = make_constant_feature_df(12, {"alpha": 10.0, "beta": 20.0})
+
+    result = forecasting.perform_forecasting(
+        df,
+        seq_len=5,
+        forecast_horizon=3,
+        model_horizon=3,
+        context_df=context_df,
+        alpha=1.0,  # pure direct: forecasts reproduce the input channel constants
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        seed=42,
+        return_all_channels=True,
+    )
+
+    assert list(result.columns) == ["timestamp", "target_forecast", "beta_forecast", "alpha_forecast"]
+    # If the rewritten input CSV used a different order than the output naming,
+    # each column would carry the other channel's constant.
+    assert result["beta_forecast"].tolist() == pytest.approx([20.0, 20.0, 20.0])
+    assert result["alpha_forecast"].tolist() == pytest.approx([10.0, 10.0, 10.0])


### PR DESCRIPTION
Fixes #50.

## Problem

In DARR mode, the column-compatibility check compared the input and context numeric columns as **sets**, so two DataFrames holding the same columns in a different order skipped the realignment branch. The direct predictions then followed the input column order while the kNN retrieval predictions followed the context column order, and `alpha * preds_direct + (1 - alpha) * preds_knn` blended mismatched channels — silently, since the channel counts matched.

## Fix

Implemented the direction suggested in the issue discussion:

- `common_columns` is now built as a **list in input-DataFrame order** (`[col for col in numeric_columns if col in context_numeric_set]`), anchoring the canonical channel order to the caller/checkpoint-facing layout.
- The mismatch condition is now **order-sensitive** (`numeric_columns != context_numeric`), so same-set/different-order inputs fall into the realignment branch.
- The context CSV always follows the canonical order; when the channel set narrows, the main CSV is rewritten in the same order (this replaces the previous `sorted(common)` normalization). For an order-only difference the main CSV is already in canonical order, so only the context CSV is realigned — with a dedicated warning, since no column is dropped in that case.
- Warnings now print the actual column orders instead of sorted sets.

## Tests

Added the three cases requested in the issue discussion, plus a direct-path guard. The value-level assertions use constant-valued feature channels: with `alpha=0.0` (pure kNN) and uniform stub embeddings the retrieval forecast reproduces each **context** channel's constant, and with `alpha=1.0` (pure direct) and a last-value stub model each forecast reproduces its **input** channel's constant — so a channel mix-up on either side surfaces as the wrong constant in the output.

- `test_perform_forecasting_darr_mode_same_columns_different_order` — same feature set, different order; asserts the order-only realignment fires (via the new warning), since the target channel alone cannot reveal misalignment
- `test_perform_forecasting_darr_mode_different_order_return_all_channels_aligned` — same scenario with `return_all_channels=True`, asserting output columns and per-channel values (fails on `main` with the other channel's constant, passes with this fix)
- `test_perform_forecasting_darr_mode_column_mismatch_uses_input_order_common_subset` — missing/extra context features use the aligned common subset in input order (feature names chosen so input order differs from sorted order)
- `test_perform_forecasting_darr_mode_column_mismatch_direct_predictions_aligned` — `alpha=1.0` variant of the mismatch case, verifying the rewritten **input** CSV keeps each forecast column on its own channel (the kNN-side tests cannot observe the main-CSV rewrite)

## Docs

- Updated the Column Mismatch Handling section (order-sensitive alignment, one canonical order anchored to the input DataFrame).
- Added the channel-order note requested in the PR #26 review: inference columns must match the checkpoint/standardizer training set and order, which is especially visible with `return_all_channels=True`. The longer-term standardizer channel-order metadata remains a separate follow-up as discussed.

## Validation

`make lint`, `make spdx-check`, and `pytest sdk/tests/test_forecasting.py -q` (50 passed) on this branch. The two kNN-side value-level tests fail on current `main` (e.g. `f1_forecast == [20.0, 20.0, 20.0]` where `10.0` is expected), confirming they capture the reported bug.

## Notes (pre-existing behavior, intentionally unchanged)

- When the two datasets share **zero common feature columns**, DARR still hard-fails with the existing `ValueError`, even though both sides share the numeric target column. Relaxing this to allow target-only DARR would be a behavior change beyond this fix — happy to follow up if you want it relaxed.
- When the realignment **narrows the channel count**, a standardizer fitted on the full training layout will fail at `standardizer.transform` with a broadcasting error before inference. That is the standardizer channel-metadata concern you flagged as a separate follow-up; the README now describes the actual behavior (order-only differences run; count changes fail at standardization).
- The `len(common_columns) != len(numeric_columns)` disjunct from the sketch in the issue discussion is implied by `numeric_columns != context_numeric` (`common_columns` is a filter of `numeric_columns`), so the implemented condition is the plain order-sensitive list comparison.