### PR TITLE
Add feature-axis and integrated gradients SDK interpretability

### DIFF
--- a/forecasting/README.md
+++ b/forecasting/README.md
@@ -148,6 +148,7 @@ forecasting/
 ├── dataset_longhorizon.py            # Dataset utilities and Standardizer
 ├── interpretability.py               # Model-agnostic explanation engine (semantic flow, lag×horizon, trajectory stability, PDF report)
 ├── channel_flow.py                   # v2 per-channel Jacobian/Shapley flow + coupling
+├── integrated_gradients.py           # Embedding Integrated Gradients / Expected Gradients
 ├── interpretability_parallel.py      # Multi-GPU Pass A / Pass B dispatch + sharding
 ├── parallel.py                       # GPU worker pool + surrogate thread pool
 ├── run_interpretability_sharded.py   # CLI benchmark for multi-GPU interpretability (Pass A ‖ Pass B sharding)

--- a/forecasting/channel_flow.py
+++ b/forecasting/channel_flow.py
@@ -54,7 +54,7 @@ These reductions are codified in the unit tests under ``tests/``.
 
 from dataclasses import dataclass
 from itertools import combinations
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 import numpy as np
 import torch
@@ -294,6 +294,48 @@ def _embed_windows_batched(
     return z
 
 
+ValueFn = Callable[..., Array]
+
+
+def make_target_forecast_value_fn(
+    *,
+    target_channel: int,
+    model_horizon: int,
+    forecast_horizon: int,
+) -> ValueFn:
+    """Build a channel-flow value function over the target forecast."""
+    from interpretability import _forecast_autoregressive
+
+    def _value_fn(model, windows, masks, *, device, batch_size) -> Array:
+        n = int(windows.shape[0])
+        if n == 0:
+            return np.zeros((0, int(forecast_horizon)), dtype=np.float32)
+        out_chunks: list[Array] = []
+        for i in range(0, n, int(batch_size)):
+            xb = torch.from_numpy(np.ascontiguousarray(windows[i : i + int(batch_size)])).to(
+                device=device,
+                dtype=torch.float32,
+            )
+            mb = torch.from_numpy(np.ascontiguousarray(masks[i : i + int(batch_size)])).to(
+                device=device,
+                dtype=torch.long,
+            )
+            forecast = _forecast_autoregressive(
+                model,
+                xb,
+                mb,
+                model_horizon=int(model_horizon),
+                target_horizon=int(forecast_horizon),
+            )
+            out_chunks.append(np.asarray(forecast[:, int(target_channel), :], dtype=np.float32))
+        values = np.concatenate(out_chunks, axis=0)
+        if np.any(~np.isfinite(values)):
+            values = np.nan_to_num(values, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32, copy=False)
+        return values
+
+    return _value_fn
+
+
 # ---------------------------------------------------------------------------
 # Variant A: Jacobian-flow (fast, first-order)
 # ---------------------------------------------------------------------------
@@ -308,6 +350,7 @@ def compute_per_channel_flow_jacobian(
     input_mask_t: Array | None = None,
     device: torch.device,
     cfg: ChannelFlowConfig | None = None,
+    value_fn: ValueFn | None = None,
 ) -> ChannelFlowReport:
     """First-order per-channel decomposition of latent flow.
 
@@ -332,6 +375,7 @@ def compute_per_channel_flow_jacobian(
     cfg = cfg or ChannelFlowConfig(method="jacobian")
     if cfg.method != "jacobian":
         raise ValueError(f"compute_per_channel_flow_jacobian requires method='jacobian', got {cfg.method!r}")
+    vf = value_fn if value_fn is not None else _embed_windows_batched
 
     xw_view, m_view, T = _rolling_window_sources(series_ct, seq_len=seq_len, input_mask_t=input_mask_t)
     if T < 2:
@@ -396,13 +440,13 @@ def compute_per_channel_flow_jacobian(
         flat_stack = stack.reshape(m_chunk * probes_per_trans, C, L)
         flat_masks = masks_full.reshape(m_chunk * probes_per_trans, L)
 
-        z_flat = _embed_windows_batched(
+        z_flat = vf(
             model,
             flat_stack,
             flat_masks,
             device=device,
             batch_size=int(cfg.batch_size),
-        )  # [m * probes_per_trans, D]
+        )  # [m * probes_per_trans, Dv]
         D = int(z_flat.shape[1])
         z = z_flat.reshape(m_chunk, probes_per_trans, D)
 
@@ -498,57 +542,79 @@ def _kernelshap_from_v(
     n_samples: int,
     rng: np.random.Generator,
 ) -> np.ndarray:
-    """Approximate Shapley values via KernelSHAP weighted least squares.
+    """Approximate Shapley values via constrained KernelSHAP regression.
 
     Solves:
         min_phi  sum_S w_S (v(S) - v(empty) - phi.T @ z_S)^2
         s.t.     sum_c phi_c = v(full) - v(empty)
     """
+    del n_samples, rng
+    coalitions = sorted(v, key=lambda s: (len(s), s))
+    values = np.asarray([v[S] for S in coalitions], dtype=np.float64)
+    return _kernelshap_from_values(coalitions, values, C=C)
+
+
+def _kernelshap_from_values(
+    coalitions: Sequence[tuple[int, ...]],
+    values: np.ndarray,
+    *,
+    C: int,
+) -> np.ndarray:
+    """Constrained KernelSHAP for one or many outputs."""
+    coalition_list = [tuple(int(c) for c in S) for S in coalitions]
+    vals = np.asarray(values, dtype=np.float64)
+    if vals.ndim < 1 or vals.shape[0] != len(coalition_list):
+        raise ValueError(
+            "values must have one leading row per coalition; "
+            f"got values.shape={vals.shape}, n_coalitions={len(coalition_list)}"
+        )
+    if C < 1:
+        raise ValueError(f"C must be positive, got {C}")
+
+    try:
+        empty_idx = coalition_list.index(())
+        full_idx = coalition_list.index(tuple(range(C)))
+    except ValueError as exc:
+        raise ValueError("KernelSHAP requires both empty and full coalitions") from exc
+
+    trailing_shape = vals.shape[1:]
+    flat = vals.reshape(vals.shape[0], -1)
+    v_empty = flat[empty_idx]
+    total_effect = flat[full_idx] - v_empty
     if C == 1:
-        return np.array([v[(0,)] - v[()]], dtype=np.float32)
-    v_empty = float(v[()])
-    v_full = float(v[tuple(range(C))])
+        return total_effect.reshape((1, *trailing_shape)).astype(np.float32)
 
-    # Sample coalitions (excluding empty and full, which act as constraints).
-    sizes = np.arange(1, C, dtype=np.int64)
-    p_sizes = np.array([_kernelshap_weight(C, int(s)) for s in sizes], dtype=np.float64)
-    p_sizes = p_sizes / p_sizes.sum()
+    interior = [(i, S) for i, S in enumerate(coalition_list) if 0 < len(S) < C]
+    if not interior:
+        uniform = np.broadcast_to(total_effect[None, :] / C, (C, total_effect.size)).copy()
+        return uniform.reshape((C, *trailing_shape)).astype(np.float32)
 
-    z_rows: list[np.ndarray] = []
-    targets: list[float] = []
-    weights: list[float] = []
-    seen: set[tuple[int, ...]] = set()
-    n_target = max(1, int(n_samples))
-    n_attempts = 0
-    while len(z_rows) < n_target and n_attempts < n_target * 5:
-        n_attempts += 1
-        size = int(rng.choice(sizes, p=p_sizes))
-        S = tuple(sorted(rng.choice(C, size=size, replace=False).tolist()))
-        if S in seen or S not in v:
-            continue
-        seen.add(S)
-        z = np.zeros((C,), dtype=np.float64)
-        z[list(S)] = 1.0
-        z_rows.append(z)
-        targets.append(float(v[S]) - v_empty)
-        weights.append(_kernelshap_weight(C, size))
-    if not z_rows:
-        # Degenerate fall back: split v(full) - v(empty) uniformly.
-        return np.full((C,), (v_full - v_empty) / C, dtype=np.float32)
+    size_counts: dict[int, int] = {}
+    for _, S in interior:
+        size_counts[len(S)] = size_counts.get(len(S), 0) + 1
 
-    Z = np.stack(z_rows, axis=0).astype(np.float64)
-    y = np.asarray(targets, dtype=np.float64)
-    w = np.sqrt(np.asarray(weights, dtype=np.float64))
-    Zw = Z * w[:, None]
-    yw = y * w
+    Z = np.zeros((len(interior), C), dtype=np.float64)
+    y = np.empty((len(interior), flat.shape[1]), dtype=np.float64)
+    w = np.empty((len(interior),), dtype=np.float64)
+    for row, (value_idx, S) in enumerate(interior):
+        size = len(S)
+        Z[row, list(S)] = 1.0
+        y[row] = flat[value_idx] - v_empty
+        size_mass = (C - 1) / (size * (C - size))
+        w[row] = size_mass / size_counts[size]
 
-    # Solve constrained least squares via projection onto the affine subspace
-    # { phi : 1^T phi = v_full - v_empty }. Project the unconstrained solution
-    # back to the constraint plane.
-    sol_unconstrained, *_ = np.linalg.lstsq(Zw, yw, rcond=None)
-    correction = (v_full - v_empty) - sol_unconstrained.sum()
-    phi = sol_unconstrained + correction / float(C)
-    return phi.astype(np.float32)
+    gram = Z.T @ (w[:, None] * Z)
+    rhs = Z.T @ (w[:, None] * y)
+    ridge = max(1e-12, 1e-10 * float(np.trace(gram)) / max(1, C))
+    gram = gram + ridge * np.eye(C, dtype=np.float64)
+    ones = np.ones((C, 1), dtype=np.float64)
+    kkt = np.block([[gram, ones], [ones.T, np.zeros((1, 1), dtype=np.float64)]])
+    target = np.concatenate([rhs, total_effect[None, :]], axis=0)
+    try:
+        sol = np.linalg.solve(kkt, target)
+    except np.linalg.LinAlgError:
+        sol, *_ = np.linalg.lstsq(kkt, target, rcond=None)
+    return sol[:C].reshape((C, *trailing_shape)).astype(np.float32)
 
 
 def _build_step_coalition_set(
@@ -575,20 +641,40 @@ def _build_step_coalition_set(
     coalitions.add(tuple(range(C)))
     for c in range(C):
         coalitions.add((c,))
+        coalitions.add(tuple(i for i in range(C) if i != c))
     if include_pairs:
         for pair in combinations(range(C), 2):
             coalitions.add(pair)
     sizes = np.arange(1, C, dtype=np.int64)
     if sizes.size:
-        p_sizes = np.array([_kernelshap_weight(C, int(s)) for s in sizes], dtype=np.float64)
-        p_sizes = p_sizes / p_sizes.sum() if p_sizes.sum() > 0 else None
+        target_total = max(len(coalitions), int(n_samples))
+        represented_sizes = {len(coalition) for coalition in coalitions}
+        for size in range(2, (C // 2) + 1):
+            complement_size = C - size
+            needed = int(size not in represented_sizes) + int(
+                complement_size not in represented_sizes and complement_size != size
+            )
+            if needed == 0 or len(coalitions) + needed > target_total:
+                continue
+            coalition = tuple(sorted(rng.choice(C, size=size, replace=False).tolist()))
+            complement = tuple(i for i in range(C) if i not in set(coalition))
+            coalitions.add(coalition)
+            if complement_size != size:
+                coalitions.add(complement)
+            represented_sizes.add(size)
+            represented_sizes.add(complement_size)
+
+        p_sizes = 1.0 / (sizes.astype(np.float64) * (C - sizes).astype(np.float64))
+        p_sizes = p_sizes / p_sizes.sum()
         attempts = 0
-        max_attempts = max(int(n_samples) * 5, int(n_samples) + 32)
-        while len(coalitions) < int(n_samples) + 2 + C and attempts < max_attempts:
+        max_attempts = max(target_total * 20, target_total + 64)
+        while len(coalitions) < target_total and attempts < max_attempts:
             attempts += 1
             size = int(rng.choice(sizes, p=p_sizes))
             S = tuple(sorted(rng.choice(C, size=size, replace=False).tolist()))
             coalitions.add(S)
+            if len(coalitions) < target_total:
+                coalitions.add(tuple(i for i in range(C) if i not in set(S)))
     # Stable ordering by (size, lex) so that batches are deterministic.
     return sorted(coalitions, key=lambda s: (len(s), s))
 
@@ -602,6 +688,8 @@ def compute_per_channel_flow_shapley(
     input_mask_t: Array | None = None,
     device: torch.device,
     cfg: ChannelFlowConfig | None = None,
+    value_fn: ValueFn | None = None,
+    protect_channels: Sequence[int] | None = None,
     _per_transition_rng: bool = False,
 ) -> ChannelFlowReport:
     """Axiomatic Shapley decomposition of latent flow.
@@ -647,6 +735,7 @@ def compute_per_channel_flow_shapley(
     cfg = cfg or ChannelFlowConfig(method="shapley")
     if cfg.method != "shapley":
         raise ValueError(f"compute_per_channel_flow_shapley requires method='shapley', got {cfg.method!r}")
+    vf = value_fn if value_fn is not None else _embed_windows_batched
 
     xw_view, m_view, T = _rolling_window_sources(series_ct, seq_len=seq_len, input_mask_t=input_mask_t)
     if T < 2:
@@ -656,16 +745,24 @@ def compute_per_channel_flow_shapley(
     C = int(np.asarray(series_ct).shape[0])
     L = int(seq_len)
     rng = np.random.default_rng(int(cfg.seed))
-    use_exact = int(cfg.shapley_max_exact_c) >= C
+
+    protect = tuple(sorted({int(p) for p in (protect_channels or ()) if 0 <= int(p) < C}))
+    free = [c for c in range(C) if c not in set(protect)]
+    n_free = len(free)
+    if n_free < 1:
+        raise ValueError("compute_per_channel_flow_shapley: all channels protected leaves no coalition game")
+    compute_coupling = bool(cfg.compute_coupling) and not protect
+
+    use_exact = int(cfg.shapley_max_exact_c) >= n_free
     method_label = "exact" if use_exact else "kernel"
-    n_samples = int(cfg.shapley_n_samples) if cfg.shapley_n_samples is not None else (2 * C + 256)
+    n_samples = int(cfg.shapley_n_samples) if cfg.shapley_n_samples is not None else (2 * n_free + 256)
 
     coalitions = _build_step_coalition_set(
-        C,
+        n_free,
         method=method_label,
         n_samples=n_samples,
         rng=rng,
-        include_pairs=bool(cfg.compute_coupling) and not use_exact,
+        include_pairs=compute_coupling and not use_exact,
     )
     coalition_idx = {S: i for i, S in enumerate(coalitions)}
 
@@ -692,9 +789,11 @@ def compute_per_channel_flow_shapley(
     # composition step (we just blend ``baseline`` and ``window`` according
     # to the channel's coalition membership).
     coal_mask = np.zeros((n_coal, C), dtype=bool)
+    if protect:
+        coal_mask[:, list(protect)] = True
     for i, S in enumerate(coalitions):
         if S:
-            coal_mask[i, list(S)] = True
+            coal_mask[i, [free[j] for j in S]] = True
     coal_keep = coal_mask.astype(np.float32)[:, :, None]  # [n_coal, C, 1]
     coal_drop = (1.0 - coal_keep).astype(np.float32)  # [n_coal, C, 1]
     nonempty_coal = coal_mask.any(axis=1)  # [n_coal] -- True iff S != empty
@@ -759,24 +858,25 @@ def compute_per_channel_flow_shapley(
         flat_stack = stack.reshape(m_chunk * 2 * n_coal, C, L)
         flat_masks = masks.reshape(m_chunk * 2 * n_coal, L)
 
-        z_flat = _embed_windows_batched(
+        z_flat = vf(
             model,
             flat_stack,
             flat_masks,
             device=device,
             batch_size=int(cfg.batch_size),
-        )  # [m * 2 * n_coal, D]
+        )  # [m * 2 * n_coal, Dv]
         D = int(z_flat.shape[1])
         z = z_flat.reshape(m_chunk, 2 * n_coal, D)
         z_a = z[:, 0::2, :]  # [m, n_coal, D]
         z_b = z[:, 1::2, :]  # [m, n_coal, D]
-        v_vals_chunk = np.linalg.norm(z_b - z_a, ord=2, axis=2).astype(np.float64)  # [m, n_coal]
+        delta_z_chunk = (z_b - z_a).astype(np.float64)  # [m, n_coal, D]
+        v_vals_chunk = np.linalg.norm(delta_z_chunk, ord=2, axis=2)  # [m, n_coal]
 
         for k, tau in enumerate(chunk):
             v_vals = v_vals_chunk[k]
             v: dict[tuple[int, ...], float] = {S: float(v_vals[coalition_idx[S]]) for S in coalitions}
             if use_exact:
-                phi_tau = _exact_shapley_from_v(v, C=C)
+                phi_free = _exact_shapley_from_v(v, C=n_free)
             else:
                 # Per-transition RNG: pin the kernel-Shapley sampler to a
                 # deterministic state derived from (seed, tau) so that the
@@ -785,24 +885,29 @@ def compute_per_channel_flow_shapley(
                 # This is what makes sharded execution produce identical
                 # results regardless of how many workers we split across.
                 rng_for_tau = np.random.default_rng((int(cfg.seed), int(tau))) if _per_transition_rng else rng
-                phi_tau = _kernelshap_from_v(
+                phi_free = _kernelshap_from_v(
                     v,
-                    C=C,
+                    C=n_free,
                     n_samples=n_samples,
                     rng=rng_for_tau,
                 )
+            phi_tau = np.zeros((C,), dtype=np.float32)
+            for j, c in enumerate(free):
+                phi_tau[c] = float(phi_free[j])
             phi[int(tau)] = phi_tau
-            flow_total[int(tau)] = float(v[tuple(range(C))])
+            flow_total[int(tau)] = float(v[tuple(range(n_free))])
 
-            if cfg.compute_coupling:
-                v_empty = float(v.get((), 0.0))
-                singletons = {c: float(v.get((c,), 0.0)) for c in range(C)}
+            if compute_coupling:
+                delta_z = delta_z_chunk[k]
+                d_empty = delta_z[coalition_idx[()]]
+                singletons = {c: delta_z[coalition_idx[(c,)]] for c in range(C)}
                 for c1, c2 in combinations(range(C), 2):
                     pair_key = (c1, c2)
-                    v_pair = v.get(pair_key)
-                    if v_pair is None:
+                    pair_idx = coalition_idx.get(pair_key)
+                    if pair_idx is None:
                         continue
-                    g = abs(float(v_pair) - singletons[c1] - singletons[c2] + v_empty)
+                    interaction = delta_z[pair_idx] - singletons[c1] - singletons[c2] + d_empty
+                    g = float(np.linalg.norm(interaction, ord=2))
                     coupling_acc[c1, c2] += g
                     coupling_acc[c2, c1] += g
                 coupling_n += 1
@@ -811,7 +916,7 @@ def compute_per_channel_flow_shapley(
     coupling_off_diag = None
     coupling_partial_sum: np.ndarray | None = None
     coupling_partial_n = 0
-    if cfg.compute_coupling and coupling_n > 0:
+    if compute_coupling and coupling_n > 0:
         if cfg.coupling_aggregation == "mean":
             coupling_matrix = (coupling_acc / float(coupling_n)).astype(np.float32)
         elif cfg.coupling_aggregation == "sum":
@@ -849,6 +954,8 @@ def compute_per_channel_flow(
     input_mask_t: Array | None = None,
     device: torch.device,
     cfg: ChannelFlowConfig | None = None,
+    value_fn: ValueFn | None = None,
+    protect_channels: Sequence[int] | None = None,
 ) -> ChannelFlowReport:
     """Dispatch to the configured per-channel flow estimator."""
     cfg = cfg or ChannelFlowConfig()
@@ -860,6 +967,7 @@ def compute_per_channel_flow(
             input_mask_t=input_mask_t,
             device=device,
             cfg=cfg,
+            value_fn=value_fn,
         )
     if cfg.method == "shapley":
         return compute_per_channel_flow_shapley(
@@ -869,6 +977,8 @@ def compute_per_channel_flow(
             input_mask_t=input_mask_t,
             device=device,
             cfg=cfg,
+            value_fn=value_fn,
+            protect_channels=protect_channels,
         )
     raise ValueError(f"Unsupported ChannelFlowConfig.method={cfg.method!r}")
 

--- a/forecasting/integrated_gradients.py
+++ b/forecasting/integrated_gradients.py
@@ -439,6 +439,7 @@ def moment_embed_fn(model, *, input_mask: torch.Tensor | None = None, grad_throu
             IG stays faithful. The override is scoped to each embedding call
             and restored immediately.
     """
+
     def _fn(x: torch.Tensor) -> torch.Tensor:
         if x.ndim != 3:
             raise ValueError(f"MOMENT embed_fn expects [n, C, L]; got {tuple(x.shape)}")

--- a/forecasting/integrated_gradients.py
+++ b/forecasting/integrated_gradients.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+"""Integrated Gradients / Expected Gradients over the embedding layer.
+
+What this measures
+==================
+This is a *general*, model-agnostic interpretability primitive. Given any model
+that encodes a time-series context window into an embedding,
+
+    e = Enc(x) ,    x in R^{...} (the input window),  e in R^{D} (the encoding),
+
+it measures the effect of the input on the encoding by **accumulating the
+gradients of the embedding layer along a straight-line path from a baseline to
+the input** (Integrated Gradients; Sundararajan et al., 2017):
+
+    A_i = (x_i - x0_i) * \\int_0^1  d g(Enc(x0 + a*(x - x0))) / d x_i  da ,
+
+where ``g`` reduces the embedding vector to a scalar (default: its L2 norm) and
+``x0`` is the baseline (default: zeros, i.e. the "absence of input"). The path
+``x0 -> x`` progressively *imputes* the input values into the encoder, and the
+accumulated gradient quantifies how strongly those values drive the encoding.
+
+By the completeness axiom,
+
+    sum_i A_i = g(Enc(x)) - g(Enc(x0)) ,
+
+which is reported as a convergence diagnostic.
+
+Baseline choice (important for time-series foundation models)
+=============================================================
+MOMENT's RevIN applies
+**instance normalization** ``(x - mean) / std`` inside the encoder, which is
+invariant to shifting and scaling the input. A straight-line path from a *zero
+or constant* baseline to ``x`` is, after normalization, the **same** normalized
+series at every step -- so the embedding is flat along the path, the accumulated
+gradient is ~0, and IG fails completeness (it misses the jump at the degenerate
+endpoint). The fix is a **structured baseline** that carries its own shape; the
+default here is white-noise matched to the input's global mean/std, which breaks
+the invariance and restores completeness. Averaging over several such baselines
+(``n_baselines > 1``) is the Expected-Gradients estimator and reduces variance.
+
+Design
+======
+* **Model-agnostic.** The core depends only on a differentiable
+  ``embed_fn: Tensor[n, *feat] -> Tensor[n, D]`` that maps a *batch* of inputs
+  to a batch of embeddings. Nothing here knows about channels, patches,
+  missingness, or any specific architecture. :func:`moment_embed_fn` builds
+  ``embed_fn`` for the SDK model, and any other encoder can be plugged in the
+  same way.
+* **Real gradients.** Unlike the gradient-free probes elsewhere in
+  this package, this uses autograd: interpolation points are pushed through the
+  encoder in one or more batches and ``torch.autograd.grad`` yields the
+  gradients with respect to the input path only (each step's embedding depends
+  only on its own row).
+* **Global, not per-axis.** The headline output is a single scalar effect over
+  the whole embedding layer plus a saliency map in the input's own shape. No
+  channel/feature-axis decomposition (that is a MOMENT-specific notion).
+
+Cost: one forward/gradient pass per interpolation chunk.
+"""
+
+import sys
+import types
+import warnings
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+import torch
+
+Array = np.ndarray
+EmbedFn = Callable[[torch.Tensor], torch.Tensor]
+Reduce = Literal["l2", "sum", "mean"]
+BaselineMode = Literal["noise", "zero", "mean"]
+NormalizationGradientMode = Literal["native", "full", "frozen"]
+
+
+@dataclass(frozen=True)
+class EmbeddingAttribution:
+    """Result of Integrated Gradients over the embedding layer.
+
+    * ``attribution``: per-input-element Integrated Gradients, in the input's
+      own shape (a model-agnostic saliency map over the context window).
+    * ``overall_effect``: ``sum_i attribution_i`` -- the net signed effect of
+      the input on the (reduced) embedding. Equal to ``embedding_delta`` up to
+      the Riemann approximation error.
+    * ``abs_effect``: ``sum_i |attribution_i|`` -- total saliency mass, a
+      magnitude summary that does not cancel across positions.
+    * ``embedding_delta``: ``g(Enc(x)) - g(Enc(x0))`` measured directly.
+    * ``embedding_delta_abs_mean``: mean absolute endpoint change across
+      Expected-Gradients baselines. This is the stable scale used below.
+    * ``convergence_delta``: ``|overall_effect - embedding_delta| /
+      (embedding_delta_abs_mean + eps)``; the Integrated-Gradients completeness
+      residual (-> 0 as ``n_steps`` grows). Using ``|mean(delta)|`` in the
+      denominator, as the old implementation did, explodes whenever endpoint
+      changes from different noise baselines cancel.
+    """
+
+    attribution: Array
+    overall_effect: float
+    abs_effect: float
+    embedding_delta: float
+    embedding_delta_abs_mean: float
+    convergence_delta: float
+    n_steps: int
+    n_baselines: int
+    baseline: str
+    reduce: str
+    embedding_dim: int
+
+
+def _reduce_embedding(emb: torch.Tensor, reduce: Reduce) -> torch.Tensor:
+    """Reduce an ``[n, D]`` (or ``[n, ...]``) embedding batch to a scalar per row."""
+    flat = emb.reshape(emb.shape[0], -1)
+    if reduce == "l2":
+        return torch.linalg.vector_norm(flat, dim=1)
+    if reduce == "sum":
+        return flat.sum(dim=1)
+    if reduce == "mean":
+        return flat.mean(dim=1)
+    raise ValueError(f"Unknown reduce {reduce!r}; expected 'l2' | 'sum' | 'mean'.")
+
+
+def _ig_single(
+    embed_fn: EmbedFn,
+    x_t: torch.Tensor,
+    x0: torch.Tensor,
+    *,
+    n_steps: int,
+    reduce: Reduce,
+    internal_batch_size: int | None = None,
+) -> tuple[Array, float, int]:
+    """One Integrated-Gradients pass for a fixed baseline ``x0``.
+
+    Returns ``(attribution, embedding_delta, embedding_dim)``.
+    """
+    delta = x_t - x0  # [*feat]
+    dev = x_t.device
+
+    chunk = int(internal_batch_size or n_steps)
+    if chunk < 1:
+        raise ValueError(f"internal_batch_size must be >= 1 when provided, got {internal_batch_size}")
+    chunk = min(chunk, int(n_steps))
+
+    grad_sum = torch.zeros_like(x_t)
+    expand_prefix = (1,) * x_t.ndim
+    for start in range(0, int(n_steps), chunk):
+        stop = min(int(n_steps), start + chunk)
+        count = stop - start
+
+        # Midpoint Riemann nodes for this chunk.
+        alphas = (torch.arange(start, stop, device=dev, dtype=torch.float32) + 0.5) / int(n_steps)
+        x_interp = x0.unsqueeze(0) + alphas.reshape((count,) + expand_prefix) * delta.unsqueeze(0)
+        x_interp = x_interp.clone().requires_grad_(True)
+
+        with torch.enable_grad():
+            emb = embed_fn(x_interp)  # [count, D]
+            if emb.shape[0] != count:
+                raise RuntimeError(
+                    f"embed_fn must preserve the leading batch dim: got {emb.shape[0]} rows for {count} inputs."
+                )
+            g = _reduce_embedding(emb, reduce)  # [count]
+            # Request only input-path gradients. Using .backward() here would
+            # also materialize parameter gradients for large encoders and keep
+            # them resident across benchmark windows.
+            grad = torch.autograd.grad(g.sum(), x_interp, retain_graph=False, create_graph=False)[0]
+
+        grad_sum += grad.detach().sum(dim=0)
+        del emb, g, grad, x_interp
+
+    avg_grad = grad_sum / float(n_steps)  # [*feat]
+    attribution = (delta * avg_grad).detach().cpu().numpy().astype(np.float32)
+
+    with torch.no_grad():
+        ends = torch.stack([x0, x_t], dim=0)
+        emb_ends = embed_fn(ends)
+        g_ends = _reduce_embedding(emb_ends, reduce)
+        emb_dim = int(emb_ends.reshape(emb_ends.shape[0], -1).shape[1])
+    embedding_delta = float((g_ends[1] - g_ends[0]).item())
+    return attribution, embedding_delta, emb_dim
+
+
+def integrated_gradients_embedding(
+    embed_fn: EmbedFn,
+    x: Array | torch.Tensor,
+    *,
+    baseline: BaselineMode | Array | torch.Tensor | float = "noise",
+    n_steps: int = 64,
+    n_baselines: int = 1,
+    internal_batch_size: int | None = None,
+    reduce: Reduce = "l2",
+    seed: int = 0,
+    device: torch.device | str | None = None,
+) -> EmbeddingAttribution:
+    """Accumulate embedding-layer gradients along the baseline->input path.
+
+    Args:
+        embed_fn: differentiable map from a *batch* of inputs ``[n, *feat]`` to a
+            batch of embeddings ``[n, D]`` (or any ``[n, ...]`` reduced to a
+            scalar per row). This is the only model-specific piece; build it with
+            :func:`moment_embed_fn` or your own.
+        x: a single input window, shape ``[*feat]`` (no batch dim).
+        baseline: path start. Either a mode string or an explicit reference:
+
+            * ``"noise"`` (default) -- white noise matched to ``x``'s global
+              mean/std. Recommended for instance-normalized models; with
+              ``n_baselines > 1`` this becomes the Expected-Gradients estimator.
+            * ``"zero"`` / ``"mean"`` / a constant float -- a *constant* baseline.
+              **Degenerate for instance-normalized backbones** (emits a warning).
+            * an array shaped like ``x`` -- an explicit baseline.
+        n_steps: number of Riemann (midpoint) steps for the path integral.
+        n_baselines: number of independent ``"noise"`` baselines to average over
+            (Expected Gradients). Ignored (forced to 1) for explicit/constant
+            baselines.
+        internal_batch_size: maximum number of interpolation points to embed at
+            once. ``None`` keeps the original one-batch behavior; smaller values
+            trade a little runtime for much lower activation memory.
+        reduce: how the embedding vector is reduced to the scalar objective
+            ``g`` -- ``'l2'`` (default), ``'sum'`` or ``'mean'``.
+        seed: RNG seed for the noise baseline(s).
+        device: device for the computation; defaults to ``x``'s device (or CPU).
+
+    Returns:
+        :class:`EmbeddingAttribution`.
+    """
+    if n_steps < 1:
+        raise ValueError(f"n_steps must be >= 1, got {n_steps}")
+    if n_baselines < 1:
+        raise ValueError(f"n_baselines must be >= 1, got {n_baselines}")
+
+    if isinstance(x, torch.Tensor):
+        dev = torch.device(device) if device is not None else x.device
+        x_t = x.detach().to(device=dev, dtype=torch.float32)
+    else:
+        dev = torch.device(device) if device is not None else torch.device("cpu")
+        x_t = torch.as_tensor(np.asarray(x, dtype=np.float32), device=dev)
+
+    # Build the list of baseline tensors.
+    baselines: list[torch.Tensor] = []
+    if isinstance(baseline, str) and baseline == "noise":
+        mu = float(x_t.mean().item())
+        sigma = float(x_t.std().item())
+        sigma = sigma if sigma > 1e-8 else 1.0
+        rng = np.random.default_rng(seed)
+        for _ in range(n_baselines):
+            noise = rng.standard_normal(tuple(x_t.shape)).astype(np.float32)
+            baselines.append(torch.as_tensor(mu + sigma * noise, device=dev))
+        baseline_name = "noise"
+    else:
+        if n_baselines != 1:
+            warnings.warn("n_baselines is ignored for non-'noise' baselines; using 1.", stacklevel=2)
+        if isinstance(baseline, str) and baseline in ("zero", "mean"):
+            const = 0.0 if baseline == "zero" else float(x_t.mean().item())
+            baselines.append(torch.full_like(x_t, const))
+            baseline_name = baseline
+            warnings.warn(
+                f"A constant '{baseline}' baseline is degenerate for instance-normalized models "
+                "(scale/shift invariance) and typically yields ~0 attribution; prefer baseline='noise'.",
+                stacklevel=2,
+            )
+        elif isinstance(baseline, (int, float)):
+            baselines.append(torch.full_like(x_t, float(baseline)))
+            baseline_name = f"const({float(baseline):g})"
+            warnings.warn(
+                "A constant baseline is degenerate for instance-normalized models; prefer baseline='noise'.",
+                stacklevel=2,
+            )
+        else:
+            x0 = (
+                baseline.detach().to(device=dev, dtype=torch.float32)
+                if isinstance(baseline, torch.Tensor)
+                else torch.as_tensor(np.asarray(baseline, dtype=np.float32), device=dev)
+            )
+            if x0.shape != x_t.shape:
+                raise ValueError(f"baseline shape {tuple(x0.shape)} must match x shape {tuple(x_t.shape)}")
+            baselines.append(x0)
+            baseline_name = "array"
+
+    attrs: list[Array] = []
+    deltas: list[float] = []
+    emb_dim = 0
+    for x0 in baselines:
+        attr, edelta, emb_dim = _ig_single(
+            embed_fn,
+            x_t,
+            x0,
+            n_steps=n_steps,
+            reduce=reduce,
+            internal_batch_size=internal_batch_size,
+        )
+        attrs.append(attr)
+        deltas.append(edelta)
+
+    attribution = np.mean(np.stack(attrs, axis=0), axis=0).astype(np.float32)
+    embedding_delta = float(np.mean(deltas))
+    embedding_delta_abs_mean = float(np.mean(np.abs(deltas)))
+    overall = float(attribution.sum())
+    abs_effect = float(np.abs(attribution).sum())
+    eps = 1e-12
+    convergence = float(abs(overall - embedding_delta) / (embedding_delta_abs_mean + eps))
+
+    return EmbeddingAttribution(
+        attribution=attribution,
+        overall_effect=overall,
+        abs_effect=abs_effect,
+        embedding_delta=embedding_delta,
+        embedding_delta_abs_mean=embedding_delta_abs_mean,
+        convergence_delta=convergence,
+        n_steps=int(n_steps),
+        n_baselines=len(baselines),
+        baseline=baseline_name,
+        reduce=str(reduce),
+        embedding_dim=int(emb_dim),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Thin model adapter (build an ``embed_fn`` for the SDK's MOMENT model).
+# ---------------------------------------------------------------------------
+
+
+def enable_grad_through_revin(model) -> int:
+    """Let gradients flow through RevIN normalization statistics (in place).
+
+    MOMENT-style RevIN computes ``(x - mean) / std`` but ``.detach()``-es ``mean``
+    and ``std``, so autograd treats them as constants and Integrated-Gradients
+    *cannot* satisfy completeness (the path integral misses the chain-rule term
+    through the statistics). This rebinds each RevIN module's ``_get_statistics``
+    to a non-detaching version.
+
+    This only changes the **backward** pass -- ``.detach()`` does not affect the
+    forward values -- so all forecasts / eval outputs are bit-for-bit unchanged;
+    it merely makes the embedding differentiable end-to-end for attribution.
+
+    Returns the number of normalizer modules patched. Idempotent.
+    """
+    patched = 0
+    for m in model.modules():
+        if getattr(m, "_grad_through_revin", False):
+            patched += 1
+            continue
+        # RevIN sets ``mean``/``stdev`` only during the forward, so detect by the
+        # always-present method + ``eps`` attribute instead.
+        if not (hasattr(m, "_get_statistics") and hasattr(m, "_normalize") and hasattr(m, "eps")):
+            continue
+        mod = sys.modules.get(type(m).__module__)
+        nanstd = getattr(mod, "nanstd", None)
+        if nanstd is None:
+            continue
+
+        def _make(nanstd_fn):
+            def _get_statistics(self, x, mask=None):
+                if mask is None:
+                    mask = torch.ones((x.shape[0], x.shape[-1]), device=x.device)
+                n_channels = x.shape[1]
+                mask = mask.unsqueeze(1).repeat(1, n_channels, 1).bool()
+                masked_x = torch.where(mask, x, torch.full_like(x, float("nan")))
+                self.mean = torch.nanmean(masked_x, dim=-1, keepdim=True)
+                self.stdev = nanstd_fn(masked_x, dim=-1, keepdim=True) + self.eps
+
+            return _get_statistics
+
+        m._get_statistics = types.MethodType(_make(nanstd), m)
+        m._grad_through_revin = True
+        patched += 1
+    return patched
+
+
+@contextmanager
+def normalization_statistics_gradient(model, mode: NormalizationGradientMode):
+    """Temporarily control gradients through supported input normalizers.
+
+    ``mode="full"`` differentiates through per-window location and scale for
+    Integrated Gradients completeness. ``mode="frozen"`` preserves the exact
+    forward values while treating those statistics as constants in backward,
+    which defines the local directional derivative in normalized coordinates.
+    ``mode="native"`` leaves the model untouched.
+    """
+    if mode not in ("native", "full", "frozen"):
+        raise ValueError(f"Unknown normalization gradient mode: {mode!r}")
+    if mode == "native":
+        yield 0
+        return
+
+    root = model if hasattr(model, "modules") else getattr(model, "model", None)
+    if root is None or not hasattr(root, "modules"):
+        yield 0
+        return
+
+    detach_statistics = mode == "frozen"
+    restores: list[tuple[object, str, object, bool]] = []
+
+    for module in root.modules():
+        if all(hasattr(module, name) for name in ("_get_statistics", "_normalize", "eps")):
+            original = module._get_statistics
+            had_instance_override = "_get_statistics" in vars(module)
+
+            def _make_revin_get_statistics(detach: bool):
+                def _get_statistics(self, x, mask=None):
+                    if mask is None:
+                        mask = torch.ones((x.shape[0], x.shape[-1]), device=x.device)
+                    expanded = mask.to(device=x.device).unsqueeze(1).expand(-1, x.shape[1], -1).bool()
+                    masked_x = torch.where(expanded, x, torch.full_like(x, float("nan")))
+                    mean = torch.nanmean(masked_x, dim=-1, keepdim=True)
+                    stdev = (masked_x - mean).square().nanmean(dim=-1, keepdim=True).sqrt()
+                    if detach:
+                        mean = mean.detach()
+                        stdev = stdev.detach()
+                    self.mean = mean
+                    self.stdev = stdev + self.eps
+
+                return _get_statistics
+
+            module._get_statistics = types.MethodType(_make_revin_get_statistics(detach_statistics), module)
+            restores.append((module, "_get_statistics", original, had_instance_override))
+
+    try:
+        yield len(restores)
+    finally:
+        for module, name, original, had_instance_override in reversed(restores):
+            if had_instance_override:
+                setattr(module, name, original)
+            else:
+                delattr(module, name)
+
+
+def moment_embed_fn(model, *, input_mask: torch.Tensor | None = None, grad_through_norm: bool = False) -> EmbedFn:
+    """``embed_fn`` for a MOMENT-style model exposing ``embed(x_enc=, input_mask=).embeddings``.
+
+    Input batch shape: ``[n, C, L]``. Returns embeddings ``[n, D]``.
+
+    Args:
+        grad_through_norm: if True, gradients flow through RevIN statistics so
+            IG stays faithful. The override is scoped to each embedding call
+            and restored immediately.
+    """
+    def _fn(x: torch.Tensor) -> torch.Tensor:
+        if x.ndim != 3:
+            raise ValueError(f"MOMENT embed_fn expects [n, C, L]; got {tuple(x.shape)}")
+        n, _, L = x.shape
+        mask = input_mask
+        if mask is None:
+            mask = torch.ones((n, L), dtype=torch.long, device=x.device)
+        elif mask.ndim == 1:
+            mask = mask.reshape(1, -1).expand(n, -1).to(device=x.device)
+        with normalization_statistics_gradient(model, "full" if grad_through_norm else "native"):
+            out = model.embed(x_enc=x, input_mask=mask)
+        emb = out.embeddings if hasattr(out, "embeddings") else out
+        return emb.reshape(emb.shape[0], -1)
+
+    return _fn
+
+
+__all__ = [
+    "EmbeddingAttribution",
+    "enable_grad_through_revin",
+    "integrated_gradients_embedding",
+    "moment_embed_fn",
+    "normalization_statistics_gradient",
+]

--- a/forecasting/interpretability.py
+++ b/forecasting/interpretability.py
@@ -39,7 +39,6 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 import numpy as np
 import torch
-
 from integrated_gradients import normalization_statistics_gradient
 
 if TYPE_CHECKING:

--- a/forecasting/interpretability.py
+++ b/forecasting/interpretability.py
@@ -40,6 +40,8 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 import numpy as np
 import torch
 
+from integrated_gradients import normalization_statistics_gradient
+
 if TYPE_CHECKING:
     from channel_flow import ChannelFlowConfig
 
@@ -413,6 +415,113 @@ def _forecast_autoregressive(
         cur_mask = torch.ones(B, seq_len, dtype=cur_mask.dtype, device=device)
 
     return np.concatenate(preds_chunks, axis=2).astype(np.float32, copy=False)
+
+
+def _channel_replacement_rows(arr_cl: Array, *, replacement: str) -> Array:
+    arr = np.asarray(arr_cl, dtype=np.float32)
+    C, L = arr.shape
+    if replacement == "zero":
+        return np.zeros((C, L), dtype=np.float32)
+    if replacement == "local_mean":
+        return np.repeat(arr.mean(axis=1, keepdims=True).astype(np.float32), L, axis=1)
+    raise ValueError(f"Unsupported replacement={replacement!r}")
+
+
+def compute_target_channel_input_jacobian_importance(
+    model: ForecastModel,
+    *,
+    x_context_ct: Array,
+    input_mask_l: Array,
+    device: torch.device,
+    target_channel: int,
+    model_horizon: int,
+    forecast_horizon: int,
+    replacement: Literal["local_mean", "zero"] = "local_mean",
+    forecast_batch_size: int = 8,
+    finite_difference_scale: float = 0.1,
+    prefer_autograd: bool = True,
+) -> Array:
+    """Target-specific directional replacement effect by channel and horizon."""
+    arr = np.asarray(x_context_ct, dtype=np.float32)
+    if arr.ndim != 2:
+        raise ValueError(f"Expected x_context_ct [C,L], got {arr.shape}")
+    C, L = arr.shape
+    H = int(forecast_horizon)
+    target = int(target_channel)
+    if not (0 <= target < C):
+        raise ValueError(f"target_channel out of range for C={C}: {target}")
+    mask = np.asarray(input_mask_l, dtype=np.int64)
+    if mask.shape != (L,):
+        raise ValueError(f"Expected input_mask_l shape {(L,)}, got {mask.shape}")
+
+    baseline = _channel_replacement_rows(arr, replacement=str(replacement))
+    delta = arr - baseline
+    active_direction = np.any(np.abs(delta) > 1e-12, axis=1)
+
+    if prefer_autograd:
+        delta_t = torch.from_numpy(delta[None]).to(device=device, dtype=torch.float32)
+        x_t = torch.from_numpy(arr[None]).to(device=device, dtype=torch.float32).requires_grad_(True)
+        m_t = torch.from_numpy(mask[None]).to(device=device, dtype=torch.long)
+        with normalization_statistics_gradient(model, "frozen"):
+            with torch.enable_grad():
+                out = model(x_enc=x_t, input_mask=m_t)
+                forecast = out.forecast[:, target, :H]
+                if forecast.shape[-1] < H:
+                    raise ValueError(f"Model returned horizon={forecast.shape[-1]}, expected at least {H}")
+                if forecast.requires_grad:
+                    importance = np.zeros((C, H), dtype=np.float32)
+                    input_is_connected = True
+                    for h in range(H):
+                        grad = torch.autograd.grad(
+                            forecast[:, h].sum(),
+                            x_t,
+                            retain_graph=h < H - 1,
+                            create_graph=False,
+                            allow_unused=True,
+                        )[0]
+                        if grad is None:
+                            input_is_connected = False
+                            break
+                        score_c = (grad * delta_t).sum(dim=-1).abs()[0]
+                        active_t = torch.as_tensor(active_direction, dtype=torch.bool, device=score_c.device)
+                        score_c = torch.where(active_t, score_c, torch.zeros_like(score_c))
+                        importance[:, h] = score_c.detach().cpu().numpy().astype(np.float32)
+                    if input_is_connected:
+                        importance[target, :] = 0.0
+                        if not np.isfinite(importance).all():
+                            n_bad = int((~np.isfinite(importance)).sum())
+                            raise FloatingPointError(f"Jacobian attribution produced {n_bad} non-finite value(s)")
+                        return importance.astype(np.float32, copy=False)
+
+    eps = float(finite_difference_scale)
+    if not (0.0 < eps <= 1.0):
+        raise ValueError(f"finite_difference_scale must be in (0, 1], got {finite_difference_scale}")
+    importance = np.zeros((C, H), dtype=np.float32)
+    chans = [c for c in range(C) if c != target]
+    channel_batch = max(1, int(forecast_batch_size) // 2)
+    for start in range(0, len(chans), channel_batch):
+        chunk = chans[start : start + channel_batch]
+        stack = np.broadcast_to(arr[None], (2 * len(chunk), C, L)).copy()
+        for i, c in enumerate(chunk):
+            stack[i, c, :] = arr[c, :] - eps * delta[c, :]
+            stack[len(chunk) + i, c, :] = arr[c, :] + eps * delta[c, :]
+        masks = np.broadcast_to(mask[None], (2 * len(chunk), L)).copy()
+        xb = torch.from_numpy(stack).to(device=device, dtype=torch.float32)
+        mb = torch.from_numpy(masks).to(device=device, dtype=torch.long)
+        yb = _forecast_autoregressive(
+            model,
+            xb,
+            mb,
+            model_horizon=int(model_horizon),
+            target_horizon=H,
+        )[:, target, :]
+        effects = np.abs(yb[len(chunk) :] - yb[: len(chunk)]) / (2.0 * eps)
+        for i, c in enumerate(chunk):
+            importance[c, :] = effects[i]
+    if not np.isfinite(importance).all():
+        n_bad = int((~np.isfinite(importance)).sum())
+        raise FloatingPointError(f"Finite-difference attribution produced {n_bad} non-finite value(s)")
+    return importance.astype(np.float32, copy=False)
 
 
 @torch.no_grad()
@@ -1531,56 +1640,63 @@ def explain_forecast(
         )
 
         chan_cfg_eff = chan_cfg if chan_cfg is not None else ChannelFlowConfig()
-        # ``channel_output_aware`` selects the flow's value function: the default
-        # latent embedding (output-agnostic "semantic flow"; feeds the coupling
-        # matrix and the Prop-1/Prop-2 reductions) or the target channel's
-        # forecast (output-aware; the target-specific attribution that the
-        # channel-faithfulness metric scores). The latent default is preserved
-        # so existing coupling / Prop experiments are unchanged.
-        chan_value_fn = None
-        if channel_output_aware:
+        if channel_output_aware and chan_cfg_eff.method == "jacobian":
             if channel_target is None:
                 raise ValueError(
                     "channel_output_aware=True requires channel_target (the forecast "
                     "channel whose prediction the attribution should explain)."
                 )
-            chan_value_fn = make_target_forecast_value_fn(
+            chan_horizon_attrib = compute_target_channel_input_jacobian_importance(
+                model,
+                x_context_ct=x0,
+                input_mask_l=mask,
+                device=device,
                 target_channel=int(channel_target),
                 model_horizon=int(model_horizon),
                 forecast_horizon=int(forecast_horizon),
             )
-        # Channel-flow operates on the same extended series so lag indices match v1.
-        # In output-aware mode we protect the target channel from ablation in the
-        # Shapley game (ablating it destroys the target signal and biases the
-        # non-target attributions); ignored by the Jacobian estimator.
-        chan_protect = (int(channel_target),) if channel_output_aware and channel_target is not None else None
-        report = compute_per_channel_flow(
-            model,
-            series_ext,
-            seq_len=L,
-            input_mask_t=mask_ext,
-            device=device,
-            cfg=chan_cfg_eff,
-            value_fn=chan_value_fn,
-            protect_channels=chan_protect,
-        )
-        per_chan_flow = report.per_channel_flow
-        chan_method = report.method
-        chan_resid_mean = report.residual_ratio_mean
-        chan_resid_p95 = report.residual_ratio_p95
-        coupling_mat = report.coupling_matrix
-        coupling_norm = report.coupling_off_diag_norm
+            chan_method = "target_input_jacobian"
+        else:
+            chan_value_fn = None
+            if channel_output_aware:
+                if channel_target is None:
+                    raise ValueError(
+                        "channel_output_aware=True requires channel_target (the forecast "
+                        "channel whose prediction the attribution should explain)."
+                    )
+                chan_value_fn = make_target_forecast_value_fn(
+                    target_channel=int(channel_target),
+                    model_horizon=int(model_horizon),
+                    forecast_horizon=int(forecast_horizon),
+                )
+            chan_protect = (int(channel_target),) if channel_output_aware and channel_target is not None else None
+            report = compute_per_channel_flow(
+                model,
+                series_ext,
+                seq_len=L,
+                input_mask_t=mask_ext,
+                device=device,
+                cfg=chan_cfg_eff,
+                value_fn=chan_value_fn,
+                protect_channels=chan_protect,
+            )
+            per_chan_flow = report.per_channel_flow
+            chan_method = report.method
+            chan_resid_mean = report.residual_ratio_mean
+            chan_resid_p95 = report.residual_ratio_p95
+            coupling_mat = report.coupling_matrix
+            coupling_norm = report.coupling_off_diag_norm
 
-        chan_tau = float(channel_softmax_tau) if channel_softmax_tau is not None else float(softmax_tau)
-        lag_chan_scores, lag_chan_attrib = lag_channel_horizon_attribution(
-            per_chan_flow,
-            t_index=t_index,
-            n_lags=K,
-            horizon=int(forecast_horizon),
-            softmax_tau=chan_tau,
-            normalize="joint",
-        )
-        chan_horizon_attrib = channel_horizon_marginal(lag_chan_attrib)
+            chan_tau = float(channel_softmax_tau) if channel_softmax_tau is not None else float(softmax_tau)
+            lag_chan_scores, lag_chan_attrib = lag_channel_horizon_attribution(
+                per_chan_flow,
+                t_index=t_index,
+                n_lags=K,
+                horizon=int(forecast_horizon),
+                softmax_tau=chan_tau,
+                normalize="joint",
+            )
+            chan_horizon_attrib = channel_horizon_marginal(lag_chan_attrib)
 
     return ForecastExplanation(
         baseline_forecast=base,

--- a/forecasting/interpretability_parallel.py
+++ b/forecasting/interpretability_parallel.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-
 from channel_flow import (
     ChannelFlowConfig,
     ChannelFlowReport,

--- a/forecasting/interpretability_parallel.py
+++ b/forecasting/interpretability_parallel.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
+
 from channel_flow import (
     ChannelFlowConfig,
     ChannelFlowReport,
@@ -57,6 +58,8 @@ class InterpretabilityPassConfig:
     parallel_passes: bool = False
     shapley_workers: int = 0
     run_coupling: bool = True
+    channel_output_aware: bool = False
+    channel_target: int | None = None
 
 
 @dataclass(frozen=True)
@@ -117,6 +120,8 @@ class _PassAJob:
     latent_batch_size: int
     surrogate_n_jobs: int | None
     chan_cfg: ChannelFlowConfig
+    channel_output_aware: bool
+    channel_target: int | None
 
 
 @dataclass(frozen=True)
@@ -155,6 +160,8 @@ def _run_pass_worker(ctx: dict, device: torch.device, job) -> dict:
             surrogate_n_jobs=job.surrogate_n_jobs,
             channel_axis=True,
             chan_cfg=job.chan_cfg,
+            channel_output_aware=job.channel_output_aware,
+            channel_target=job.channel_target,
         )
         return {"expl": expl, "elapsed": time.time() - t0}
     if isinstance(job, _PassBJob):
@@ -331,6 +338,8 @@ def _run_parallel_passes(
                 latent_batch_size=int(cfg.latent_batch_size),
                 surrogate_n_jobs=cfg.surrogate_n_jobs,
                 chan_cfg=chan_cfg_jac,
+                channel_output_aware=bool(cfg.channel_output_aware),
+                channel_target=cfg.channel_target,
             ),
         ]
         for shard_idx, sl in enumerate(shard_slices):
@@ -377,6 +386,8 @@ def _run_parallel_passes(
                 latent_batch_size=int(cfg.latent_batch_size),
                 surrogate_n_jobs=cfg.surrogate_n_jobs,
                 chan_cfg=chan_cfg_jac,
+                channel_output_aware=bool(cfg.channel_output_aware),
+                channel_target=cfg.channel_target,
             ),
             _PassBJob(
                 series_ext=series_ext,
@@ -528,6 +539,8 @@ def run_interpretability_passes(
         surrogate_n_jobs=cfg.surrogate_n_jobs,
         channel_axis=use_channel_axis,
         chan_cfg=chan_cfg_jac if use_channel_axis else None,
+        channel_output_aware=bool(cfg.channel_output_aware),
+        channel_target=cfg.channel_target,
     )
     t_jac = time.time() - t0
 

--- a/forecasting/sdk/README.md
+++ b/forecasting/sdk/README.md
@@ -122,6 +122,7 @@ interp_result = perform_forecasting(
     interpretability_dataset_name="my_dataset.csv",
     n_lags=128,
     softmax_tau=1.0,
+    integrated_gradients=True,
 )
 ```
 
@@ -130,7 +131,7 @@ interp_result = perform_forecasting(
 | Value | Files written under `<interpretability_out_dir>/run_<UTC>/` |
 |-------|-------------------------------------------------------------|
 | `"json"` | `forecast.csv`, `explanation.json` |
-| `"pdf"` | `forecast.csv`, `lag_horizon_attributions.csv`, `lag_horizon_long.csv`, `lag_horizon_heatmap.png`, `semantic_flow.csv`, `explanation_report.pdf` |
+| `"pdf"` | `forecast.csv`, lag/semantic-flow artifacts, feature-axis artifacts for multivariate input, optional integrated-gradients artifacts, `explanation_report.pdf` |
 | `None`  | All of the above |
 
 The returned DataFrame is the explanation-aligned forecast (single forward pass, so it lines up 1:1 with the attribution matrix). PDF / heatmap require `matplotlib`; if it's missing, those steps are skipped with a warning while JSON output continues to work.
@@ -179,6 +180,14 @@ perform_forecasting(
     interpretability_dataset_name: Optional[str] = None,
     n_lags: int = 128,
     softmax_tau: float = 1.0,
+    channel_output_aware: bool = False,
+    integrated_gradients: bool = False,
+    integrated_gradients_baseline: Any = "noise",
+    integrated_gradients_steps: int = 64,
+    integrated_gradients_n_baselines: int = 1,
+    integrated_gradients_internal_batch_size: Optional[int] = None,
+    integrated_gradients_reduce: str = "l2",
+    integrated_gradients_grad_through_norm: bool = True,
 
     # v2 channel-axis interpretability
     interpretability_channel_axis: Optional[bool] = None,
@@ -222,6 +231,14 @@ perform_forecasting(
 | `interpretability_dataset_name` | Free-form label embedded in the JSON metadata and the PDF cover page |
 | `n_lags` | Number of past steps the lag-attribution matrix resolves (default `128`) |
 | `softmax_tau` | Temperature applied when softmaxing scores into per-horizon attribution |
+| `channel_output_aware` | Use target-specific directional input-Jacobian effects for feature-axis attribution (default `False`) |
+| `integrated_gradients` | Add embedding integrated-gradients attribution to the JSON/PDF report and export its CSV/PNG artifacts |
+| `integrated_gradients_baseline` | IG reference input; `"noise"` is the default and avoids the constant-baseline degeneracy of instance normalization |
+| `integrated_gradients_steps` | Number of midpoint integration steps (default `64`) |
+| `integrated_gradients_n_baselines` | Number of noise baselines averaged as Expected Gradients (default `1`) |
+| `integrated_gradients_internal_batch_size` | Maximum interpolation points embedded per batch; `None` processes all steps together |
+| `integrated_gradients_reduce` | Embedding scalar objective: `"l2"`, `"sum"`, or `"mean"` |
+| `integrated_gradients_grad_through_norm` | Include RevIN statistics in the attribution gradient while leaving forward outputs unchanged |
 | `return_all_channels` | When `True`, the result contains one `{column}_forecast` column per processed channel (target column first, then the remaining numeric features) instead of only `{target_column}_forecast`. Not supported with `interpretability=True` (raises `ValueError`) |
 | `interpretability_channel_axis` | Enable v2 per-channel Jacobian flow (auto-enabled for `C > 1`) |
 | `interpretability_coupling` | Enable Shapley channel coupling matrix (auto-enabled for `C > 1`) |
@@ -272,7 +289,12 @@ When `interpretability=True`, the run directory contains the following files (se
 | `lag_horizon_long.csv` | pdf, both | Tidy `(lag, horizon, attribution[, score])` table |
 | `lag_horizon_heatmap.png` | pdf, both *(needs matplotlib)* | Visual heatmap, viridis cmap |
 | `semantic_flow.csv` | pdf, both | Tidy `(transition_index, segment, flow_magnitude)` table, where `segment` is `history` for transitions fully inside the input window, `forecast` for transitions whose window extends into the model-generated future, and `tail` for any trailing transitions outside both segments |
-| `explanation_report.pdf` | pdf, both *(needs matplotlib)* | Multi-page report: (1) cover with metadata, (2) forecast preview, (3) lag×horizon heatmap, (4) top-`interpretability_top_k` lag-step tables, (5) semantic-flow magnitudes page with the per-transition flow time series (history/forecast split annotated), a per-segment summary (mean / median / p95 / max / variance / transition count) and the four forecast-vs-history diagnostic ratios (`flow_ratio`, `flow_variance_ratio`, `curvature_ratio`, `latent_diag_mahalanobis_ratio`), (6) latent-trajectory stability table with per-dimension zero-crossing / direction-flip / relative-jitter (mean & p95) and occupancy metrics |
+| `channel_horizon_attributions.csv` | multivariate pdf, both | Feature-axis `C×H` attribution matrix |
+| `channel_horizon_heatmap.png` | multivariate pdf, both *(needs matplotlib)* | Feature-axis channel-by-horizon heatmap |
+| `integrated_gradients_attributions.csv` | `integrated_gradients=True` with pdf or both | Signed embedding IG value for every channel and context position |
+| `integrated_gradients_channel_summary.csv` | `integrated_gradients=True` with pdf or both | Signed effect, absolute effect, and absolute share by channel |
+| `integrated_gradients_heatmap.png` | `integrated_gradients=True` with pdf or both *(needs matplotlib)* | Signed channel-by-context IG heatmap |
+| `explanation_report.pdf` | pdf, both *(needs matplotlib)* | Multi-page report covering forecast, lag×horizon attribution, feature-axis attribution for multivariate input, semantic flow, latent stability, and optional embedding integrated gradients |
 | `channel_coupling_matrix.csv` | multivariate inputs | `C×C` coupling matrix `Γ[i,j]` — how much channel `j` influences the forecast via channel `i` |
 | `channel_coupling_heatmap.png` | multivariate inputs *(needs matplotlib)* | Heatmap of the channel coupling matrix |
 
@@ -280,7 +302,7 @@ The run directory path is printed on stdout when the call completes.
 
 ## Multi-GPU channel-axis interpretability
 
-On hosts with 2+ CUDA devices, Pass A (Jacobian) and Pass B (Shapley coupling) can run concurrently, and Pass B can be sharded across N GPUs:
+On hosts with 2+ CUDA devices, feature-axis Pass A (Jacobian) and Pass B (Shapley coupling) run concurrently automatically when coupling is enabled. Pass B can also be sharded across N GPUs. Integrated gradients is a separate optional attribution pass and is not part of this Pass A / Pass B dispatch.
 
 ```python
 perform_forecasting(

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -26,6 +26,7 @@ except ImportError:
 
 # Clean absolute imports - package is installed in editable mode
 from backbone.utils.utils import control_randomness
+
 from dataset_longhorizon import (
     CSVLongHorizonSimpleDataset,
     Standardizer,
@@ -769,7 +770,7 @@ def _semantic_flow_page(
         color="gray",
     )
 
-    ax = fig.add_axes((0.08, 0.52, 0.84, 0.26))
+    ax = fig.add_axes((0.08, 0.57, 0.84, 0.23))
     x_axis = np.arange(T_trans)
     ax.plot(x_axis, flow, linewidth=1.0, color="#1f77b4", label="flow magnitude")
     if 0 < boundary < T_trans:
@@ -810,7 +811,7 @@ def _semantic_flow_page(
         ["Variance", hist_s[4], fcst_s[4]],
         ["Transitions", hist_s[5], fcst_s[5]],
     ]
-    ax_t1 = fig.add_axes((0.06, 0.32, 0.42, 0.18))
+    ax_t1 = fig.add_axes((0.06, 0.34, 0.42, 0.15))
     ax_t1.axis("off")
     table_seg = ax_t1.table(
         cellText=seg_rows,
@@ -821,7 +822,7 @@ def _semantic_flow_page(
     )
     table_seg.auto_set_font_size(False)
     table_seg.set_fontsize(8)
-    table_seg.scale(1.0, 1.3)
+    table_seg.scale(1.0, 1.2)
     for c in range(3):
         cell = table_seg[(0, c)]
         cell.set_facecolor("#dddddd")
@@ -849,7 +850,7 @@ def _semantic_flow_page(
             "~1 healthy, >>1 OOD shift",
         ],
     ]
-    ax_t2 = fig.add_axes((0.52, 0.32, 0.42, 0.18))
+    ax_t2 = fig.add_axes((0.52, 0.34, 0.42, 0.15))
     ax_t2.axis("off")
     table_diag = ax_t2.table(
         cellText=diag_rows,
@@ -860,7 +861,7 @@ def _semantic_flow_page(
     )
     table_diag.auto_set_font_size(False)
     table_diag.set_fontsize(8)
-    table_diag.scale(1.0, 1.3)
+    table_diag.scale(1.0, 1.2)
     for c in range(3):
         cell = table_diag[(0, c)]
         cell.set_facecolor("#dddddd")
@@ -902,6 +903,416 @@ def _semantic_flow_page(
     plt.close(fig)
 
 
+def _save_channel_axis_artifacts(
+    out_dir: Path,
+    channel_horizon_attributions: np.ndarray,
+    channel_labels: list[str] | None = None,
+    *,
+    na_rep: str = "nan",
+) -> Path | None:
+    """Write the [C, H] channel x horizon attribution CSV and a heatmap PNG.
+
+    Returns the path to the heatmap PNG if matplotlib is available, else None.
+    """
+    A = np.asarray(channel_horizon_attributions, dtype=np.float32)
+    if A.ndim != 2:
+        return None
+    C, H = A.shape
+    labels = channel_labels if (channel_labels and len(channel_labels) == C) else [f"channel_{c}" for c in range(C)]
+
+    df = pd.DataFrame(A, columns=[f"horizon_{h}" for h in range(H)])
+    df.insert(0, "channel", labels)
+    df.to_csv(out_dir / "channel_horizon_attributions.csv", index=False, na_rep=na_rep)
+
+    try:
+        import matplotlib as mpl
+
+        mpl.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return None
+
+    fig, ax = plt.subplots(figsize=(max(8, H * 0.15), max(4, C * 0.4)))
+    im = ax.imshow(A, aspect="auto", cmap="viridis", interpolation="nearest")
+    ax.set_xlabel("Forecast horizon")
+    ax.set_ylabel("Input channel")
+    ax.set_yticks(range(C))
+    ax.set_yticklabels(labels, fontsize=8)
+    xt = np.linspace(0, H - 1, min(12, H), dtype=int)
+    ax.set_xticks(xt)
+    ax.set_xticklabels(xt)
+    plt.colorbar(im, ax=ax, label="Attribution")
+    plt.tight_layout()
+    heatmap_path = out_dir / "channel_horizon_heatmap.png"
+    plt.savefig(heatmap_path, dpi=120)
+    plt.close(fig)
+    return heatmap_path
+
+
+def _channel_axis_page(
+    pdf: Any,
+    plt: Any,
+    *,
+    explanation: ForecastExplanation,
+    channel_labels: list[str] | None = None,
+) -> None:
+    """Append one PDF page for the feature-axis (channel x horizon) attribution.
+
+    Primary visual: a [C, H] heatmap of how much each input channel contributes to
+    each forecast step. A side bar summarizes each channel's total attribution
+    (summed over horizons) as a single feature-importance score.
+    """
+    A = getattr(explanation, "channel_horizon_attributions", None)
+    if A is None:
+        return
+    A = np.asarray(A, dtype=np.float32)
+    if A.ndim != 2 or A.shape[0] < 1 or A.shape[1] < 1:
+        return
+    C, H = A.shape
+    labels = channel_labels if (channel_labels and len(channel_labels) == C) else [f"channel_{c}" for c in range(C)]
+    importance = A.sum(axis=1)
+    method = getattr(explanation, "channel_flow_method", None) or "jacobian"
+    resid = getattr(explanation, "channel_flow_residual_ratio_mean", None)
+    target_jacobian = method == "target_input_jacobian"
+    intro = (
+        "Which input channel drives each target forecast step. Each cell is the magnitude of\n"
+        "the target forecast's local directional response when that channel moves from its\n"
+        "local-mean replacement to the observed input. Rows are channels and columns are\n"
+        "forecast steps; brighter = a stronger target-specific effect."
+        if target_jacobian
+        else "Which input channel (feature) drives each forecast step. The model's response is\n"
+        "decomposed along the feature axis into per-channel contributions, then aggregated\n"
+        "per horizon. Rows are input channels, columns are forecast steps; brighter = that\n"
+        "channel matters more there."
+    )
+
+    fig = plt.figure(figsize=(11, 8.5))
+    fig.text(
+        0.5,
+        0.95,
+        "Feature-axis attribution (channel x horizon)",
+        ha="center",
+        fontsize=14,
+        fontweight="bold",
+    )
+    fig.text(
+        0.06,
+        0.90,
+        intro,
+        ha="left",
+        va="top",
+        fontsize=9,
+        color="gray",
+    )
+
+    ax = fig.add_axes((0.08, 0.40, 0.56, 0.42))
+    im = ax.imshow(A, aspect="auto", cmap="viridis", interpolation="nearest")
+    ax.set_xlabel("Forecast horizon (0 = first predicted step)")
+    ax.set_ylabel("Input channel")
+    ax.set_yticks(range(C))
+    ax.set_yticklabels(labels, fontsize=8)
+    xt = np.linspace(0, H - 1, min(12, H), dtype=int)
+    ax.set_xticks(xt)
+    ax.set_xticklabels(xt)
+    fig.colorbar(
+        im,
+        ax=ax,
+        fraction=0.046,
+        pad=0.04,
+        label="Directional effect" if target_jacobian else "Attribution",
+    )
+
+    axb = fig.add_axes((0.72, 0.40, 0.22, 0.42))
+    y = np.arange(C)
+    axb.barh(y, importance, color="#1f77b4")
+    axb.set_yticks(y)
+    axb.set_yticklabels([])
+    axb.invert_yaxis()  # channel 0 at top, aligned with the heatmap rows
+    axb.set_title("Channel importance\n(sum over horizons)", fontsize=9)
+    axb.set_xlabel("Total effect" if target_jacobian else "Total attribution", fontsize=8)
+    axb.tick_params(axis="both", labelsize=7)
+
+    top_c = int(np.argmax(importance))
+    resid_line = (
+        f"  - Estimator: {method}. Jacobian trust ratio (mean residual): {resid:.3f}\n"
+        "    (lower = more reliable first-order split; high values flag strong\n"
+        "    cross-channel interaction the first-order decomposition cannot capture).\n"
+        if resid is not None
+        else f"  - Estimator: {method}.\n"
+    )
+    heatmap_note = (
+        "  - Heatmap cell (channel c, horizon h): magnitude of the target forecast's\n"
+        "    first-order directional replacement effect; columns are not normalized.\n"
+        if target_jacobian
+        else "  - Heatmap cell (channel c, horizon h): share of the forecast at step h\n"
+        "    attributable to input channel c (each horizon column sums to 1 over channels).\n"
+    )
+    bar_note = "total effect" if target_jacobian else "total attribution"
+    note = (
+        "How to read this page\n"
+        "---------------------\n"
+        + heatmap_note
+        + f"  - Right bar: each channel's {bar_note} summed across horizons -- a single\n"
+        "    feature-importance score per input channel.\n"
+        f"  - Most influential channel overall: {labels[top_c]}.\n" + resid_line + "\n"
+        "Full [C x H] values are exported as channel_horizon_attributions.csv."
+    )
+    fig.text(
+        0.06,
+        0.30,
+        note,
+        ha="left",
+        va="top",
+        fontsize=9,
+        family="monospace",
+        color="#333333",
+        linespacing=1.05,
+    )
+
+    pdf.savefig(fig)
+
+
+def _compute_integrated_gradients_report(
+    *,
+    model: torch.nn.Module,
+    x_context_ct: np.ndarray,
+    input_mask_l: np.ndarray,
+    device: torch.device,
+    channel_labels: list[str],
+    baseline: Any,
+    n_steps: int,
+    n_baselines: int,
+    internal_batch_size: int | None,
+    reduce: str,
+    seed: int,
+    grad_through_norm: bool,
+) -> dict[str, Any]:
+    """Run embedding integrated gradients for the current SDK context window."""
+    from integrated_gradients import (
+        integrated_gradients_embedding,
+        moment_embed_fn,
+    )
+
+    x_tensor = torch.as_tensor(np.asarray(x_context_ct, dtype=np.float32), device=device)
+    input_mask = torch.as_tensor(np.asarray(input_mask_l, dtype=np.int64), device=device)
+    embed_fn = moment_embed_fn(model, input_mask=input_mask, grad_through_norm=grad_through_norm)
+
+    attribution = integrated_gradients_embedding(
+        embed_fn,
+        x_tensor,
+        baseline=baseline,
+        n_steps=n_steps,
+        n_baselines=n_baselines,
+        internal_batch_size=internal_batch_size,
+        reduce=reduce,
+        seed=seed,
+        device=device,
+    )
+
+    A = np.asarray(attribution.attribution, dtype=np.float32)
+    if A.ndim != 2:
+        raise ValueError(f"integrated gradients attribution must be [C, L], got shape {A.shape}")
+
+    C, _ = A.shape
+    labels = channel_labels if len(channel_labels) == C else [f"channel_{c}" for c in range(C)]
+    abs_A = np.abs(A)
+    channel_abs_effect = abs_A.sum(axis=1).astype(np.float32)
+    channel_signed_effect = A.sum(axis=1).astype(np.float32)
+    total_abs = float(channel_abs_effect.sum())
+    channel_abs_share = (
+        (channel_abs_effect / total_abs).astype(np.float32)
+        if total_abs > 1e-12
+        else np.zeros_like(channel_abs_effect, dtype=np.float32)
+    )
+    time_abs_effect = abs_A.sum(axis=0).astype(np.float32)
+    top_order = np.argsort(-channel_abs_effect)[: min(10, C)]
+
+    return {
+        "attribution": A,
+        "channel_labels": labels,
+        "channel_abs_effect": channel_abs_effect,
+        "channel_signed_effect": channel_signed_effect,
+        "channel_abs_share": channel_abs_share,
+        "time_abs_effect": time_abs_effect,
+        "top_channels": [
+            {
+                "channel": labels[int(i)],
+                "abs_effect": float(channel_abs_effect[int(i)]),
+                "signed_effect": float(channel_signed_effect[int(i)]),
+                "abs_share": float(channel_abs_share[int(i)]),
+            }
+            for i in top_order
+        ],
+        "overall_effect": float(attribution.overall_effect),
+        "abs_effect": float(attribution.abs_effect),
+        "embedding_delta": float(attribution.embedding_delta),
+        "embedding_delta_abs_mean": float(attribution.embedding_delta_abs_mean),
+        "convergence_delta": float(attribution.convergence_delta),
+        "n_steps": int(attribution.n_steps),
+        "n_baselines": int(attribution.n_baselines),
+        "baseline": str(attribution.baseline),
+        "reduce": str(attribution.reduce),
+        "embedding_dim": int(attribution.embedding_dim),
+        "grad_through_norm": bool(grad_through_norm),
+    }
+
+
+def _save_integrated_gradients_artifacts(
+    out_dir: Path,
+    integrated_gradients_report: dict[str, Any],
+    *,
+    na_rep: str = "nan",
+) -> Path | None:
+    """Write integrated-gradients CSVs and a signed heatmap PNG."""
+    A = np.asarray(integrated_gradients_report.get("attribution"), dtype=np.float32)
+    if A.ndim != 2:
+        return None
+    C, L = A.shape
+    labels = integrated_gradients_report.get("channel_labels")
+    labels = labels if isinstance(labels, list) and len(labels) == C else [f"channel_{c}" for c in range(C)]
+
+    df_matrix = pd.DataFrame(A.T, columns=labels)
+    df_matrix.insert(0, "lag_from_last", np.arange(L - 1, -1, -1, dtype=int))
+    df_matrix.insert(0, "context_index", np.arange(L, dtype=int))
+    df_matrix.to_csv(out_dir / "integrated_gradients_attributions.csv", index=False, na_rep=na_rep)
+
+    summary = pd.DataFrame(
+        {
+            "channel": labels,
+            "signed_effect": np.asarray(integrated_gradients_report["channel_signed_effect"], dtype=np.float32),
+            "abs_effect": np.asarray(integrated_gradients_report["channel_abs_effect"], dtype=np.float32),
+            "abs_share": np.asarray(integrated_gradients_report["channel_abs_share"], dtype=np.float32),
+        }
+    )
+    summary.to_csv(out_dir / "integrated_gradients_channel_summary.csv", index=False, na_rep=na_rep)
+
+    try:
+        import matplotlib as mpl
+
+        mpl.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return None
+
+    scale = float(np.nanpercentile(np.abs(A), 99)) if np.isfinite(A).any() else 0.0
+    if scale <= 1e-12:
+        scale = float(np.nanmax(np.abs(A))) if np.isfinite(A).any() else 1.0
+    if scale <= 1e-12:
+        scale = 1.0
+
+    fig, ax = plt.subplots(figsize=(max(8, L * 0.02), max(4, C * 0.35)))
+    im = ax.imshow(A, aspect="auto", cmap="coolwarm", interpolation="nearest", vmin=-scale, vmax=scale)
+    ax.set_xlabel("Input context lag (0 = most recent)")
+    ax.set_ylabel("Input channel")
+    ax.set_yticks(range(C))
+    ax.set_yticklabels(labels, fontsize=8)
+    xt = np.linspace(0, L - 1, min(12, L), dtype=int)
+    ax.set_xticks(xt)
+    ax.set_xticklabels((L - 1 - xt).astype(int))
+    plt.colorbar(im, ax=ax, label="Signed IG attribution")
+    plt.tight_layout()
+    heatmap_path = out_dir / "integrated_gradients_heatmap.png"
+    plt.savefig(heatmap_path, dpi=120)
+    plt.close(fig)
+    return heatmap_path
+
+
+def _integrated_gradients_page(
+    pdf: Any,
+    plt: Any,
+    *,
+    integrated_gradients_report: dict[str, Any] | None,
+) -> None:
+    """Append one PDF page for embedding integrated gradients."""
+    if integrated_gradients_report is None:
+        return
+    A = np.asarray(integrated_gradients_report.get("attribution"), dtype=np.float32)
+    if A.ndim != 2 or A.shape[0] < 1 or A.shape[1] < 1:
+        return
+    C, L = A.shape
+    labels = integrated_gradients_report.get("channel_labels")
+    labels = labels if isinstance(labels, list) and len(labels) == C else [f"channel_{c}" for c in range(C)]
+    abs_effect = np.asarray(integrated_gradients_report.get("channel_abs_effect"), dtype=np.float32)
+    if abs_effect.shape != (C,):
+        abs_effect = np.abs(A).sum(axis=1)
+
+    scale = float(np.nanpercentile(np.abs(A), 99)) if np.isfinite(A).any() else 0.0
+    if scale <= 1e-12:
+        scale = float(np.nanmax(np.abs(A))) if np.isfinite(A).any() else 1.0
+    if scale <= 1e-12:
+        scale = 1.0
+
+    fig = plt.figure(figsize=(11, 8.5))
+    fig.text(
+        0.5,
+        0.95,
+        "Integrated gradients (embedding sensitivity)",
+        ha="center",
+        fontsize=14,
+        fontweight="bold",
+    )
+    fig.text(
+        0.06,
+        0.90,
+        "Signed input attributions for the model embedding along the baseline-to-input path.\n"
+        "Rows are input channels and columns are the context timesteps; lag 0 is the most\n"
+        "recent input. Positive and negative colors show direction, while magnitude shows strength.",
+        ha="left",
+        va="top",
+        fontsize=9,
+        color="gray",
+    )
+
+    ax = fig.add_axes((0.08, 0.38, 0.58, 0.43))
+    im = ax.imshow(A, aspect="auto", cmap="coolwarm", interpolation="nearest", vmin=-scale, vmax=scale)
+    ax.set_xlabel("Input context lag (0 = most recent)")
+    ax.set_ylabel("Input channel")
+    ax.set_yticks(range(C))
+    ax.set_yticklabels(labels, fontsize=8)
+    xt = np.linspace(0, L - 1, min(12, L), dtype=int)
+    ax.set_xticks(xt)
+    ax.set_xticklabels((L - 1 - xt).astype(int))
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label="Signed attribution")
+
+    axb = fig.add_axes((0.74, 0.38, 0.22, 0.43))
+    y = np.arange(C)
+    axb.barh(y, abs_effect, color="#2a9d8f")
+    axb.set_yticks(y)
+    axb.set_yticklabels([])
+    axb.invert_yaxis()
+    axb.set_title("Channel effect\n(sum |IG|)", fontsize=9)
+    axb.set_xlabel("Absolute effect", fontsize=8)
+    axb.tick_params(axis="both", labelsize=7)
+
+    top_c = int(np.argmax(abs_effect))
+    baseline = integrated_gradients_report.get("baseline")
+    reduce = integrated_gradients_report.get("reduce")
+    steps = integrated_gradients_report.get("n_steps")
+    n_baselines = integrated_gradients_report.get("n_baselines")
+    convergence = _scalar_to_jsonable(integrated_gradients_report.get("convergence_delta"))
+    emb_delta = _scalar_to_jsonable(integrated_gradients_report.get("embedding_delta"))
+    grad_norm = bool(integrated_gradients_report.get("grad_through_norm"))
+    note = (
+        "How to read this page\n"
+        "---------------------\n"
+        "  - Heatmap cell (channel c, lag l): signed contribution of that input value\n"
+        "    to the scalar embedding objective used by integrated gradients.\n"
+        "  - Right bar: per-channel absolute effect, summed over all context timesteps.\n"
+        f"  - Most influential channel by |IG|: {labels[top_c]}.\n"
+        f"  - Config: baseline={baseline}, steps={steps}, baselines={n_baselines}, reduce={reduce}.\n"
+        f"  - RevIN/statistics gradient path enabled: {grad_norm}.\n"
+        f"  - Embedding delta: {emb_delta}; convergence delta: {convergence}.\n"
+        "\n"
+        "Full values are exported as integrated_gradients_attributions.csv and\n"
+        "integrated_gradients_channel_summary.csv."
+    )
+    fig.text(0.06, 0.30, note, ha="left", va="top", fontsize=9, family="monospace", color="#333333")
+
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+
 def _build_pdf_report(
     pdf_path: Path,
     *,
@@ -916,6 +1327,8 @@ def _build_pdf_report(
     trajectory_report: TrajectoryStabilityReport | None = None,
     context_len: int | None = None,
     forecast_horizon: int | None = None,
+    channel_labels: list[str] | None = None,
+    integrated_gradients_report: dict[str, Any] | None = None,
 ) -> Path | None:
     """Compose a multi-page PDF with the forecast and attribution heatmap."""
     try:
@@ -971,7 +1384,16 @@ def _build_pdf_report(
             "   forecast-vs-history diagnostics.",
             "5. Latent trajectory stability: temporal-smoothness metrics",
             "   over the context window.",
+            "6. Feature-axis attribution: which input channel drives each",
+            "   forecast step (multivariate inputs only).",
         ]
+        if integrated_gradients_report is not None:
+            summary.extend(
+                [
+                    "7. Integrated gradients: signed input-channel/time",
+                    "   sensitivity for the model embedding.",
+                ]
+            )
         fig.text(0.08, 0.85, "\n".join(summary), ha="left", va="top", fontsize=10, family="monospace")
         pdf.savefig(fig)
         plt.close(fig)
@@ -1201,6 +1623,29 @@ def _build_pdf_report(
             pdf.savefig(fig)
             plt.close(fig)
 
+        # Feature-axis page last (and only for multivariate inputs), matching
+        # its position in the cover summary.
+        if getattr(explanation, "channel_horizon_attributions", None) is not None:
+            try:
+                _channel_axis_page(
+                    pdf,
+                    plt,
+                    explanation=explanation,
+                    channel_labels=channel_labels,
+                )
+            except Exception as e:
+                logger.warning("Feature-axis page skipped: %s", e)
+
+        if integrated_gradients_report is not None:
+            try:
+                _integrated_gradients_page(
+                    pdf,
+                    plt,
+                    integrated_gradients_report=integrated_gradients_report,
+                )
+            except Exception as e:
+                logger.warning("Integrated-gradients page skipped: %s", e)
+
     return pdf_path
 
 
@@ -1244,6 +1689,39 @@ def _trajectory_report_to_dict(report: TrajectoryStabilityReport | None) -> dict
     }
 
 
+def _integrated_gradients_to_dict(
+    integrated_gradients_report: dict[str, Any] | None,
+    *,
+    include_full_arrays: bool = True,
+) -> dict[str, Any] | None:
+    """Convert an integrated-gradients report into a JSON-friendly dict."""
+    if integrated_gradients_report is None:
+        return None
+
+    payload: dict[str, Any] = {
+        "baseline": integrated_gradients_report.get("baseline"),
+        "reduce": integrated_gradients_report.get("reduce"),
+        "n_steps": int(integrated_gradients_report.get("n_steps", 0)),
+        "n_baselines": int(integrated_gradients_report.get("n_baselines", 0)),
+        "embedding_dim": int(integrated_gradients_report.get("embedding_dim", 0)),
+        "grad_through_norm": bool(integrated_gradients_report.get("grad_through_norm", False)),
+        "overall_effect": _scalar_to_jsonable(integrated_gradients_report.get("overall_effect")),
+        "abs_effect": _scalar_to_jsonable(integrated_gradients_report.get("abs_effect")),
+        "embedding_delta": _scalar_to_jsonable(integrated_gradients_report.get("embedding_delta")),
+        "embedding_delta_abs_mean": _scalar_to_jsonable(integrated_gradients_report.get("embedding_delta_abs_mean")),
+        "convergence_delta": _scalar_to_jsonable(integrated_gradients_report.get("convergence_delta")),
+        "channel_labels": list(integrated_gradients_report.get("channel_labels", [])),
+        "channel_signed_effect": _array_to_jsonable(integrated_gradients_report.get("channel_signed_effect")),
+        "channel_abs_effect": _array_to_jsonable(integrated_gradients_report.get("channel_abs_effect")),
+        "channel_abs_share": _array_to_jsonable(integrated_gradients_report.get("channel_abs_share")),
+        "top_channels": integrated_gradients_report.get("top_channels", []),
+    }
+    if include_full_arrays:
+        payload["attribution"] = _array_to_jsonable(integrated_gradients_report.get("attribution"))
+        payload["time_abs_effect"] = _array_to_jsonable(integrated_gradients_report.get("time_abs_effect"))
+    return payload
+
+
 def _explanation_to_dict(
     forecast_df: pd.DataFrame,
     explanation: ForecastExplanation,
@@ -1253,6 +1731,7 @@ def _explanation_to_dict(
     dataset_name: str | None = None,
     include_full_arrays: bool = True,
     trajectory_report: TrajectoryStabilityReport | None = None,
+    integrated_gradients_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Render the (forecast, explanation) pair as a JSON-serializable dict."""
     fc = forecast_df.copy()
@@ -1325,6 +1804,13 @@ def _explanation_to_dict(
             explanation.channel_coupling_off_diag_norm
         )
 
+    ig_block = _integrated_gradients_to_dict(
+        integrated_gradients_report,
+        include_full_arrays=include_full_arrays,
+    )
+    if ig_block is not None:
+        explanation_block["integrated_gradients"] = ig_block
+
     return {
         "metadata": {
             "dataset_name": dataset_name,
@@ -1349,6 +1835,7 @@ def _save_explanation_json(
     include_full_arrays: bool = True,
     indent: int | None = 2,
     trajectory_report: TrajectoryStabilityReport | None = None,
+    integrated_gradients_report: dict[str, Any] | None = None,
 ) -> Path:
     """Persist the (forecast, explanation) pair as a JSON file."""
     out_path = Path(path)
@@ -1362,6 +1849,7 @@ def _save_explanation_json(
         dataset_name=dataset_name,
         include_full_arrays=include_full_arrays,
         trajectory_report=trajectory_report,
+        integrated_gradients_report=integrated_gradients_report,
     )
     with out_path.open("w", encoding="utf-8") as fh:
         json.dump(payload, fh, indent=indent, allow_nan=False)
@@ -1416,6 +1904,14 @@ def _run_interpretability(
     dataset_name: str | None,
     channel_output_aware: bool = False,
     return_all_channels: bool = False,
+    integrated_gradients: bool = False,
+    integrated_gradients_baseline: Any = "noise",
+    integrated_gradients_steps: int = 64,
+    integrated_gradients_n_baselines: int = 1,
+    integrated_gradients_internal_batch_size: int | None = None,
+    integrated_gradients_reduce: str = "l2",
+    integrated_gradients_seed: int = 0,
+    integrated_gradients_grad_through_norm: bool = True,
     # v2 channel-axis / coupling params
     interpretability_channel_axis: bool | None = None,
     interpretability_coupling: bool | None = None,
@@ -1492,13 +1988,10 @@ def _run_interpretability(
 
     model.eval()
 
-    # Optionally dispatch to interpretability_parallel for multi-GPU coupling.
-    use_parallel = (
-        channel_axis
-        and bool(interpretability_coupling)
-        and (bool(interpretability_parallel_passes) or int(interpretability_shapley_workers) >= 2)
-    )
-    if use_parallel:
+    # Coupling runs use the Pass A / Pass B orchestrator, which selects serial
+    # or multi-GPU execution from the requested and available devices.
+    use_pass_runner = channel_axis and bool(interpretability_coupling)
+    if use_pass_runner:
         from interpretability_parallel import (
             InterpretabilityPassConfig,
             run_interpretability_passes,
@@ -1519,6 +2012,8 @@ def _run_interpretability(
             parallel_passes=bool(interpretability_parallel_passes),
             shapley_workers=int(interpretability_shapley_workers),
             run_coupling=True,
+            channel_output_aware=output_aware,
+            channel_target=0 if output_aware else None,
         )
         pass_result = run_interpretability_passes(
             x_ct=x_context_ct,
@@ -1628,6 +2123,15 @@ def _run_interpretability(
                 )
             except Exception as e:
                 logger.warning("semantic_flow.csv skipped: %s", e)
+        if getattr(explanation, "channel_horizon_attributions", None) is not None:
+            try:
+                _save_channel_axis_artifacts(
+                    run_dir,
+                    np.asarray(explanation.channel_horizon_attributions, dtype=np.float32),
+                    channel_labels=columns_to_process,
+                )
+            except Exception as e:
+                logger.warning("channel_horizon artifacts skipped: %s", e)
 
     trajectory_report: TrajectoryStabilityReport | None = None
     try:
@@ -1641,6 +2145,29 @@ def _run_interpretability(
     except Exception as e:
         logger.warning("Trajectory stability skipped: %s", e)
 
+    integrated_gradients_report: dict[str, Any] | None = None
+    if integrated_gradients:
+        model.eval()
+        integrated_gradients_report = _compute_integrated_gradients_report(
+            model=model,
+            x_context_ct=x_context_ct,
+            input_mask_l=input_mask_l,
+            device=device,
+            channel_labels=columns_to_process,
+            baseline=integrated_gradients_baseline,
+            n_steps=integrated_gradients_steps,
+            n_baselines=integrated_gradients_n_baselines,
+            internal_batch_size=integrated_gradients_internal_batch_size,
+            reduce=integrated_gradients_reduce,
+            seed=integrated_gradients_seed,
+            grad_through_norm=integrated_gradients_grad_through_norm,
+        )
+        if write_pdf:
+            try:
+                _save_integrated_gradients_artifacts(run_dir, integrated_gradients_report)
+            except Exception as e:
+                logger.warning("integrated_gradients artifacts skipped: %s", e)
+
     if write_json:
         _save_explanation_json(
             forecast_df=forecast_df,
@@ -1650,6 +2177,7 @@ def _run_interpretability(
             timestamp_column=timestamp_column,
             dataset_name=dataset_name,
             trajectory_report=trajectory_report,
+            integrated_gradients_report=integrated_gradients_report,
         )
         logger.info("Interpretability JSON written to: %s", run_dir / "explanation.json")
 
@@ -1668,6 +2196,8 @@ def _run_interpretability(
             trajectory_report=trajectory_report,
             context_len=seq_len,
             forecast_horizon=forecast_horizon,
+            channel_labels=columns_to_process,
+            integrated_gradients_report=integrated_gradients_report,
         )
         if produced is None:
             logger.warning("Interpretability PDF report skipped: matplotlib is not installed.")
@@ -1716,6 +2246,14 @@ def perform_forecasting(
     interpretability_dataset_name: str | None = None,
     n_lags: int = 128,
     softmax_tau: float = 1.0,
+    channel_output_aware: bool = False,
+    integrated_gradients: bool = False,
+    integrated_gradients_baseline: Any = "noise",
+    integrated_gradients_steps: int = 64,
+    integrated_gradients_n_baselines: int = 1,
+    integrated_gradients_internal_batch_size: int | None = None,
+    integrated_gradients_reduce: str = "l2",
+    integrated_gradients_grad_through_norm: bool = True,
     # v2 channel-axis interpretability
     interpretability_channel_axis: bool | None = None,
     interpretability_coupling: bool | None = None,
@@ -2032,6 +2570,15 @@ def perform_forecasting(
                 interpretability_run_name=interpretability_run_name,
                 interpretability_top_k=interpretability_top_k,
                 dataset_name=interpretability_dataset_name,
+                channel_output_aware=channel_output_aware,
+                integrated_gradients=integrated_gradients,
+                integrated_gradients_baseline=integrated_gradients_baseline,
+                integrated_gradients_steps=integrated_gradients_steps,
+                integrated_gradients_n_baselines=integrated_gradients_n_baselines,
+                integrated_gradients_internal_batch_size=integrated_gradients_internal_batch_size,
+                integrated_gradients_reduce=integrated_gradients_reduce,
+                integrated_gradients_seed=seed,
+                integrated_gradients_grad_through_norm=integrated_gradients_grad_through_norm,
                 interpretability_channel_axis=interpretability_channel_axis,
                 interpretability_coupling=interpretability_coupling,
                 interpretability_coupling_transitions=interpretability_coupling_transitions,

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -26,7 +26,6 @@ except ImportError:
 
 # Clean absolute imports - package is installed in editable mode
 from backbone.utils.utils import control_randomness
-
 from dataset_longhorizon import (
     CSVLongHorizonSimpleDataset,
     Standardizer,
@@ -1310,7 +1309,6 @@ def _integrated_gradients_page(
 
     pdf.savefig(fig)
     plt.close(fig)
-
 
 
 def _build_pdf_report(

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
-
 from sdk import forecasting
 
 

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
+import json
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -10,6 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+
 from sdk import forecasting
 
 
@@ -343,6 +346,172 @@ def test_perform_forecasting_return_all_channels_rejects_interpretability():
             return_all_channels=True,
             interpretability=True,
         )
+
+
+def test_interpretability_sdk_defaults_match_algorithms():
+    from integrated_gradients import integrated_gradients_embedding
+
+    sdk_params = inspect.signature(forecasting.perform_forecasting).parameters
+    explain_params = inspect.signature(forecasting.explain_forecast).parameters
+    ig_params = inspect.signature(integrated_gradients_embedding).parameters
+
+    assert sdk_params["n_lags"].default == explain_params["n_lags"].default
+    assert sdk_params["softmax_tau"].default == explain_params["softmax_tau"].default
+    assert sdk_params["channel_output_aware"].default == explain_params["channel_output_aware"].default
+    assert sdk_params["integrated_gradients_baseline"].default == ig_params["baseline"].default
+    assert sdk_params["integrated_gradients_steps"].default == ig_params["n_steps"].default
+    assert sdk_params["integrated_gradients_n_baselines"].default == ig_params["n_baselines"].default
+    assert sdk_params["integrated_gradients_internal_batch_size"].default == ig_params["internal_batch_size"].default
+    assert sdk_params["integrated_gradients_reduce"].default == ig_params["reduce"].default
+
+
+def test_perform_forecasting_forwards_output_aware_mode(monkeypatch, tmp_path):
+    captured = {}
+
+    def run_interpretability(**kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2024-01-02", periods=2, freq="h"),
+                "target_forecast": np.ones(2, dtype=np.float32),
+            }
+        ), tmp_path
+
+    monkeypatch.setattr(forecasting, "_run_interpretability", run_interpretability)
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=10, freq="h"),
+            "target": np.arange(10, dtype=np.float32),
+            "feature": np.linspace(0.0, 1.0, 10, dtype=np.float32),
+        }
+    )
+    forecasting.perform_forecasting(
+        df,
+        seq_len=5,
+        forecast_horizon=2,
+        model_horizon=2,
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        interpretability=True,
+        channel_output_aware=True,
+    )
+
+    assert captured["channel_output_aware"] is True
+
+
+def test_run_interpretability_integrated_gradients_reaches_report(monkeypatch, tmp_path):
+    import integrated_gradients as ig
+
+    explanation = SimpleNamespace(
+        baseline_forecast=np.ones((2, 2), dtype=np.float32),
+        lag_horizon_scores=np.ones((3, 2), dtype=np.float32),
+        lag_horizon_attributions=np.ones((3, 2), dtype=np.float32) / 3.0,
+        flow_magnitudes=None,
+        latent_trajectory=None,
+        surrogate_coef=None,
+        surrogate_intercept=None,
+        surrogate_feature_layout=None,
+        flow_ratio_forecast_vs_history=None,
+        flow_variance_ratio_forecast_vs_history=None,
+        curvature_ratio_forecast_vs_history=None,
+        latent_diag_mahalanobis_ratio_forecast_vs_history=None,
+        per_channel_flow=None,
+        lag_channel_horizon_attributions=None,
+        channel_horizon_attributions=None,
+        channel_coupling_matrix=None,
+        channel_flow_method=None,
+        channel_coupling_off_diag_norm=None,
+    )
+    captured = {}
+
+    def moment_embed_fn(model, *, input_mask=None, grad_through_norm=False):
+        captured["input_mask"] = input_mask.detach().cpu().tolist()
+        captured["grad_through_norm"] = grad_through_norm
+        return lambda x: x.reshape(x.shape[0], -1).sum(dim=1, keepdim=True)
+
+    def integrated_gradients_embedding(embed_fn, x, **kwargs):
+        captured["ig_shape"] = tuple(x.shape)
+        captured["ig_kwargs"] = kwargs
+        assert tuple(embed_fn(torch.zeros((2, *x.shape), dtype=torch.float32)).shape) == (2, 1)
+        return SimpleNamespace(
+            attribution=np.array([[1.0, 2.0, 3.0, 4.0], [-1.0, -2.0, -3.0, -4.0]], dtype=np.float32),
+            overall_effect=0.0,
+            abs_effect=20.0,
+            embedding_delta=0.5,
+            embedding_delta_abs_mean=0.5,
+            convergence_delta=0.1,
+            n_steps=kwargs["n_steps"],
+            n_baselines=kwargs["n_baselines"],
+            baseline=kwargs["baseline"],
+            reduce=kwargs["reduce"],
+            embedding_dim=1,
+        )
+
+    def build_pdf_report(pdf_path, **kwargs):
+        captured["pdf_report"] = kwargs["integrated_gradients_report"]
+        captured["channel_labels"] = kwargs["channel_labels"]
+        pdf_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
+        return pdf_path
+
+    monkeypatch.setattr(forecasting, "explain_forecast", lambda *args, **kwargs: explanation)
+    monkeypatch.setattr(forecasting, "compute_trajectory_stability", lambda *args, **kwargs: None)
+    monkeypatch.setattr(ig, "moment_embed_fn", moment_embed_fn)
+    monkeypatch.setattr(ig, "integrated_gradients_embedding", integrated_gradients_embedding)
+    monkeypatch.setattr(forecasting, "_save_lag_horizon_artifacts", lambda *args, **kwargs: None)
+    monkeypatch.setattr(forecasting, "_build_pdf_report", build_pdf_report)
+
+    model = SimpleNamespace(eval=lambda: None)
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=6, freq="h"),
+            "target": np.arange(6, dtype=np.float32),
+            "feature": np.linspace(0.0, 1.0, 6, dtype=np.float32),
+        }
+    )
+    standardizer = forecasting.Standardizer(
+        mean=np.zeros(2, dtype=np.float32),
+        std=np.ones(2, dtype=np.float32),
+    )
+    _, run_dir = forecasting._run_interpretability(
+        model=model,
+        standardizer=standardizer,
+        working_df=df,
+        columns_to_process=["target", "feature"],
+        timestamp_column="timestamp",
+        target_column="target",
+        seq_len=4,
+        forecast_horizon=2,
+        model_horizon=2,
+        device=torch.device("cpu"),
+        n_lags=3,
+        softmax_tau=1.0,
+        interpretability_output=None,
+        interpretability_out_dir=tmp_path,
+        interpretability_run_name="integrated_gradients",
+        interpretability_top_k=2,
+        dataset_name="unit",
+        integrated_gradients=True,
+        integrated_gradients_steps=7,
+        integrated_gradients_n_baselines=2,
+        integrated_gradients_internal_batch_size=3,
+        integrated_gradients_reduce="mean",
+        integrated_gradients_seed=123,
+        interpretability_channel_axis=False,
+    )
+
+    payload = json.loads((run_dir / "explanation.json").read_text(encoding="utf-8"))
+    ig_payload = payload["explanation"]["integrated_gradients"]
+    assert ig_payload["channel_labels"] == ["target", "feature"]
+    assert ig_payload["channel_abs_effect"] == [10.0, 10.0]
+    assert captured["input_mask"] == [1, 1, 1, 1]
+    assert captured["ig_shape"] == (2, 4)
+    assert captured["ig_kwargs"]["internal_batch_size"] == 3
+    assert captured["ig_kwargs"]["seed"] == 123
+    assert captured["grad_through_norm"] is True
+    assert captured["channel_labels"] == ["target", "feature"]
+    assert captured["pdf_report"]["attribution"].shape == (2, 4)
+    assert (run_dir / "integrated_gradients_attributions.csv").exists()
+    assert (run_dir / "integrated_gradients_channel_summary.csv").exists()
 
 
 def test_perform_forecasting_return_all_channels_rejects_timestamp_collision():


### PR DESCRIPTION
## Summary

Adds feature-axis interpretability and integrated gradients to the forecasting SDK and its PDF reports.

- Adds channel-by-horizon feature attribution.
- Supports output-aware target-input Jacobian attribution.
- Adds integrated gradients embedding sensitivity analysis.
- Uses parallel interpretability passes for channel coupling when multiple CUDA devices are available, with a serial fallback.
- Adds CSV, JSON, heatmap, and PDF artifacts for the new results.
- Fixes the semantic-flow PDF layout overlap.
- Preserves existing forecasting behavior and output contracts.