### PR TITLE
Add SDK embedding stability reporting

### DIFF
--- a/forecasting/channel_stability.py
+++ b/forecasting/channel_stability.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+"""Per-channel embedding stability (v2 feature-axis stability).
+
+This module contains the channel-axis analogue of v1's embedding stability
+primitive in :mod:`interpretability`:
+
+* :func:`compute_embedding_stability` (v1) reports a single scalar Lipschitz
+  ratio per (model, series), aggregating over many input perturbation trials.
+  Its v2 counterpart :func:`compute_per_channel_embedding_stability` reports
+  the same ratio *per input channel*, by perturbing only one row of the input
+  window at a time. Answers: "which input channels does the embedding map
+  treat in a Lipschitz-safe way?"
+
+Mathematical definitions
+========================
+
+**Per-channel embedding stability (Lipschitz-style).**
+For an input context ``X_t in R^{C x L}`` and a channel ``c in {0, ..., C-1}``,
+define the per-channel-perturbed input
+
+    X_t^(c, eps) = X_t + epsilon e_c x_t^T ,    epsilon ~ N(0, (alpha sigma_c)^2 I_L),
+
+i.e. additive Gaussian noise with scale ``alpha * sigma_c`` (where
+``sigma_c = std(X_t[c, observed])`` and ``alpha = noise_scale``) restricted to
+row ``c`` of the input. Only row ``c`` differs from ``X_t``, so the Frobenius
+norm reduces to a row-vector L2 norm:
+
+    || X_t^(c, eps) - X_t ||_F  =  || epsilon ||_2  =  || x_t'[c, :] - x_t[c, :] ||_2 .
+
+The per-channel Lipschitz-style ratio is
+
+    R_t^(c) = || embed(X_t^(c, eps)) - embed(X_t) ||_2 / ( || X_t^(c, eps) - X_t ||_F + eta ),
+
+where ``eta = 1e-12`` is a numerical floor on the denominator. We aggregate
+over ``n_trials`` perturbation trials per channel and per time index, then
+report mean / max / p50 / p95 per channel.
+
+**Sanity invariance.** If the embedding is channel-independent --
+``embed(X) = sum_c phi_c(x_c)`` for some per-channel maps ``phi_c`` -- then
+perturbing only row ``c`` changes ``embed`` by ``phi_c(x_c + n) - phi_c(x_c)``
+alone. The ratio ``R_t^(c)`` therefore probes the local Lipschitz constant of
+``phi_c`` in isolation. In the limit of vanishing noise scale,
+``R_t^(c) -> ||J_{phi_c}||_op``. For the linear channel-independent mock model
+the ratio is *exactly* ``||W^c||_op`` of that channel's projection -- this is
+the invariance checked by
+``test_channel_independent_model_recovers_jacobian_norm`` in the test suite.
+
+Cost summary
+============
+
+* :func:`compute_per_channel_embedding_stability`:
+  ``n_trials * C`` embed calls per time index, ``+1`` baseline embed call.
+  All batched into one forward pass per time index via ``_embed_windows_batched``.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from channel_flow import _embed_windows_batched
+from interpretability import (
+    Array,
+    ForecastModel,
+    _rolling_window_sources,
+    extract_latent_trajectory,
+)
+
+# ---------------------------------------------------------------------------
+# Reports
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PerChannelEmbeddingStabilityReport:
+    """Per-channel result of the empirical embedding stability test.
+
+    Shapes (with ``C`` input channels):
+
+    * ``lip_ratio_mean``, ``lip_ratio_max``, ``lip_ratio_p50``, ``lip_ratio_p95``:
+      ``[C]`` -- aggregates over the ratios collected for that channel.
+    * ``n_trials_per_channel``: ``[C]`` -- number of perturbation trials that
+      contributed a finite ratio for that channel (may differ across channels
+      if some perturbations were skipped, e.g. a fully-zero noise draw on a
+      constant channel).
+    * ``n_unique_windows``: ``int`` -- count of distinct time indices that
+      contributed to at least one channel's ratio set.
+    * ``step_delta_norm_mean``: ``float`` -- mean ``||Z_{t+1} - Z_t||`` on the
+      unperturbed trajectory (a v1-style reference scale; identical to the
+      scalar returned by :func:`compute_embedding_stability`).
+    """
+
+    lip_ratio_mean: Array  # [C]
+    lip_ratio_max: Array  # [C]
+    lip_ratio_p50: Array  # [C]
+    lip_ratio_p95: Array  # [C]
+    n_trials_per_channel: Array  # [C], int
+    n_unique_windows: int
+    step_delta_norm_mean: float
+    n_channels: int
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _select_time_indices(
+    *,
+    seq_len: int,
+    T: int,
+    n_trials: int,
+    rng: np.random.Generator,
+    time_indices: Array | None = None,
+) -> np.ndarray:
+    """Mirror the sampling discipline used in v1 :func:`compute_embedding_stability`.
+
+    Prefers indices ``[seq_len - 1, T)`` (full-window region) and repeats with
+    a shuffle if the candidate pool is smaller than ``n_trials``. Different
+    perturbation seeds across the repeats keep the trials statistically
+    distinct even when the underlying windows are reused.
+    """
+    if time_indices is not None:
+        return np.asarray(time_indices, dtype=np.int64).reshape(-1)
+    candidates = np.arange(seq_len - 1, T, dtype=np.int64)
+    if len(candidates) == 0:
+        candidates = np.arange(T, dtype=np.int64)
+    if len(candidates) >= n_trials:
+        return rng.choice(candidates, size=n_trials, replace=False)
+    n_repeats = int(np.ceil(n_trials / len(candidates)))
+    out = np.tile(candidates, n_repeats)[:n_trials]
+    rng.shuffle(out)
+    return out
+
+
+def _per_channel_std(window_cl: Array, win_mask: Array) -> Array:
+    """Per-channel std of ``window_cl[:, observed]``.
+
+    Channels with std ``< 1e-8`` (numerically constant on the observed slice)
+    fall back to ``1.0`` to match the v1 convention -- they get the *raw*
+    noise scale and we measure ``embed`` sensitivity to that absolute scale
+    rather than to a normalised-by-zero scale.
+    """
+    obs = np.asarray(win_mask, dtype=bool)
+    if not np.any(obs):
+        return np.ones((window_cl.shape[0],), dtype=np.float32)
+    std = np.std(window_cl[:, obs], axis=1).astype(np.float32, copy=False)
+    std = np.where(std < 1e-8, np.float32(1.0), std)
+    return std
+
+
+# ---------------------------------------------------------------------------
+# Per-channel embedding stability
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def compute_per_channel_embedding_stability(
+    model: ForecastModel,
+    series_ct: Array,  # [C, T]
+    *,
+    seq_len: int,
+    input_mask_t: Array | None = None,
+    device: torch.device,
+    n_trials: int = 30,
+    noise_scale: float = 0.01,
+    time_indices: Array | None = None,
+    batch_size: int = 16,
+    trajectory_batch_size: int = 32,
+    seed: int = 42,
+) -> PerChannelEmbeddingStabilityReport:
+    """Channel-wise Lipschitz-style stability test.
+
+    For each channel ``c``, perturbs only row ``c`` of the input window and
+    measures the ratio ``|| embed(X') - embed(X) ||_2 / || X' - X ||_F``
+    averaged over ``n_trials`` perturbation trials. The result is the v2
+    feature-axis analogue of :func:`compute_embedding_stability` (which
+    perturbs all channels jointly and returns a single scalar).
+
+    Args:
+        model: forecast model exposing the ``embed`` interface.
+        series_ct: ``[C, T]`` series; only the trailing time indices matter.
+        seq_len: context length ``L`` of the model.
+        input_mask_t: optional ``[T]`` observed-mask for the series.
+        device: torch device for the embed calls.
+        n_trials: number of perturbation trials *per channel and per time
+            index*. Total perturbation embeds = ``n_trials * |time_indices| * C``.
+        noise_scale: noise amplitude as a fraction of per-channel std.
+        time_indices: optional explicit ``[T_idx]`` time-index list. If None,
+            samples ``n_trials`` indices from the full-window region.
+        batch_size: chunk size for batched embed of perturbation windows.
+        trajectory_batch_size: chunk size for the reference-trajectory embed
+            (separate budget because the reference is computed once over the
+            full series).
+        seed: RNG seed for the per-channel noise.
+
+    Returns:
+        :class:`PerChannelEmbeddingStabilityReport` with shape-``[C]`` summaries.
+    """
+    xw_view, m_view, T = _rolling_window_sources(series_ct, seq_len=seq_len, input_mask_t=input_mask_t)
+    if T < 2:
+        raise ValueError(f"Need at least 2 time steps for per-channel stability test, got T={T}")
+    C = int(np.asarray(series_ct).shape[0])
+    L = int(seq_len)
+
+    rng = np.random.default_rng(int(seed))
+    sampled_indices = _select_time_indices(seq_len=L, T=T, n_trials=int(n_trials), rng=rng, time_indices=time_indices)
+    sampled_indices = np.unique(np.clip(sampled_indices, 0, T - 1))
+    if sampled_indices.size == 0:
+        raise ValueError("No valid time indices to sample for per-channel stability.")
+
+    # Collected ratios are gathered into per-channel lists across all
+    # (time_index, trial) draws so the aggregation is purely vectorised at the
+    # end. Each accepted draw contributes one float per channel.
+    per_channel_ratios: list[list[float]] = [[] for _ in range(C)]
+    n_unique = 0
+
+    # Number of trials per time index: keep at least 1; rotate noise seeds so
+    # the trials are not identical across time indices.
+    trials_per_index = max(1, int(np.ceil(n_trials / sampled_indices.size)))
+
+    for t_idx, t in enumerate(sampled_indices):
+        win = np.asarray(xw_view[int(t)], dtype=np.float32)  # [C, L]
+        mask = np.asarray(m_view[int(t)], dtype=np.int64)  # [L]
+        obs_mask = mask.astype(bool)
+        if not np.any(obs_mask):
+            continue
+
+        std_per_chan = _per_channel_std(win, mask)  # [C]
+        win_mask_f = mask.astype(np.float32, copy=False)  # [L]
+
+        # Build a [1 + C * trials_per_index, C, L] probe stack:
+        # slot 0 = baseline; slots 1..C, C+1..2C, ... = trial-major,
+        # channel-minor perturbations (channel c of trial r at slot 1 + r*C + c).
+        n_perturbs = C * trials_per_index
+        stack = np.empty((1 + n_perturbs, C, L), dtype=np.float32)
+        stack[0] = win
+
+        # Draw noise once per (trial, channel) at scale alpha * std_c restricted
+        # to observed positions. Padded positions contribute 0 to both
+        # numerator (embed sees the same masked input) and denominator (we
+        # measure Frobenius norm of x' - x, which is zero in masked positions).
+        noise_unit = rng.standard_normal((trials_per_index, C, L)).astype(np.float32)
+        # Apply the observation mask (zero perturbation where mask=0).
+        noise_unit = noise_unit * win_mask_f[None, None, :]
+        # Per-channel scale.
+        noise_unit *= (float(noise_scale) * std_per_chan)[None, :, None]  # [r, C, L]
+
+        # Frobenius norm equals the row-c L2 norm of the per-channel noise.
+        # Drop trials where every channel ended up with a numerically zero
+        # noise vector (e.g. constant + tiny noise_scale on a fully-padded
+        # window) -- they would inject inf into the ratio aggregation.
+        dx_norm = np.linalg.norm(noise_unit.reshape(trials_per_index * C, L), ord=2, axis=1).astype(np.float32)
+        dx_norm = dx_norm.reshape(trials_per_index, C)
+
+        # Materialise perturbed windows: copy ``win`` then overwrite row c with
+        # ``win[c] + noise[r, c, :]``.
+        perturbed = np.broadcast_to(win[None, None, :, :], (trials_per_index, C, C, L)).copy()
+        chan_idx = np.arange(C)
+        perturbed[:, chan_idx, chan_idx, :] = win[chan_idx, :][None, :, :] + noise_unit  # [r, C, L]
+
+        # Flatten trial/channel dims into the leading "slot" axis.
+        stack[1:] = perturbed.reshape(n_perturbs, C, L)
+        masks_stack = np.broadcast_to(mask[None, :], (1 + n_perturbs, L)).copy()
+
+        z = _embed_windows_batched(
+            model,
+            stack,
+            masks_stack,
+            device=device,
+            batch_size=int(batch_size),
+        )  # [1 + n_perturbs, D]
+        z_base = z[0]  # [D]
+        z_pert = z[1:].reshape(trials_per_index, C, -1)  # [r, C, D]
+
+        dz_norm = np.linalg.norm(z_pert - z_base[None, None, :], ord=2, axis=2).astype(np.float32)  # [r, C]
+
+        # Aggregate per-channel ratios. Skip (trial, channel) cells where the
+        # noise vector was numerically zero.
+        valid_mask = dx_norm > 1e-12
+        eps = np.float32(1e-12)
+        ratios = dz_norm / (dx_norm + eps)
+        for c in range(C):
+            valid_c = valid_mask[:, c]
+            if not np.any(valid_c):
+                continue
+            for r_val in ratios[valid_c, c]:
+                per_channel_ratios[c].append(float(r_val))
+        n_unique += 1
+
+    # Reference scale (matches v1 step_delta_norm_mean) - computed once over
+    # the full series. Failure-tolerant: if the trajectory is degenerate, fall
+    # back to NaN.
+    try:
+        Z_full = extract_latent_trajectory(
+            model,
+            series_ct,
+            seq_len=L,
+            input_mask_t=input_mask_t,
+            device=device,
+            batch_size=int(trajectory_batch_size),
+        )
+        if Z_full.shape[0] >= 2:
+            step_deltas = np.linalg.norm(Z_full[1:] - Z_full[:-1], ord=2, axis=1)
+            step_delta_mean = float(np.nanmean(step_deltas))
+        else:
+            step_delta_mean = float("nan")
+    except Exception:
+        step_delta_mean = float("nan")
+
+    lip_mean = np.full((C,), np.nan, dtype=np.float32)
+    lip_max = np.full((C,), np.nan, dtype=np.float32)
+    lip_p50 = np.full((C,), np.nan, dtype=np.float32)
+    lip_p95 = np.full((C,), np.nan, dtype=np.float32)
+    n_per_chan = np.zeros((C,), dtype=np.int64)
+    for c in range(C):
+        if not per_channel_ratios[c]:
+            continue
+        arr = np.asarray(per_channel_ratios[c], dtype=np.float64)
+        finite = arr[np.isfinite(arr)]
+        if finite.size == 0:
+            continue
+        lip_mean[c] = float(np.mean(finite))
+        lip_max[c] = float(np.max(finite))
+        lip_p50[c] = float(np.percentile(finite, 50))
+        lip_p95[c] = float(np.percentile(finite, 95))
+        n_per_chan[c] = int(finite.size)
+
+    return PerChannelEmbeddingStabilityReport(
+        lip_ratio_mean=lip_mean,
+        lip_ratio_max=lip_max,
+        lip_ratio_p50=lip_p50,
+        lip_ratio_p95=lip_p95,
+        n_trials_per_channel=n_per_chan,
+        n_unique_windows=int(n_unique),
+        step_delta_norm_mean=step_delta_mean,
+        n_channels=int(C),
+    )
+
+
+__all__ = [
+    "PerChannelEmbeddingStabilityReport",
+    "compute_per_channel_embedding_stability",
+]

--- a/forecasting/sdk/README.md
+++ b/forecasting/sdk/README.md
@@ -10,8 +10,9 @@ Programmatic entry point for running `perform_forecasting()` on pandas DataFrame
 - **Robust preprocessing**: Converts timestamps, fills numeric NULLs with zeros, enforces minimum sequence length (`seq_len`), and standardizes input using saved standardizer metadata.
 - **Column alignment**: Automatically handles datasets with different feature sets by aligning to common columns, preventing broadcasting errors.
 - **Diverse output**: Produces hybrid, direct, and kNN forecasts when context is provided; otherwise returns only the direct forecast column.
-- **Built-in interpretability**: Opt-in `interpretability=True` produces horizon-resolved lag attribution, semantic-flow diagnostics, latent-trajectory stability, JSON/CSV/PNG artifacts, and a self-contained PDF report. Output format is selectable via `interpretability_output` (`"json"`, `"pdf"`, or `None` for both).
+- **Built-in interpretability**: Opt-in `interpretability=True` produces horizon-resolved lag attribution, semantic-flow diagnostics, latent-trajectory stability, JSON/CSV/PNG artifacts, and a self-contained PDF report with feature-axis embedding stability for multivariate inputs. Output format is selectable via `interpretability_output` (`"json"`, `"pdf"`, or `None` for both).
 - **Feature-axis interpretability**: For multivariate inputs, the SDK automatically adds batched Jacobian channel-by-horizon attribution to the PDF and artifact bundle.
+- **Feature-axis embedding stability**: Multivariate interpretability runs perturb one input feature at a time and report Lipschitz-style embedding sensitivity in the feature-axis JSON block, `feature_axis_embedding_stability.csv`, and a dedicated PDF page.
 
 ## Installation
 
@@ -131,10 +132,12 @@ interp_result = perform_forecasting(
 | Value | Files written under `<interpretability_out_dir>/run_<UTC>/` |
 |-------|-------------------------------------------------------------|
 | `"json"` | `forecast.csv`, `explanation.json` |
-| `"pdf"` | `forecast.csv`, lag/semantic-flow artifacts, feature-axis artifacts for multivariate input, optional integrated-gradients artifacts, `explanation_report.pdf` |
+| `"pdf"` | `forecast.csv`, lag/semantic-flow artifacts, feature-axis attribution and embedding-stability artifacts for multivariate input, optional integrated-gradients artifacts, `explanation_report.pdf` |
 | `None`  | All of the above |
 
 The returned DataFrame is the explanation-aligned forecast (single forward pass, so it lines up 1:1 with the attribution matrix). PDF / heatmap require `matplotlib`; if it's missing, those steps are skipped with a warning while JSON output continues to work.
+
+If the input DataFrame has more than one numeric column, the feature-axis decomposition runs automatically: the report gains channel-by-horizon attribution and feature-axis embedding-stability pages. By default attribution is measured in latent space (output-agnostic); set `channel_output_aware=True` to attribute the target channel's forecast directly.
 
 ## Function signature
 
@@ -262,17 +265,18 @@ When `interpretability=True`, the run directory contains the following files (se
 | File | Written when | Contents |
 |------|--------------|----------|
 | `forecast.csv` | json, pdf, both | The returned forecast DataFrame |
-| `explanation.json` | json, both | Forecast + full explanation payload, including lag×horizon values, semantic-flow diagnostics, trajectory stability, feature-axis results for multivariate input, optional Integrated Gradients, and dataset metadata |
+| `explanation.json` | json, both | Forecast + full explanation payload, including lag×horizon values, semantic-flow diagnostics, trajectory stability, a multivariate `feature_axis` block containing attribution and `embedding_stability` results, optional Integrated Gradients, and dataset metadata |
 | `lag_horizon_attributions.csv` | pdf, both | Wide K×H attribution matrix |
 | `lag_horizon_long.csv` | pdf, both | Tidy `(lag, horizon, attribution[, score])` table |
 | `lag_horizon_heatmap.png` | pdf, both *(needs matplotlib)* | Visual heatmap, viridis cmap |
 | `semantic_flow.csv` | pdf, both | Tidy `(transition_index, segment, flow_magnitude)` table, where `segment` is `history` for transitions fully inside the input window, `forecast` for transitions whose window extends into the model-generated future, and `tail` for any trailing transitions outside both segments |
 | `channel_horizon_attributions.csv` | multivariate pdf, both | Feature-axis `C×H` attribution matrix |
 | `channel_horizon_heatmap.png` | multivariate pdf, both *(needs matplotlib)* | Feature-axis channel-by-horizon heatmap |
+| `feature_axis_embedding_stability.csv` | multivariate pdf, both | Complete feature-level embedding-stability report: mean, p50, p95, and max Lipschitz-style ratios, retained trial counts, sampled-window count, and the unperturbed latent-step reference scale |
 | `integrated_gradients_attributions.csv` | `integrated_gradients=True` with pdf or both | Signed embedding IG value for every channel and context position |
 | `integrated_gradients_channel_summary.csv` | `integrated_gradients=True` with pdf or both | Signed effect, absolute effect, and absolute share by channel |
 | `integrated_gradients_heatmap.png` | `integrated_gradients=True` with pdf or both *(needs matplotlib)* | Signed channel-by-context IG heatmap |
-| `explanation_report.pdf` | pdf, both *(needs matplotlib)* | Multi-page report covering forecast, lag×horizon attribution, semantic flow, latent stability, feature-axis attribution for multivariate input, and optional embedding Integrated Gradients |
+| `explanation_report.pdf` | pdf, both *(needs matplotlib)* | Multi-page report covering forecast, lag×horizon attribution, semantic flow, latent stability, feature-axis attribution, feature-axis embedding stability, and optional embedding Integrated Gradients |
 
 The run directory path is printed on stdout when the call completes.
 

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -5,7 +5,6 @@ import hashlib
 import json
 import logging
 import os
-import sys
 import tempfile
 import types
 from contextlib import contextmanager
@@ -36,6 +35,10 @@ except ImportError:
 
 # Clean absolute imports - package is installed in editable mode
 from backbone.utils.utils import control_randomness
+from channel_stability import (
+    PerChannelEmbeddingStabilityReport,
+    compute_per_channel_embedding_stability,
+)
 from dataset_longhorizon import (
     CSVLongHorizonSimpleDataset,
     Standardizer,
@@ -763,17 +766,20 @@ def _semantic_flow_page(
     fig.text(
         0.06,
         0.90,
-        "Per-step latent flow m_t = ||Z_{t+1} - Z_t||_2 over the trajectory built on\n"
+        r"Per-step latent flow is $m_t = \Vert \mathbf{z}_{t+1} - \mathbf{z}_t \Vert_2$"
+        " over the trajectory built on\n"
         "[history; forecast]. This is the temporal signal that drives the lag x horizon\n"
         "heatmap; bigger spikes contribute more to attribution. Compare the history\n"
         "segment against the forecast segment to gauge representation-level stability.",
         ha="left",
         va="top",
         fontsize=9,
+        fontfamily="DejaVu Sans",
+        math_fontfamily="dejavusans",
         color="gray",
     )
 
-    ax = fig.add_axes((0.08, 0.57, 0.84, 0.23))
+    ax = fig.add_axes((0.08, 0.55, 0.84, 0.23))
     x_axis = np.arange(T_trans)
     ax.plot(x_axis, flow, linewidth=1.0, color="#1f77b4", label="flow magnitude")
     if 0 < boundary < T_trans:
@@ -802,8 +808,8 @@ def _semantic_flow_page(
             linewidth=1.2,
             label=f"forecast mean ({fcst_mean:.3f})",
         )
-    ax.set_xlabel("Latent transition index (t -> t+1)")
-    ax.set_ylabel("||Z_{t+1} - Z_t||_2")
+    ax.set_xlabel(r"Latent transition index ($t \rightarrow t+1$)")
+    ax.set_ylabel(r"$\Vert \mathbf{z}_{t+1} - \mathbf{z}_t \Vert_2$")
     ax.legend(loc="upper right", fontsize=8, framealpha=0.85)
 
     seg_rows = [
@@ -814,7 +820,7 @@ def _semantic_flow_page(
         ["Variance", hist_s[4], fcst_s[4]],
         ["Transitions", hist_s[5], fcst_s[5]],
     ]
-    ax_t1 = fig.add_axes((0.06, 0.34, 0.42, 0.15))
+    ax_t1 = fig.add_axes((0.06, 0.32, 0.42, 0.18))
     ax_t1.axis("off")
     table_seg = ax_t1.table(
         cellText=seg_rows,
@@ -825,7 +831,7 @@ def _semantic_flow_page(
     )
     table_seg.auto_set_font_size(False)
     table_seg.set_fontsize(8)
-    table_seg.scale(1.0, 1.2)
+    table_seg.scale(1.0, 1.3)
     for c in range(3):
         cell = table_seg[(0, c)]
         cell.set_facecolor("#dddddd")
@@ -833,27 +839,27 @@ def _semantic_flow_page(
 
     diag_rows = [
         [
-            "Flow ratio (fcst/hist)",
+            "Flow ratio (forecast/history)",
             _fmt(explanation.flow_ratio_forecast_vs_history),
-            "~1 healthy, >1.5 OOD-volatile",
+            r"$\approx 1$ healthy, $>1.5$ OOD-volatile",
         ],
         [
             "Flow variance ratio",
             _fmt(explanation.flow_variance_ratio_forecast_vs_history),
-            "~1 healthy, >2 noisy",
+            r"$\approx 1$ healthy, $>2$ noisy",
         ],
         [
             "Curvature ratio",
             _fmt(explanation.curvature_ratio_forecast_vs_history),
-            "~1 healthy, >1.5 jaggy",
+            r"$\approx 1$ healthy, $>1.5$ jaggy",
         ],
         [
             "Latent diag-Mahalanobis ratio",
             _fmt(explanation.latent_diag_mahalanobis_ratio_forecast_vs_history),
-            "~1 healthy, >>1 OOD shift",
+            r"$\approx 1$ healthy, $\gg 1$ OOD shift",
         ],
     ]
-    ax_t2 = fig.add_axes((0.52, 0.34, 0.42, 0.15))
+    ax_t2 = fig.add_axes((0.52, 0.32, 0.42, 0.18))
     ax_t2.axis("off")
     table_diag = ax_t2.table(
         cellText=diag_rows,
@@ -864,7 +870,7 @@ def _semantic_flow_page(
     )
     table_diag.auto_set_font_size(False)
     table_diag.set_fontsize(8)
-    table_diag.scale(1.0, 1.2)
+    table_diag.scale(1.0, 1.3)
     for c in range(3):
         cell = table_diag[(0, c)]
         cell.set_facecolor("#dddddd")
@@ -877,14 +883,14 @@ def _semantic_flow_page(
         "    flow magnitudes split into history (transitions fully inside the\n"
         "    input window) and forecast (transitions whose window touches the\n"
         "    model-generated future).\n"
-        "  - Flow ratio: mean(forecast flow) / mean(history flow). Values near 1\n"
-        "    mean the model's latent dynamics in the OOD segment match history.\n"
+        "  - Flow ratio: average forecast flow divided by average history flow. Values\n"
+        "    near 1 mean the model's latent dynamics in the OOD segment match history.\n"
         "    Large values flag attributions in that region as likely noisy.\n"
         "  - Flow variance ratio: same comparison on variance.\n"
         "  - Curvature ratio: second-difference energy of Z; spikes when the\n"
         "    forecast segment becomes much jaggier than history.\n"
         "  - Latent diag-Mahalanobis ratio: per-dim distance of forecast latents\n"
-        "    from the history mean (scaled by history variance). >>1 indicates a\n"
+        "    from the history mean (scaled by history variance). Values well above 1 indicate a\n"
         "    representation-level OOD shift.\n"
         "\n"
         "These scalars are also under explanation.diagnostics in explanation.json,\n"
@@ -1058,7 +1064,7 @@ def _channel_axis_page(
         + f"  - Right bar: each channel's {bar_note} summed across horizons -- a single\n"
         "    feature-importance score per input channel.\n"
         f"  - Most influential channel overall: {labels[top_c]}.\n" + resid_line + "\n"
-        "Full [C x H] values are exported as channel_horizon_attributions.csv."
+        "Full channel-by-horizon values are exported as channel_horizon_attributions.csv."
     )
     fig.text(
         0.06,
@@ -1071,6 +1077,133 @@ def _channel_axis_page(
         color="#333333",
         linespacing=1.05,
     )
+
+    pdf.savefig(fig)
+    plt.close(fig)
+
+
+def _feature_axis_embedding_stability_frame(
+    report: PerChannelEmbeddingStabilityReport,
+    channel_labels: list[str] | None = None,
+) -> pd.DataFrame:
+    """Return the complete feature-axis embedding-stability report."""
+    n_channels = int(report.n_channels)
+    labels = (
+        channel_labels
+        if channel_labels is not None and len(channel_labels) == n_channels
+        else [f"channel_{c}" for c in range(n_channels)]
+    )
+    return pd.DataFrame(
+        {
+            "feature": labels,
+            "lip_ratio_mean": np.asarray(report.lip_ratio_mean, dtype=np.float32),
+            "lip_ratio_p50": np.asarray(report.lip_ratio_p50, dtype=np.float32),
+            "lip_ratio_p95": np.asarray(report.lip_ratio_p95, dtype=np.float32),
+            "lip_ratio_max": np.asarray(report.lip_ratio_max, dtype=np.float32),
+            "n_trials_per_channel": np.asarray(report.n_trials_per_channel, dtype=np.int64),
+            "n_unique_windows": int(report.n_unique_windows),
+            "step_delta_norm_mean": float(report.step_delta_norm_mean),
+        }
+    )
+
+
+def _save_feature_axis_embedding_stability_csv(
+    out_dir: Path,
+    report: PerChannelEmbeddingStabilityReport,
+    channel_labels: list[str] | None = None,
+) -> Path:
+    """Write the complete feature-axis embedding-stability report."""
+    out_path = out_dir / "feature_axis_embedding_stability.csv"
+    _feature_axis_embedding_stability_frame(report, channel_labels).to_csv(out_path, index=False, na_rep="nan")
+    return out_path
+
+
+def _feature_axis_embedding_stability_page(
+    pdf: Any,
+    plt: Any,
+    *,
+    report: PerChannelEmbeddingStabilityReport,
+    channel_labels: list[str] | None = None,
+) -> None:
+    """Append the feature-axis embedding-stability summary."""
+    frame = _feature_axis_embedding_stability_frame(report, channel_labels)
+    shown = frame.sort_values("lip_ratio_p95", ascending=False, na_position="last").head(10)
+
+    def _fmt(value: Any) -> str:
+        numeric = float(value)
+        return f"{numeric:.4f}" if np.isfinite(numeric) else "n/a"
+
+    fig = plt.figure(figsize=(11, 8.5))
+    fig.text(
+        0.5,
+        0.95,
+        "Feature-axis embedding stability",
+        ha="center",
+        fontsize=14,
+        fontweight="bold",
+    )
+    fig.text(
+        0.06,
+        0.90,
+        "This shows the delta between two embedding points after a small, controlled change to one feature.\n"
+        r"Each sensitivity score is $\Vert \Delta \mathbf{z} \Vert_2"
+        r"\,/\, \Vert \Delta \mathbf{x}_c \Vert_2$."
+        "\nLower values mean less latent movement per unit feature change; compare features\n"
+        "within the same model and dataset because embedding scales are model-specific.",
+        ha="left",
+        va="top",
+        fontsize=9,
+        fontfamily="DejaVu Sans",
+        math_fontfamily="dejavusans",
+        color="gray",
+    )
+
+    table_rows = [
+        [
+            row.feature,
+            _fmt(row.lip_ratio_mean),
+            _fmt(row.lip_ratio_p50),
+            _fmt(row.lip_ratio_p95),
+            _fmt(row.lip_ratio_max),
+            str(int(row.n_trials_per_channel)),
+        ]
+        for row in shown.itertuples(index=False)
+    ]
+    table_ax = fig.add_axes((0.06, 0.50, 0.88, 0.28))
+    table_ax.axis("off")
+    table = table_ax.table(
+        cellText=table_rows,
+        colLabels=["Feature", "Mean", "P50", "P95", "Max", "Trials"],
+        colWidths=[0.30, 0.14, 0.14, 0.14, 0.14, 0.14],
+        loc="upper center",
+        cellLoc="center",
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(8)
+    table.scale(1.0, 1.2)
+    for c in range(6):
+        cell = table[(0, c)]
+        cell.set_facecolor("#dddddd")
+        cell.set_text_props(weight="bold")
+
+    interp_text = (
+        "How to read these metrics\n"
+        "-------------------------\n"
+        "  - Mean / P50 / P95 / Max: summaries of the sensitivity score across\n"
+        "    small feature changes. Lower values mean the embedding\n"
+        "    moves less per unit change in that feature.\n"
+        "  - P95: conservative tail sensitivity. Rows are ranked by P95; the highest\n"
+        "    values identify features whose small changes can move the embedding most.\n"
+        "  - Trials: valid sensitivity measurements retained for that feature.\n"
+        f"  - Sample coverage: {int(report.n_unique_windows)} unique windows. Mean\n"
+        f"    baseline latent step: {_fmt(report.step_delta_norm_mean)} (reference only).\n"
+        "  - Compare values only within the same model and dataset because embedding\n"
+        "    scales are model-specific. A larger ratio is sensitivity, not by itself a defect.\n"
+        "\n"
+        "All features and raw report fields are exported to\n"
+        "feature_axis_embedding_stability.csv and explanation.json."
+    )
+    fig.text(0.06, 0.43, interp_text, ha="left", va="top", fontsize=9, family="monospace", color="#333333")
 
     pdf.savefig(fig)
     plt.close(fig)
@@ -1090,26 +1223,21 @@ def _normalization_statistics_gradient(model: torch.nn.Module, *, enabled: bool)
 
         original = module._get_statistics
         had_instance_override = "_get_statistics" in vars(module)
-        module_namespace = sys.modules.get(type(module).__module__)
-        nanstd = getattr(module_namespace, "nanstd", None)
 
-        def _make_get_statistics(nanstd_fn: Any):
-            def _get_statistics(self: Any, x: torch.Tensor, mask: torch.Tensor | None = None) -> None:
-                if mask is None:
-                    mask = torch.ones((x.shape[0], x.shape[-1]), device=x.device)
-                expanded = mask.to(device=x.device).unsqueeze(1).repeat(1, x.shape[1], 1).bool()
-                masked_x = torch.where(expanded, x, torch.full_like(x, float("nan")))
-                self.mean = torch.nanmean(masked_x, dim=-1, keepdim=True)
-                if nanstd_fn is None:
-                    centered = masked_x - torch.nanmean(masked_x, dim=-1, keepdim=True)
-                    stdev = centered.square().nanmean(dim=-1, keepdim=True).sqrt()
-                else:
-                    stdev = nanstd_fn(masked_x, dim=-1, keepdim=True)
-                self.stdev = stdev + self.eps
+        def _get_statistics(self: Any, x: torch.Tensor, mask: torch.Tensor | None = None) -> None:
+            if mask is None:
+                mask = torch.ones((x.shape[0], x.shape[-1]), device=x.device)
+            expanded = mask.to(device=x.device).unsqueeze(1).expand(-1, x.shape[1], -1).bool()
+            masked_x = torch.where(expanded, x, torch.full_like(x, float("nan")))
+            mean = torch.nanmean(masked_x, dim=-1, keepdim=True)
+            variance = (masked_x - mean).square().nanmean(dim=-1, keepdim=True)
+            raw_stdev = variance.sqrt()
+            eps_sq = torch.as_tensor(float(self.eps) ** 2, dtype=variance.dtype, device=variance.device)
+            safe_stdev = variance.clamp_min(eps_sq).sqrt()
+            self.mean = mean
+            self.stdev = raw_stdev.detach() + safe_stdev - safe_stdev.detach() + self.eps
 
-            return _get_statistics
-
-        module._get_statistics = types.MethodType(_make_get_statistics(nanstd), module)
+        module._get_statistics = types.MethodType(_get_statistics, module)
         restores.append((module, original, had_instance_override))
 
     try:
@@ -1335,7 +1463,7 @@ def _integrated_gradients_page(
     axb.set_yticks(y)
     axb.set_yticklabels([])
     axb.invert_yaxis()
-    axb.set_title("Channel effect\n(sum |IG|)", fontsize=9)
+    axb.set_title(r"Channel effect" "\n" r"($\sum |\mathrm{IG}|$)", fontsize=9, math_fontfamily="dejavusans")
     axb.set_xlabel("Absolute effect", fontsize=8)
     axb.tick_params(axis="both", labelsize=7)
 
@@ -1353,7 +1481,7 @@ def _integrated_gradients_page(
         "  - Heatmap cell (channel c, lag l): signed contribution of that input value\n"
         "    to the scalar embedding objective used by integrated gradients.\n"
         "  - Right bar: per-channel absolute effect, summed over all context timesteps.\n"
-        f"  - Most influential channel by |IG|: {labels[top_c]}.\n"
+        f"  - Most influential channel by absolute IG: {labels[top_c]}.\n"
         f"  - Config: baseline={baseline}, steps={steps}, baselines={n_baselines}, reduce={reduce}.\n"
         f"  - RevIN/statistics gradient path enabled: {grad_norm}.\n"
         f"  - Embedding delta: {emb_delta}; convergence delta: {convergence}.\n"
@@ -1379,6 +1507,7 @@ def _build_pdf_report(
     topk_rows: list[list[str]],
     top_k: int,
     trajectory_report: TrajectoryStabilityReport | None = None,
+    feature_axis_embedding_stability_report: PerChannelEmbeddingStabilityReport | None = None,
     context_len: int | None = None,
     forecast_horizon: int | None = None,
     channel_labels: list[str] | None = None,
@@ -1396,6 +1525,19 @@ def _build_pdf_report(
 
     attrib = np.asarray(explanation.lag_horizon_attributions)
     K, H = attrib.shape
+    flow_magnitudes = getattr(explanation, "flow_magnitudes", None)
+    show_heatmap = heatmap_path is not None and heatmap_path.exists()
+    show_topk = bool(topk_rows)
+    show_semantic_flow = (
+        context_len is not None
+        and forecast_horizon is not None
+        and flow_magnitudes is not None
+        and np.asarray(flow_magnitudes).size > 0
+    )
+    show_trajectory_stability = trajectory_report is not None
+    show_feature_axis = getattr(explanation, "channel_horizon_attributions", None) is not None
+    show_feature_axis_stability = feature_axis_embedding_stability_report is not None
+    show_integrated_gradients = integrated_gradients_report is not None
 
     with PdfPages(pdf_path) as pdf:
         fig = plt.figure(figsize=(8.5, 11))
@@ -1416,6 +1558,60 @@ def _build_pdf_report(
             color="gray",
         )
 
+        sections = [
+            section
+            for available, section in [
+                (True, ["Forecast preview: line chart of predicted target values."]),
+                (
+                    show_heatmap,
+                    [
+                        "Lag x Horizon attribution heatmap: how much each past step",
+                        "   contributes to each forecast step.",
+                        "   a) lag=0 is the most recent input.",
+                        "   b) Softmax-normalized weights; brighter cells = time steps",
+                        "      that contribute more to the forecast.",
+                    ],
+                ),
+                (show_topk, ["Top-k lag steps per horizon (marginal contributions)."]),
+                (
+                    show_semantic_flow,
+                    [
+                        "Semantic flow magnitudes: per-transition latent flow and",
+                        "   forecast-vs-history diagnostics.",
+                    ],
+                ),
+                (
+                    show_trajectory_stability,
+                    [
+                        "Latent trajectory stability: temporal-smoothness metrics",
+                        "   over the context window.",
+                    ],
+                ),
+                (
+                    show_feature_axis,
+                    [
+                        "Feature-axis attribution: which input channel drives each",
+                        "   forecast step (multivariate inputs only).",
+                    ],
+                ),
+                (
+                    show_feature_axis_stability,
+                    [
+                        "Feature-axis embedding stability: per-channel sensitivity",
+                        "   to small, controlled input changes (multivariate inputs only).",
+                    ],
+                ),
+                (
+                    show_integrated_gradients,
+                    [
+                        "Integrated gradients: signed input-channel/time",
+                        "   sensitivity for the model embedding.",
+                    ],
+                ),
+            ]
+            if available
+        ]
+
         summary = [
             "Overview",
             "--------",
@@ -1427,27 +1623,9 @@ def _build_pdf_report(
             "",
             "What is in this report",
             "----------------------",
-            "1. Forecast preview: line chart of predicted target values.",
-            "2. Lag x Horizon attribution heatmap: how much each past step",
-            "   contributes to each forecast step.",
-            "   a) lag=0 is the most recent input.",
-            "   b) Softmax-normalized weights; brighter cells = time steps",
-            "      that contribute more to the forecast.",
-            "3. Top-k lag steps per horizon (marginal contributions).",
-            "4. Semantic flow magnitudes: per-transition latent flow and",
-            "   forecast-vs-history diagnostics.",
-            "5. Latent trajectory stability: temporal-smoothness metrics",
-            "   over the context window.",
-            "6. Feature-axis attribution: which input channel drives each",
-            "   forecast step (multivariate inputs only).",
         ]
-        if integrated_gradients_report is not None:
-            summary.extend(
-                [
-                    "7. Integrated gradients: signed input-channel/time",
-                    "   sensitivity for the model embedding.",
-                ]
-            )
+        for number, section in enumerate(sections, start=1):
+            summary.extend([f"{number}. {section[0]}", *section[1:]])
         fig.text(0.08, 0.85, "\n".join(summary), ha="left", va="top", fontsize=10, family="monospace")
         pdf.savefig(fig)
         plt.close(fig)
@@ -1471,7 +1649,7 @@ def _build_pdf_report(
         pdf.savefig(fig)
         plt.close(fig)
 
-        if heatmap_path is not None and heatmap_path.exists():
+        if show_heatmap:
             try:
                 from matplotlib.image import imread
             except ImportError:
@@ -1507,7 +1685,7 @@ def _build_pdf_report(
             pdf.savefig(fig)
             plt.close(fig)
 
-        if topk_rows:
+        if show_topk:
             header = ["Horizon"]
             for r in range(1, top_k + 1):
                 header.extend([f"Rank-{r}\nLag", f"Rank-{r}\nProb"])
@@ -1567,7 +1745,7 @@ def _build_pdf_report(
                 pdf.savefig(fig)
                 plt.close(fig)
 
-        if context_len is not None and forecast_horizon is not None:
+        if show_semantic_flow:
             try:
                 _semantic_flow_page(
                     pdf,
@@ -1579,7 +1757,7 @@ def _build_pdf_report(
             except Exception as e:
                 logger.warning("Semantic flow page skipped: %s", e)
 
-        if trajectory_report is not None:
+        if show_trajectory_stability:
             r = trajectory_report
             rows = [
                 [
@@ -1619,10 +1797,14 @@ def _build_pdf_report(
                 0.90,
                 "Per-dimension temporal-smoothness metrics for the latent trajectory.\n"
                 "Lower zero-crossing, direction-flip, and relative-jitter values indicate\n"
-                "a smoother embedding (supports the framework's stability assumption).",
+                "a smoother embedding (supports the framework's stability assumption).\n"
+                r"Relative jitter compares $\mathrm{mean}(|\Delta z|)$ with "
+                r"$\mathrm{mean}(|z-z_{\mathrm{center}}|)$.",
                 ha="left",
                 va="top",
                 fontsize=9,
+                fontfamily="DejaVu Sans",
+                math_fontfamily="dejavusans",
                 color="gray",
             )
 
@@ -1649,10 +1831,10 @@ def _build_pdf_report(
                 "  - Zero-crossing rate: fraction of consecutive steps where the centered\n"
                 "    latent value flips sign. Lower => trajectory stays on one side of the\n"
                 "    reference for longer (less oscillation).\n"
-                "  - Direction-flip rate: fraction of steps where the step direction (delta z)\n"
+                "  - Direction-flip rate: fraction of steps where the latent step direction\n"
                 "    reverses sign. Lower => monotone, smoother dynamics.\n"
-                "  - Relative jitter: mean(|delta z|) / mean(|z - center|). Step size relative\n"
-                "    to typical displacement from the reference. Lower => small smooth steps\n"
+                "  - Relative jitter: average latent step size divided by average displacement\n"
+                "    from the reference. Lower => small smooth steps\n"
                 "    relative to overall amplitude.\n"
                 "  - Occupancy positive / negative: fraction of time the centered trajectory\n"
                 "    sits above / below the deadband. Asymmetry can flag regime drift.\n"
@@ -1679,7 +1861,7 @@ def _build_pdf_report(
 
         # Feature-axis page last (and only for multivariate inputs), matching
         # its position in the cover summary.
-        if getattr(explanation, "channel_horizon_attributions", None) is not None:
+        if show_feature_axis:
             try:
                 _channel_axis_page(
                     pdf,
@@ -1690,7 +1872,18 @@ def _build_pdf_report(
             except Exception as e:
                 logger.warning("Feature-axis page skipped: %s", e)
 
-        if integrated_gradients_report is not None:
+        if show_feature_axis_stability:
+            try:
+                _feature_axis_embedding_stability_page(
+                    pdf,
+                    plt,
+                    report=feature_axis_embedding_stability_report,
+                    channel_labels=channel_labels,
+                )
+            except Exception as e:
+                logger.warning("Feature-axis embedding-stability page skipped: %s", e)
+
+        if show_integrated_gradients:
             try:
                 _integrated_gradients_page(
                     pdf,
@@ -1743,6 +1936,27 @@ def _trajectory_report_to_dict(report: TrajectoryStabilityReport | None) -> dict
     }
 
 
+def _feature_axis_embedding_stability_to_dict(
+    report: PerChannelEmbeddingStabilityReport | None,
+    *,
+    channel_labels: list[str] | None = None,
+) -> dict[str, Any] | None:
+    """Convert a feature-axis embedding-stability report to JSON."""
+    if report is None:
+        return None
+    frame = _feature_axis_embedding_stability_frame(report, channel_labels)
+    return {
+        "channel_labels": frame["feature"].tolist(),
+        "lip_ratio_mean": _array_to_jsonable(frame["lip_ratio_mean"].to_numpy()),
+        "lip_ratio_p50": _array_to_jsonable(frame["lip_ratio_p50"].to_numpy()),
+        "lip_ratio_p95": _array_to_jsonable(frame["lip_ratio_p95"].to_numpy()),
+        "lip_ratio_max": _array_to_jsonable(frame["lip_ratio_max"].to_numpy()),
+        "n_trials_per_channel": _array_to_jsonable(frame["n_trials_per_channel"].to_numpy()),
+        "n_unique_windows": int(report.n_unique_windows),
+        "step_delta_norm_mean": _scalar_to_jsonable(report.step_delta_norm_mean),
+    }
+
+
 def _integrated_gradients_to_dict(
     integrated_gradients_report: dict[str, Any] | None,
     *,
@@ -1785,6 +1999,8 @@ def _explanation_to_dict(
     dataset_name: str | None = None,
     include_full_arrays: bool = True,
     trajectory_report: TrajectoryStabilityReport | None = None,
+    feature_axis_embedding_stability_report: PerChannelEmbeddingStabilityReport | None = None,
+    channel_labels: list[str] | None = None,
     integrated_gradients_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Render the (forecast, explanation) pair as a JSON-serializable dict."""
@@ -1837,16 +2053,27 @@ def _explanation_to_dict(
         "trajectory_stability": _trajectory_report_to_dict(trajectory_report),
     }
 
-    channel_attribution = getattr(explanation, "channel_horizon_attributions", None)
-    if channel_attribution is not None:
-        feature_axis: dict[str, Any] = {
-            "method": getattr(explanation, "channel_flow_method", None),
-            "channel_horizon_attributions": _array_to_jsonable(np.asarray(channel_attribution)),
-            "residual_ratio_mean": _scalar_to_jsonable(explanation.channel_flow_residual_ratio_mean),
-            "residual_ratio_p95": _scalar_to_jsonable(explanation.channel_flow_residual_ratio_p95),
-        }
+    # Feature-axis (channel) attribution -- only present for multivariate inputs.
+    chan_attrib = getattr(explanation, "channel_horizon_attributions", None)
+    stability_block = _feature_axis_embedding_stability_to_dict(
+        feature_axis_embedding_stability_report,
+        channel_labels=channel_labels,
+    )
+    if chan_attrib is not None or stability_block is not None:
+        feature_axis: dict[str, Any] = {}
+        if chan_attrib is not None:
+            feature_axis.update(
+                {
+                    "method": getattr(explanation, "channel_flow_method", None),
+                    "channel_horizon_attributions": _array_to_jsonable(np.asarray(chan_attrib)),
+                    "residual_ratio_mean": _scalar_to_jsonable(explanation.channel_flow_residual_ratio_mean),
+                    "residual_ratio_p95": _scalar_to_jsonable(explanation.channel_flow_residual_ratio_p95),
+                }
+            )
         if include_full_arrays and getattr(explanation, "per_channel_flow", None) is not None:
             feature_axis["per_channel_flow"] = _array_to_jsonable(np.asarray(explanation.per_channel_flow))
+        if stability_block is not None:
+            feature_axis["embedding_stability"] = stability_block
         explanation_block["feature_axis"] = feature_axis
 
     if include_full_arrays:
@@ -1884,6 +2111,8 @@ def _save_explanation_json(
     include_full_arrays: bool = True,
     indent: int | None = 2,
     trajectory_report: TrajectoryStabilityReport | None = None,
+    feature_axis_embedding_stability_report: PerChannelEmbeddingStabilityReport | None = None,
+    channel_labels: list[str] | None = None,
     integrated_gradients_report: dict[str, Any] | None = None,
 ) -> Path:
     """Persist the (forecast, explanation) pair as a JSON file."""
@@ -1898,6 +2127,8 @@ def _save_explanation_json(
         dataset_name=dataset_name,
         include_full_arrays=include_full_arrays,
         trajectory_report=trajectory_report,
+        feature_axis_embedding_stability_report=feature_axis_embedding_stability_report,
+        channel_labels=channel_labels,
         integrated_gradients_report=integrated_gradients_report,
     )
     with out_path.open("w", encoding="utf-8") as fh:
@@ -2065,6 +2296,26 @@ def _run_interpretability(
     except Exception as e:
         logger.warning("Trajectory stability skipped: %s", e)
 
+    feature_axis_embedding_stability_report: PerChannelEmbeddingStabilityReport | None = None
+    if channel_axis:
+        try:
+            feature_axis_embedding_stability_report = compute_per_channel_embedding_stability(
+                model,
+                x_context_ct,
+                seq_len=seq_len,
+                input_mask_t=input_mask_l,
+                device=device,
+            )
+        except Exception as e:
+            logger.warning("Feature-axis embedding stability skipped: %s", e)
+
+    if write_pdf and feature_axis_embedding_stability_report is not None:
+        _save_feature_axis_embedding_stability_csv(
+            run_dir,
+            feature_axis_embedding_stability_report,
+            columns_to_process,
+        )
+
     integrated_gradients_report: dict[str, Any] | None = None
     if integrated_gradients:
         model.eval()
@@ -2097,6 +2348,8 @@ def _run_interpretability(
             timestamp_column=timestamp_column,
             dataset_name=dataset_name,
             trajectory_report=trajectory_report,
+            feature_axis_embedding_stability_report=feature_axis_embedding_stability_report,
+            channel_labels=columns_to_process,
             integrated_gradients_report=integrated_gradients_report,
         )
         logger.info("Interpretability JSON written to: %s", run_dir / "explanation.json")
@@ -2114,6 +2367,7 @@ def _run_interpretability(
             top_k=interpretability_top_k,
             dataset_name=dataset_name,
             trajectory_report=trajectory_report,
+            feature_axis_embedding_stability_report=feature_axis_embedding_stability_report,
             context_len=seq_len,
             forecast_horizon=forecast_horizon,
             channel_labels=columns_to_process,

--- a/forecasting/sdk/quick_example.py
+++ b/forecasting/sdk/quick_example.py
@@ -90,8 +90,10 @@ if __name__ == "__main__":
     #   - "pdf"  -> writes forecast.csv + lag_horizon_*.csv/png + explanation_report.pdf
     #   - None   -> writes both (full bundle)
     interp_out_dir = Path(__file__).resolve().parent / "interpretability_output"
-    # Add two derived channels so the feature-attribution page is included. Replace
-    # these with the actual feature columns used by your model in production.
+    # Add two derived channels so the feature-attribution and feature-axis
+    # embedding-stability pages are included. The run also writes the complete
+    # feature_axis_embedding_stability.csv report. Replace these with the actual
+    # feature columns used by your model in production.
     df_interp = df.copy()
     df_interp[f"{target_col}_diff"] = df_interp[target_col].diff().fillna(0.0)
     df_interp[f"{target_col}_roll12"] = df_interp[target_col].rolling(window=12, min_periods=1).mean()
@@ -118,3 +120,4 @@ if __name__ == "__main__":
         interp_df.head().to_string(index=False),
     )
     logger.info("\nReport bundle written under: %s", interp_out_dir)
+    logger.info("Multivariate input includes feature-axis attribution and stability pages.")

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -377,6 +377,36 @@ def test_interpretability_sdk_defaults_match_algorithms():
     assert sdk_params["integrated_gradients_reduce"].default == ig_params["reduce"].default
 
 
+def test_feature_axis_embedding_stability_csv_contains_complete_report(tmp_path):
+    report = SimpleNamespace(
+        lip_ratio_mean=np.array([0.1, 0.2], dtype=np.float32),
+        lip_ratio_max=np.array([0.4, 0.5], dtype=np.float32),
+        lip_ratio_p50=np.array([0.08, 0.18], dtype=np.float32),
+        lip_ratio_p95=np.array([0.3, 0.4], dtype=np.float32),
+        n_trials_per_channel=np.array([7, 6], dtype=np.int64),
+        n_unique_windows=5,
+        step_delta_norm_mean=0.25,
+        n_channels=2,
+    )
+
+    path = forecasting._save_feature_axis_embedding_stability_csv(tmp_path, report, ["target", "feature"])
+    saved = pd.read_csv(path)
+
+    assert list(saved.columns) == [
+        "feature",
+        "lip_ratio_mean",
+        "lip_ratio_p50",
+        "lip_ratio_p95",
+        "lip_ratio_max",
+        "n_trials_per_channel",
+        "n_unique_windows",
+        "step_delta_norm_mean",
+    ]
+    assert saved["feature"].tolist() == ["target", "feature"]
+    assert saved["n_trials_per_channel"].tolist() == [7, 6]
+    assert saved["n_unique_windows"].tolist() == [5, 5]
+
+
 def test_explanation_json_groups_feature_axis_results():
     explanation = forecasting.ForecastExplanation(
         baseline_forecast=np.ones((2, 2), dtype=np.float32),
@@ -501,14 +531,35 @@ def test_run_interpretability_integrated_gradients_reaches_report(monkeypatch, t
             embedding_dim=1,
         )
 
+    def compute_per_channel_embedding_stability(model, series_ct, **kwargs):
+        captured["embedding_stability_model"] = model
+        captured["embedding_stability_series_ct"] = series_ct
+        captured["embedding_stability_kwargs"] = kwargs
+        return SimpleNamespace(
+            lip_ratio_mean=np.array([0.1, 0.2], dtype=np.float32),
+            lip_ratio_max=np.array([0.4, 0.5], dtype=np.float32),
+            lip_ratio_p50=np.array([0.08, 0.18], dtype=np.float32),
+            lip_ratio_p95=np.array([0.3, 0.4], dtype=np.float32),
+            n_trials_per_channel=np.array([7, 7], dtype=np.int64),
+            n_unique_windows=5,
+            step_delta_norm_mean=0.25,
+            n_channels=2,
+        )
+
     def build_pdf_report(pdf_path, **kwargs):
         captured["pdf_report"] = kwargs["integrated_gradients_report"]
+        captured["embedding_stability_report"] = kwargs["feature_axis_embedding_stability_report"]
         captured["channel_labels"] = kwargs["channel_labels"]
         pdf_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
         return pdf_path
 
     monkeypatch.setattr(forecasting, "explain_forecast", lambda *args, **kwargs: explanation)
     monkeypatch.setattr(forecasting, "compute_trajectory_stability", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        forecasting,
+        "compute_per_channel_embedding_stability",
+        compute_per_channel_embedding_stability,
+    )
     monkeypatch.setattr(ig, "integrated_gradients_embedding", integrated_gradients_embedding)
     monkeypatch.setattr(forecasting, "_normalization_statistics_gradient", normalization_statistics_gradient)
     monkeypatch.setattr(forecasting, "_save_lag_horizon_artifacts", lambda *args, **kwargs: None)
@@ -554,8 +605,19 @@ def test_run_interpretability_integrated_gradients_reaches_report(monkeypatch, t
 
     payload = json.loads((run_dir / "explanation.json").read_text(encoding="utf-8"))
     ig_payload = payload["explanation"]["integrated_gradients"]
+    stability_payload = payload["explanation"]["feature_axis"]["embedding_stability"]
     assert ig_payload["channel_labels"] == ["target", "feature"]
     assert ig_payload["channel_abs_effect"] == [10.0, 10.0]
+    assert stability_payload["channel_labels"] == ["target", "feature"]
+    assert stability_payload["lip_ratio_mean"] == pytest.approx([0.1, 0.2])
+    assert stability_payload["n_trials_per_channel"] == [7, 7]
+    assert captured["embedding_stability_model"] is model
+    np.testing.assert_array_equal(
+        captured["embedding_stability_series_ct"],
+        df[["target", "feature"]].tail(4).to_numpy(dtype=np.float32).T,
+    )
+    assert captured["embedding_stability_kwargs"]["seq_len"] == 4
+    assert captured["embedding_stability_kwargs"]["device"] == torch.device("cpu")
     assert captured["input_mask"] == [1, 1, 1, 1]
     assert captured["ig_shape"] == (2, 4)
     assert captured["ig_kwargs"]["internal_batch_size"] == 3
@@ -563,8 +625,10 @@ def test_run_interpretability_integrated_gradients_reaches_report(monkeypatch, t
     assert captured["grad_through_norm"] is True
     assert captured["channel_labels"] == ["target", "feature"]
     assert captured["pdf_report"]["attribution"].shape == (2, 4)
+    assert captured["embedding_stability_report"].n_channels == 2
     assert (run_dir / "integrated_gradients_attributions.csv").exists()
     assert (run_dir / "integrated_gradients_channel_summary.csv").exists()
+    assert (run_dir / "feature_axis_embedding_stability.csv").exists()
 
 
 def test_normalization_statistics_gradient_is_scoped():


### PR DESCRIPTION
## Summary

- Add feature-axis embedding stability analysis to SDK interpretability runs
- Include embedding stability results in JSON and CSV outputs
- Add an embedding stability section to the generated PDF report
- Improve mathematical expression formatting and report section numbering
- Update SDK documentation and the quick example