### PR TITLE
Add missing function and disable missing function arguments

### DIFF
--- a/forecasting/channel_flow.py
+++ b/forecasting/channel_flow.py
@@ -60,12 +60,13 @@ import numpy as np
 import torch
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
 from interpretability import (
     Array,
     ForecastModel,
     _embed_batch,
+    _forecast_autoregressive,
     _rolling_window_sources,
 )
 
@@ -1134,3 +1135,50 @@ def lag_horizon_marginal(attribution_kch: Array) -> Array:
     plugged directly into :func:`evaluate_lag_faithfulness`.
     """
     return np.asarray(attribution_kch, dtype=np.float32).sum(axis=1).astype(np.float32)
+
+
+def make_target_forecast_value_fn(
+    *,
+    target_channel: int,
+    model_horizon: int,
+    forecast_horizon: int,
+) -> Callable[..., Array]:
+    """Return a value function that evaluates the target channel's forecast.
+
+    The returned callable runs the model autoregressively on a batch of input
+    windows and returns the mean-absolute forecast for ``target_channel`` over
+    ``forecast_horizon`` steps as a 1-D array of shape ``[B]``. It is designed
+    to be passed as ``value_fn`` to :func:`compute_per_channel_flow` to enable
+    output-aware per-channel attribution, where the Shapley game measures how
+    each channel affects a specific forecast output rather than the latent
+    embedding.
+
+    Args:
+        target_channel: Index of the forecast channel to explain.
+        model_horizon: Native forecast horizon of the model.
+        forecast_horizon: Desired number of future steps to attribute.
+
+    Returns:
+        A callable ``f(model, x_enc, input_mask) -> Array[B]`` giving the
+        mean absolute forecast value for the target channel over the requested
+        horizon for each sample in the batch.
+    """
+    _tc = int(target_channel)
+    _mh = int(model_horizon)
+    _fh = int(forecast_horizon)
+
+    def _value_fn(
+        model: ForecastModel,
+        x_enc: torch.Tensor,
+        input_mask: torch.Tensor,
+    ) -> Array:
+        forecast = _forecast_autoregressive(
+            model,
+            x_enc,
+            input_mask,
+            model_horizon=_mh,
+            target_horizon=_fh,
+        )  # [B, C, H]
+        return np.mean(np.abs(forecast[:, _tc, :]), axis=1).astype(np.float32)  # [B]
+
+    return _value_fn

--- a/forecasting/interpretability.py
+++ b/forecasting/interpretability.py
@@ -1561,8 +1561,8 @@ def explain_forecast(
             input_mask_t=mask_ext,
             device=device,
             cfg=chan_cfg_eff,
-            value_fn=chan_value_fn,
-            protect_channels=chan_protect,
+            # value_fn=chan_value_fn,
+            # protect_channels=chan_protect,
         )
         per_chan_flow = report.per_channel_flow
         chan_method = report.method

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -360,6 +360,25 @@ def test_perform_forecasting_return_all_channels_rejects_timestamp_collision():
         )
 
 
+def test_perform_forecasting_with_interpretability_exports_json(tmp_path):
+    df = make_timeseries(num_rows=10)
+    result = forecasting.perform_forecasting(
+        df,
+        seq_len=5,
+        forecast_horizon=3,
+        model_horizon=3,
+        standardizer_pkl="fake_std.pkl",
+        ckpt="fake_ckpt.pt",
+        interpretability=True,
+        interpretability_output="json",
+        interpretability_out_dir=tmp_path,
+        interpretability_run_name="test_run",
+        n_lags=4,
+    )
+
+    assert (tmp_path / "test_run" / "explanation.json").exists()
+
+
 def test_perform_forecasting_requires_timestamp_column():
     df = make_timeseries(num_rows=6).drop(columns=["timestamp"])
     with pytest.raises(ValueError, match="Timestamp column 'timestamp' not found"):


### PR DESCRIPTION
This pull request adds a missing function expected in channel flow. It also disables missing functions arguments and adds a test for the interpretability success path.

In channel flow, I've added `make_target_forecast_value_fn` as a factory function returning a callable that evaluates the target channel's forecast. The returned callable runs the model autoregressively and returns the mean-absolute forecast for the target channel.

With the new test, we can [see it failing](https://github.com/rafmudaf/NV-Tesseract/actions/runs/29609301310) with the import error. Then, [the test passes](https://github.com/rafmudaf/NV-Tesseract/actions/runs/29609914817) with the new function.

@neptunel or others feel free to make any changes if this was not the intent of `make_target_forecast_value_fn`.
