### PR TITLE
Make RevIN statistics request-local for concurrent forecasts

### DIFF
--- a/forecasting/backbone.py
+++ b/forecasting/backbone.py
@@ -26,9 +26,12 @@ import sys
 import types
 import warnings
 from argparse import Namespace
+from contextlib import contextmanager
+from contextvars import ContextVar
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
+from weakref import WeakKeyDictionary
 
 logger = logging.getLogger(__name__)
 
@@ -206,15 +209,30 @@ def nanstd(tensor, dim=None, keepdim=False):
 
 
 RevINStatistics = tuple[torch.Tensor, torch.Tensor]
+_RevINGradientContexts = tuple[tuple[object, bool], ...]
+_REVIN_GRADIENT_CONTEXTS: ContextVar[_RevINGradientContexts] = ContextVar(
+    "revin_gradient_contexts",
+    default=(),
+)
+_REVIN_LEGACY_STATISTICS: ContextVar[WeakKeyDictionary[nn.Module, RevINStatistics] | None] = ContextVar(
+    "revin_legacy_statistics",
+    default=None,
+)
+
+
+def _revin_statistics_gradients_enabled() -> bool:
+    contexts = _REVIN_GRADIENT_CONTEXTS.get()
+    return bool(contexts and contexts[-1][1])
 
 
 class RevIN(nn.Module):
     """Reversible instance normalization with request-local statistics.
 
     A caller that later denormalizes must request the statistics produced by
-    the matching normalization call and pass them back explicitly. Keeping
-    these tensors out of module state allows one model instance to serve
-    concurrent requests safely.
+    the matching normalization call and pass them back explicitly. Legacy
+    callers that omit return_statistics keep their latest statistics in the
+    current thread/task context instead of module state, so the original
+    sequential norm then denorm API remains safe across requests.
     """
 
     def __init__(self, num_features: int, eps: float = 1e-5, affine: bool = False):
@@ -240,14 +258,34 @@ class RevIN(nn.Module):
             normalized = self._normalize(x, statistics)
             if return_statistics:
                 return normalized, statistics
+            self._remember_legacy_statistics(statistics)
             return normalized
         if mode == "denorm":
             if statistics is None:
-                raise ValueError("RevIN denormalization requires statistics from the matching normalization call")
+                statistics = self._legacy_statistics()
             if return_statistics:
                 raise ValueError("return_statistics is only supported when mode='norm'")
             return self._denormalize(x, statistics)
         raise NotImplementedError
+
+    @staticmethod
+    @contextmanager
+    def statistics_gradient_context(*, enabled: bool):
+        """Select statistics autograd behavior for the current thread/task.
+
+        Entries are removed by identity instead of reset with a ContextVar
+        token. That keeps overlapping contexts correct even if callers exit
+        them out of LIFO order.
+        """
+
+        marker = object()
+        contexts = _REVIN_GRADIENT_CONTEXTS.get()
+        _REVIN_GRADIENT_CONTEXTS.set((*contexts, (marker, enabled)))
+        try:
+            yield
+        finally:
+            contexts = _REVIN_GRADIENT_CONTEXTS.get()
+            _REVIN_GRADIENT_CONTEXTS.set(tuple(context for context in contexts if context[0] is not marker))
 
     def _init_params(self):
         self.affine_weight = nn.Parameter(torch.ones(1, self.num_features, 1))
@@ -259,9 +297,34 @@ class RevIN(nn.Module):
         n_channels = x.shape[1]
         mask = mask.to(device=x.device).unsqueeze(1).expand(-1, n_channels, -1).bool()
         masked_x = torch.where(mask, x, torch.nan)
-        mean = torch.nanmean(masked_x, dim=-1, keepdim=True).detach()
-        stdev = nanstd(masked_x, dim=-1, keepdim=True).detach() + self.eps
+        mean = torch.nanmean(masked_x, dim=-1, keepdim=True)
+        detached_stdev = nanstd(masked_x, dim=-1, keepdim=True).detach()
+
+        if not _revin_statistics_gradients_enabled():
+            return mean.detach(), detached_stdev + self.eps
+
+        variance = (masked_x - mean).square().nanmean(dim=-1, keepdim=True)
+        eps_sq = torch.as_tensor(float(self.eps) ** 2, dtype=variance.dtype, device=variance.device)
+        safe_stdev = variance.clamp_min(eps_sq).sqrt()
+        stdev = detached_stdev + safe_stdev - safe_stdev.detach() + self.eps
         return mean, stdev
+
+    def _remember_legacy_statistics(self, statistics: RevINStatistics) -> None:
+        statistics_by_module = _REVIN_LEGACY_STATISTICS.get()
+        updated: WeakKeyDictionary[nn.Module, RevINStatistics] = WeakKeyDictionary()
+        if statistics_by_module is not None:
+            updated.update(statistics_by_module)
+        updated[self] = statistics
+        _REVIN_LEGACY_STATISTICS.set(updated)
+
+    def _legacy_statistics(self) -> RevINStatistics:
+        statistics_by_module = _REVIN_LEGACY_STATISTICS.get()
+        if statistics_by_module is None or self not in statistics_by_module:
+            raise ValueError(
+                "RevIN denormalization requires statistics from a matching normalization call "
+                "in the current thread/task context"
+            )
+        return statistics_by_module[self]
 
     def _normalize(self, x, statistics: RevINStatistics):
         mean, stdev = statistics
@@ -605,7 +668,7 @@ class BackboneModel(nn.Module):
         if input_mask is None:
             input_mask = torch.ones((batch_size, seq_len)).to(x_enc.device)
 
-        x_enc = self.normalizer(x=x_enc, mask=input_mask, mode="norm")
+        x_enc, _ = self.normalizer(x=x_enc, mask=input_mask, mode="norm", return_statistics=True)
         x_enc = torch.nan_to_num(x_enc, nan=0, posinf=0, neginf=0)
 
         input_mask_patch_view = Masking.convert_seq_to_patch_view(input_mask, self.patch_len)
@@ -708,7 +771,7 @@ class BackboneModel(nn.Module):
         if input_mask is None:
             input_mask = torch.ones((batch_size, seq_len)).to(x_enc.device)
 
-        x_enc = self.normalizer(x=x_enc, mask=input_mask, mode="norm")
+        x_enc, _ = self.normalizer(x=x_enc, mask=input_mask, mode="norm", return_statistics=True)
         x_enc = torch.nan_to_num(x_enc, nan=0, posinf=0, neginf=0)
         x_enc = self.tokenizer(x=x_enc)
         enc_in = self.patch_embedding(x_enc, mask=input_mask)

--- a/forecasting/backbone.py
+++ b/forecasting/backbone.py
@@ -205,7 +205,18 @@ def nanstd(tensor, dim=None, keepdim=False):
     return nanvar(tensor, dim=dim, keepdim=keepdim).sqrt()
 
 
+RevINStatistics = tuple[torch.Tensor, torch.Tensor]
+
+
 class RevIN(nn.Module):
+    """Reversible instance normalization with request-local statistics.
+
+    A caller that later denormalizes must request the statistics produced by
+    the matching normalization call and pass them back explicitly. Keeping
+    these tensors out of module state allows one model instance to serve
+    concurrent requests safely.
+    """
+
     def __init__(self, num_features: int, eps: float = 1e-5, affine: bool = False):
         super().__init__()
         self.num_features = num_features
@@ -214,43 +225,60 @@ class RevIN(nn.Module):
         if self.affine:
             self._init_params()
 
-    def forward(self, x: torch.Tensor, mode: str = "norm", mask: torch.Tensor = None):
+    def forward(
+        self,
+        x: torch.Tensor,
+        mode: str = "norm",
+        mask: torch.Tensor | None = None,
+        statistics: RevINStatistics | None = None,
+        return_statistics: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, RevINStatistics]:
         if mode == "norm":
-            self._get_statistics(x, mask=mask)
-            x = self._normalize(x)
-        elif mode == "denorm":
-            x = self._denormalize(x)
-        else:
-            raise NotImplementedError
-        return x
+            if statistics is not None:
+                raise ValueError("statistics must not be provided when mode='norm'")
+            statistics = self._get_statistics(x, mask=mask)
+            normalized = self._normalize(x, statistics)
+            if return_statistics:
+                return normalized, statistics
+            return normalized
+        if mode == "denorm":
+            if statistics is None:
+                raise ValueError("RevIN denormalization requires statistics from the matching normalization call")
+            if return_statistics:
+                raise ValueError("return_statistics is only supported when mode='norm'")
+            return self._denormalize(x, statistics)
+        raise NotImplementedError
 
     def _init_params(self):
         self.affine_weight = nn.Parameter(torch.ones(1, self.num_features, 1))
         self.affine_bias = nn.Parameter(torch.zeros(1, self.num_features, 1))
 
-    def _get_statistics(self, x, mask=None):
+    def _get_statistics(self, x, mask=None) -> RevINStatistics:
         if mask is None:
-            mask = torch.ones((x.shape[0], x.shape[-1]))
+            mask = torch.ones((x.shape[0], x.shape[-1]), device=x.device)
         n_channels = x.shape[1]
-        mask = mask.unsqueeze(1).repeat(1, n_channels, 1).bool()
+        mask = mask.to(device=x.device).unsqueeze(1).expand(-1, n_channels, -1).bool()
         masked_x = torch.where(mask, x, torch.nan)
-        self.mean = torch.nanmean(masked_x, dim=-1, keepdim=True).detach()
-        self.stdev = nanstd(masked_x, dim=-1, keepdim=True).detach() + self.eps
+        mean = torch.nanmean(masked_x, dim=-1, keepdim=True).detach()
+        stdev = nanstd(masked_x, dim=-1, keepdim=True).detach() + self.eps
+        return mean, stdev
 
-    def _normalize(self, x):
-        x = x - self.mean
-        x = x / self.stdev
+    def _normalize(self, x, statistics: RevINStatistics):
+        mean, stdev = statistics
+        x = x - mean
+        x = x / stdev
         if self.affine:
             x = x * self.affine_weight
             x = x + self.affine_bias
         return x
 
-    def _denormalize(self, x):
+    def _denormalize(self, x, statistics: RevINStatistics):
+        mean, stdev = statistics
         if self.affine:
             x = x - self.affine_bias
             x = x / (self.affine_weight + self.eps * self.eps)
-        x = x * self.stdev
-        x = x + self.mean
+        x = x * stdev
+        x = x + mean
         return x
 
 
@@ -615,7 +643,12 @@ class BackboneModel(nn.Module):
             mask = self.mask_generator.generate_mask(x=x_enc, input_mask=input_mask)
             mask = mask.to(x_enc.device)
 
-        x_enc = self.normalizer(x=x_enc, mask=mask * input_mask, mode="norm")
+        x_enc, revin_statistics = self.normalizer(
+            x=x_enc,
+            mask=mask * input_mask,
+            mode="norm",
+            return_statistics=True,
+        )
         x_enc = torch.nan_to_num(x_enc, nan=0, posinf=0, neginf=0)
         x_enc = self.tokenizer(x=x_enc)
         enc_in = self.patch_embedding(x_enc, mask=mask)
@@ -636,13 +669,18 @@ class BackboneModel(nn.Module):
         enc_out = self._apply_cross_channel(enc_out)
 
         dec_out = self.head(enc_out)
-        dec_out = self.normalizer(x=dec_out, mode="denorm")
+        dec_out = self.normalizer(x=dec_out, mode="denorm", statistics=revin_statistics)
         return TimeseriesOutputs(input_mask=input_mask, reconstruction=dec_out, pretrain_mask=mask, illegal_output=None)
 
     def forecast(self, *, x_enc: torch.Tensor, input_mask: torch.Tensor = None, **kwargs) -> TimeseriesOutputs:
         batch_size, n_channels, seq_len = x_enc.shape
 
-        x_enc = self.normalizer(x=x_enc, mask=input_mask, mode="norm")
+        x_enc, revin_statistics = self.normalizer(
+            x=x_enc,
+            mask=input_mask,
+            mode="norm",
+            return_statistics=True,
+        )
         x_enc = torch.nan_to_num(x_enc, nan=0, posinf=0, neginf=0)
         x_enc = self.tokenizer(x=x_enc)
         enc_in = self.patch_embedding(x_enc, mask=torch.ones_like(input_mask))
@@ -660,7 +698,7 @@ class BackboneModel(nn.Module):
         enc_out = self._apply_cross_channel(enc_out)
 
         dec_out = self.head(enc_out)
-        dec_out = self.normalizer(x=dec_out, mode="denorm")
+        dec_out = self.normalizer(x=dec_out, mode="denorm", statistics=revin_statistics)
         return TimeseriesOutputs(input_mask=input_mask, forecast=dec_out)
 
     def classify(

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -1245,7 +1245,11 @@ def _normalization_statistics_gradient(model: torch.nn.Module, *, enabled: bool)
         original = module._get_statistics
         had_instance_override = "_get_statistics" in vars(module)
 
-        def _get_statistics(self: Any, x: torch.Tensor, mask: torch.Tensor | None = None) -> None:
+        def _get_statistics(
+            self: Any,
+            x: torch.Tensor,
+            mask: torch.Tensor | None = None,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
             if mask is None:
                 mask = torch.ones((x.shape[0], x.shape[-1]), device=x.device)
             expanded = mask.to(device=x.device).unsqueeze(1).expand(-1, x.shape[1], -1).bool()
@@ -1255,8 +1259,8 @@ def _normalization_statistics_gradient(model: torch.nn.Module, *, enabled: bool)
             raw_stdev = variance.sqrt()
             eps_sq = torch.as_tensor(float(self.eps) ** 2, dtype=variance.dtype, device=variance.device)
             safe_stdev = variance.clamp_min(eps_sq).sqrt()
-            self.mean = mean
-            self.stdev = raw_stdev.detach() + safe_stdev - safe_stdev.detach() + self.eps
+            stdev = raw_stdev.detach() + safe_stdev - safe_stdev.detach() + self.eps
+            return mean, stdev
 
         module._get_statistics = types.MethodType(_get_statistics, module)
         restores.append((module, original, had_instance_override))

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import tempfile
-import types
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +33,7 @@ except ImportError:
 
 
 # Clean absolute imports - package is installed in editable mode
+from backbone import RevIN
 from backbone.utils.utils import control_randomness
 from channel_stability import (
     PerChannelEmbeddingStabilityReport,
@@ -1232,47 +1232,10 @@ def _feature_axis_embedding_stability_page(
 
 @contextmanager
 def _normalization_statistics_gradient(model: torch.nn.Module, *, enabled: bool):
-    """Temporarily include supported normalization statistics in autograd."""
-    if not enabled:
-        yield 0
-        return
-
-    restores: list[tuple[object, object, bool]] = []
-    for module in model.modules():
-        if not all(hasattr(module, name) for name in ("_get_statistics", "_normalize", "eps")):
-            continue
-
-        original = module._get_statistics
-        had_instance_override = "_get_statistics" in vars(module)
-
-        def _get_statistics(
-            self: Any,
-            x: torch.Tensor,
-            mask: torch.Tensor | None = None,
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            if mask is None:
-                mask = torch.ones((x.shape[0], x.shape[-1]), device=x.device)
-            expanded = mask.to(device=x.device).unsqueeze(1).expand(-1, x.shape[1], -1).bool()
-            masked_x = torch.where(expanded, x, torch.full_like(x, float("nan")))
-            mean = torch.nanmean(masked_x, dim=-1, keepdim=True)
-            variance = (masked_x - mean).square().nanmean(dim=-1, keepdim=True)
-            raw_stdev = variance.sqrt()
-            eps_sq = torch.as_tensor(float(self.eps) ** 2, dtype=variance.dtype, device=variance.device)
-            safe_stdev = variance.clamp_min(eps_sq).sqrt()
-            stdev = raw_stdev.detach() + safe_stdev - safe_stdev.detach() + self.eps
-            return mean, stdev
-
-        module._get_statistics = types.MethodType(_get_statistics, module)
-        restores.append((module, original, had_instance_override))
-
-    try:
-        yield len(restores)
-    finally:
-        for module, original, had_instance_override in reversed(restores):
-            if had_instance_override:
-                module._get_statistics = original
-            else:
-                delattr(module, "_get_statistics")
+    """Select request-local RevIN statistics autograd without mutating models."""
+    normalizer_count = sum(isinstance(module, RevIN) for module in model.modules())
+    with RevIN.statistics_gradient_context(enabled=enabled):
+        yield normalizer_count if enabled else 0
 
 
 def _compute_integrated_gradients_report(

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -638,11 +638,13 @@ def test_normalization_statistics_gradient_is_scoped():
             self.eps = 1e-5
 
         def _get_statistics(self, x, mask=None):
-            self.mean = x.mean(dim=-1, keepdim=True).detach()
-            self.stdev = x.std(dim=-1, keepdim=True, correction=0).detach() + self.eps
+            mean = x.mean(dim=-1, keepdim=True).detach()
+            stdev = x.std(dim=-1, keepdim=True, correction=0).detach() + self.eps
+            return mean, stdev
 
-        def _normalize(self, x):
-            return (x - self.mean) / self.stdev
+        def _normalize(self, x, statistics):
+            mean, stdev = statistics
+            return (x - mean) / stdev
 
     model = torch.nn.Sequential(Normalizer())
     normalizer = model[0]
@@ -650,15 +652,15 @@ def test_normalization_statistics_gradient_is_scoped():
 
     assert "_get_statistics" not in vars(normalizer)
     with forecasting._normalization_statistics_gradient(model, enabled=True) as patched:
-        normalizer._get_statistics(x)
+        mean, stdev = normalizer._get_statistics(x)
         assert patched == 1
-        assert normalizer.mean.requires_grad
-        assert normalizer.stdev.requires_grad
+        assert mean.requires_grad
+        assert stdev.requires_grad
 
     assert "_get_statistics" not in vars(normalizer)
-    normalizer._get_statistics(x)
-    assert not normalizer.mean.requires_grad
-    assert not normalizer.stdev.requires_grad
+    mean, stdev = normalizer._get_statistics(x)
+    assert not mean.requires_grad
+    assert not stdev.requires_grad
 
 
 def test_perform_forecasting_return_all_channels_rejects_timestamp_collision():

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+from backbone import RevIN
 from sdk import forecasting
 
 
@@ -632,33 +633,19 @@ def test_run_interpretability_integrated_gradients_reaches_report(monkeypatch, t
 
 
 def test_normalization_statistics_gradient_is_scoped():
-    class Normalizer(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.eps = 1e-5
-
-        def _get_statistics(self, x, mask=None):
-            mean = x.mean(dim=-1, keepdim=True).detach()
-            stdev = x.std(dim=-1, keepdim=True, correction=0).detach() + self.eps
-            return mean, stdev
-
-        def _normalize(self, x, statistics):
-            mean, stdev = statistics
-            return (x - mean) / stdev
-
-    model = torch.nn.Sequential(Normalizer())
+    model = torch.nn.Sequential(RevIN(num_features=1))
     normalizer = model[0]
     x = torch.arange(12, dtype=torch.float32).reshape(1, 2, 6).requires_grad_(True)
 
     assert "_get_statistics" not in vars(normalizer)
     with forecasting._normalization_statistics_gradient(model, enabled=True) as patched:
-        mean, stdev = normalizer._get_statistics(x)
+        _, (mean, stdev) = normalizer(x, mode="norm", return_statistics=True)
         assert patched == 1
         assert mean.requires_grad
         assert stdev.requires_grad
 
     assert "_get_statistics" not in vars(normalizer)
-    mean, stdev = normalizer._get_statistics(x)
+    _, (mean, stdev) = normalizer(x, mode="norm", return_statistics=True)
     assert not mean.requires_grad
     assert not stdev.requires_grad
 

--- a/forecasting/sdk/tests/test_revin_concurrency.py
+++ b/forecasting/sdk/tests/test_revin_concurrency.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+import torch
+from backbone import BackboneModel, RevIN
+
+
+@pytest.mark.parametrize("affine", [False, True])
+def test_revin_round_trip_uses_explicit_statistics(affine: bool):
+    revin = RevIN(num_features=1, affine=affine)
+    x = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
+
+    normalized, statistics = revin(x, mode="norm", return_statistics=True)
+    restored = revin(normalized, mode="denorm", statistics=statistics)
+
+    assert not hasattr(revin, "mean")
+    assert not hasattr(revin, "stdev")
+    torch.testing.assert_close(restored, x)
+
+
+def test_revin_denormalization_requires_matching_statistics():
+    revin = RevIN(num_features=1)
+    x = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
+    normalized = revin(x, mode="norm")
+
+    with pytest.raises(ValueError, match="matching normalization call"):
+        revin(normalized, mode="denorm")
+
+
+class _CoordinatedTokenizer:
+    """Pause one forecast after RevIN norm until a second forecast has normalized."""
+
+    def __init__(self):
+        self._label = threading.local()
+        self.request_one_normalized = threading.Event()
+        self.request_two_normalized = threading.Event()
+
+    def set_request_label(self, label: str):
+        self._label.value = label
+
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        if self._label.value == "request_one":
+            self.request_one_normalized.set()
+            assert self.request_two_normalized.wait(timeout=5)
+        else:
+            self.request_two_normalized.set()
+        return x.unfold(dimension=-1, size=1, step=1)
+
+
+class _IdentityPatchEmbedding(torch.nn.Module):
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        return x
+
+
+class _IdentityEncoder(torch.nn.Module):
+    def forward(self, *, inputs_embeds: torch.Tensor, attention_mask: torch.Tensor):
+        return SimpleNamespace(last_hidden_state=inputs_embeds)
+
+
+class _LastPatchHead(torch.nn.Module):
+    def forward(self, enc_out: torch.Tensor) -> torch.Tensor:
+        return enc_out[:, :, -1, :]
+
+
+class _ForecastHarness:
+    """Minimal object that executes the production BackboneModel.forecast path."""
+
+    forecast = BackboneModel.forecast
+    _apply_cross_channel = BackboneModel._apply_cross_channel
+
+    def __init__(self):
+        self.normalizer = RevIN(num_features=1)
+        self.tokenizer = _CoordinatedTokenizer()
+        self.patch_embedding = _IdentityPatchEmbedding()
+        self.encoder = _IdentityEncoder()
+        self.head = _LastPatchHead()
+        self.patch_len = 1
+        self.config = SimpleNamespace(d_model=1)
+        self.use_cross_channel = False
+
+
+def test_concurrent_forecasts_keep_revin_statistics_request_local():
+    model = _ForecastHarness()
+    input_mask = torch.ones((1, 4))
+    request_one = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
+    request_two = torch.tensor([[[100.0, 200.0, 300.0, 400.0]]])
+
+    def invoke(label: str, x: torch.Tensor):
+        if label == "request_two":
+            assert model.tokenizer.request_one_normalized.wait(timeout=5)
+        model.tokenizer.set_request_label(label)
+        return model.forecast(x_enc=x, input_mask=input_mask).forecast
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(invoke, "request_one", request_one)
+        second = pool.submit(invoke, "request_two", request_two)
+        output_one = first.result(timeout=10)
+        output_two = second.result(timeout=10)
+
+    torch.testing.assert_close(output_one, torch.tensor([[[4.0]]]))
+    torch.testing.assert_close(output_two, torch.tensor([[[400.0]]]))

--- a/forecasting/sdk/tests/test_revin_concurrency.py
+++ b/forecasting/sdk/tests/test_revin_concurrency.py
@@ -1,13 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+import gc
 import threading
+import weakref
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import Context
 from types import SimpleNamespace
 
 import pytest
 import torch
-from backbone import BackboneModel, RevIN
+from backbone import _REVIN_LEGACY_STATISTICS, BackboneModel, RevIN
+from sdk import forecasting
 
 
 @pytest.mark.parametrize("affine", [False, True])
@@ -18,18 +23,209 @@ def test_revin_round_trip_uses_explicit_statistics(affine: bool):
     normalized, statistics = revin(x, mode="norm", return_statistics=True)
     restored = revin(normalized, mode="denorm", statistics=statistics)
 
+    assert not statistics[0].requires_grad
+    assert not statistics[1].requires_grad
     assert not hasattr(revin, "mean")
     assert not hasattr(revin, "stdev")
     torch.testing.assert_close(restored, x)
 
 
-def test_revin_denormalization_requires_matching_statistics():
+def test_revin_legacy_sequential_round_trip_uses_context_local_statistics():
     revin = RevIN(num_features=1)
     x = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
     normalized = revin(x, mode="norm")
+    restored = revin(normalized, mode="denorm")
 
-    with pytest.raises(ValueError, match="matching normalization call"):
-        revin(normalized, mode="denorm")
+    torch.testing.assert_close(restored, x)
+
+
+def test_revin_denormalization_without_context_statistics_fails():
+    def invoke():
+        revin = RevIN(num_features=1)
+        x = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
+
+        with pytest.raises(ValueError, match="current thread/task context"):
+            revin(x, mode="denorm")
+
+    Context().run(invoke)
+
+
+def test_revin_legacy_statistics_release_dead_modules():
+    def invoke():
+        revin = RevIN(num_features=1)
+        reference = weakref.ref(revin)
+        revin(torch.tensor([[[1.0, 2.0, 3.0, 4.0]]]), mode="norm")
+
+        statistics_by_module = _REVIN_LEGACY_STATISTICS.get()
+        assert statistics_by_module is not None
+        assert len(statistics_by_module) == 1
+
+        del revin
+        gc.collect()
+
+        assert reference() is None
+        assert len(statistics_by_module) == 0
+
+    Context().run(invoke)
+
+
+def test_revin_legacy_statistics_are_copy_on_write_across_async_contexts():
+    revin = RevIN(num_features=1)
+    parent_input = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
+    child_input = torch.tensor([[[100.0, 200.0, 300.0, 400.0]]])
+    parent_normalized = revin(parent_input, mode="norm")
+
+    async def child_round_trip() -> torch.Tensor:
+        child_normalized = revin(child_input, mode="norm")
+        await asyncio.sleep(0)
+        return revin(child_normalized, mode="denorm")
+
+    child_output = asyncio.run(child_round_trip())
+    parent_output = revin(parent_normalized, mode="denorm")
+
+    torch.testing.assert_close(child_output, child_input)
+    torch.testing.assert_close(parent_output, parent_input)
+
+
+def test_revin_legacy_concurrent_round_trips_are_context_local():
+    revin = RevIN(num_features=1)
+    request_one_normalized = threading.Event()
+    request_two_normalized = threading.Event()
+    request_one = torch.tensor([[[1.0, 2.0, 3.0, 4.0]]])
+    request_two = torch.tensor([[[100.0, 200.0, 300.0, 400.0]]])
+
+    def round_trip(label: str, x: torch.Tensor) -> torch.Tensor:
+        if label == "request_two":
+            assert request_one_normalized.wait(timeout=5)
+
+        normalized = revin(x, mode="norm")
+
+        if label == "request_one":
+            request_one_normalized.set()
+            assert request_two_normalized.wait(timeout=5)
+        else:
+            request_two_normalized.set()
+
+        return revin(normalized, mode="denorm")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(round_trip, "request_one", request_one)
+        second = pool.submit(round_trip, "request_two", request_two)
+        output_one = first.result(timeout=10)
+        output_two = second.result(timeout=10)
+
+    torch.testing.assert_close(output_one, request_one)
+    torch.testing.assert_close(output_two, request_two)
+
+
+def _statistics(revin: RevIN, x: torch.Tensor):
+    _, statistics = revin(x, mode="norm", return_statistics=True)
+    return statistics
+
+
+def test_revin_gradient_statistics_preserve_forward_math():
+    revin = RevIN(num_features=1)
+    model = torch.nn.Sequential(revin)
+    x = torch.tensor([[[1.0, 2.0, 4.0, 8.0]]], requires_grad=True)
+
+    detached_mean, detached_stdev = _statistics(revin, x)
+    with forecasting._normalization_statistics_gradient(model, enabled=True) as normalizers:
+        normalized, (gradient_mean, gradient_stdev) = revin(x, mode="norm", return_statistics=True)
+
+    assert normalizers == 1
+    assert gradient_mean.requires_grad
+    assert gradient_stdev.requires_grad
+    torch.testing.assert_close(gradient_mean, detached_mean, rtol=0, atol=0)
+    torch.testing.assert_close(gradient_stdev, detached_stdev, rtol=0, atol=0)
+    torch.testing.assert_close(normalized, (x - detached_mean) / detached_stdev)
+
+    gradient = torch.autograd.grad(gradient_mean.sum() + gradient_stdev.sum(), x)[0]
+    assert torch.isfinite(gradient).all()
+
+
+def test_revin_gradient_statistics_use_finite_clamp_surrogate():
+    revin = RevIN(num_features=1)
+    model = torch.nn.Sequential(revin)
+    x = torch.ones((1, 1, 4), requires_grad=True)
+
+    with forecasting._normalization_statistics_gradient(model, enabled=True):
+        _, (_, stdev) = revin(x, mode="norm", return_statistics=True)
+
+    gradient = torch.autograd.grad(stdev.sum(), x)[0]
+    assert torch.isfinite(gradient).all()
+
+
+def test_normalization_statistics_gradient_handles_out_of_order_exits():
+    revin = RevIN(num_features=1)
+    model = torch.nn.Sequential(revin)
+    x = torch.arange(12, dtype=torch.float32).reshape(1, 2, 6).requires_grad_(True)
+    first = forecasting._normalization_statistics_gradient(model, enabled=True)
+    second = forecasting._normalization_statistics_gradient(model, enabled=True)
+
+    first.__enter__()
+    second.__enter__()
+    first.__exit__(None, None, None)
+    try:
+        mean, stdev = _statistics(revin, x)
+        assert mean.requires_grad
+        assert stdev.requires_grad
+        assert "_get_statistics" not in vars(revin)
+    finally:
+        second.__exit__(None, None, None)
+
+    mean, stdev = _statistics(revin, x)
+    assert not mean.requires_grad
+    assert not stdev.requires_grad
+    assert "_get_statistics" not in vars(revin)
+
+
+def test_normalization_statistics_gradient_disabled_flow_is_scoped():
+    revin = RevIN(num_features=1)
+    model = torch.nn.Sequential(revin)
+    x = torch.arange(12, dtype=torch.float32).reshape(1, 2, 6).requires_grad_(True)
+
+    with forecasting._normalization_statistics_gradient(model, enabled=True):
+        mean, stdev = _statistics(revin, x)
+        assert mean.requires_grad
+        assert stdev.requires_grad
+
+        with forecasting._normalization_statistics_gradient(model, enabled=False) as normalizers:
+            mean, stdev = _statistics(revin, x)
+            assert normalizers == 0
+            assert not mean.requires_grad
+            assert not stdev.requires_grad
+
+        mean, stdev = _statistics(revin, x)
+        assert mean.requires_grad
+        assert stdev.requires_grad
+
+    mean, stdev = _statistics(revin, x)
+    assert not mean.requires_grad
+    assert not stdev.requires_grad
+
+
+def test_normalization_statistics_gradient_is_thread_local():
+    revin = RevIN(num_features=1)
+    model = torch.nn.Sequential(revin)
+    barrier = threading.Barrier(2)
+
+    def invoke(enabled: bool) -> tuple[bool, bool]:
+        x = torch.arange(12, dtype=torch.float32).reshape(1, 2, 6).requires_grad_(True)
+        with forecasting._normalization_statistics_gradient(model, enabled=enabled):
+            barrier.wait(timeout=5)
+            mean, stdev = _statistics(revin, x)
+            barrier.wait(timeout=5)
+            return mean.requires_grad, stdev.requires_grad
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        enabled = pool.submit(invoke, True)
+        disabled = pool.submit(invoke, False)
+        enabled_result = enabled.result(timeout=10)
+        disabled_result = disabled.result(timeout=10)
+
+    assert enabled_result == (True, True)
+    assert disabled_result == (False, False)
+    assert "_get_statistics" not in vars(revin)
 
 
 class _CoordinatedTokenizer:


### PR DESCRIPTION
Closes #69

## Problem

The forecasting SDK caches one model instance for a checkpoint/configuration
key. RevIN previously stored each input's mean and standard deviation on that
shared module as mutable fields.

The forecast and reconstruction paths normalize an input, run the encoder and
head, then denormalize later. If another request normalizes on the same cached
model during that interval, the first request can be denormalized with the
second request's statistics and silently return a forecast on the wrong scale.

A deterministic repro pauses request A after normalization, lets request B
normalize, then resumes request A. Before this change, an input ending in 4
can return approximately 400 when the concurrent request is scaled from 100
to 400.

Integrated gradients had a second shared-state race: its statistics-gradient
context temporarily replaced `module._get_statistics` on the cached RevIN
instance. Overlapping contexts that exited out of LIFO order could disable
gradients while a request remained active and then leak the override after all
contexts exited.

## Root cause

Per-request tensors and per-request autograd behavior were stored on, or
installed onto, a shared model instance. The cache itself is useful and
remains unchanged; the unsafe part was making the cached model own request
state.

## Fix

- Make `_get_statistics` return a local `(mean, stdev)` pair rather than
  assigning module attributes.
- Have forecast and reconstruction pass that exact pair from normalization to
  denormalization.
- Have embedding and classification request explicit statistics and discard
  them, so normal model paths do not populate compatibility state.
- Preserve the legacy sequential `norm` then `denorm` RevIN API with a
  context-local, copy-on-write `WeakKeyDictionary`. It isolates threads/tasks,
  does not retain destroyed RevIN modules or their tensors, and cannot confuse
  a new module with a dead module through object-id reuse.
- Replace integrated-gradients method monkey-patching with an overlap-safe
  ContextVar stack. Entries are removed by marker identity, so non-LIFO exits
  cannot disable a still-active context or leak behavior afterward.
- Keep normal statistics detached. When statistics gradients are enabled, the
  forward mean/stdev values remain exactly equal to the detached path while
  stdev uses the existing variance-clamp surrogate for finite gradients.

The explicit statistics path is preferred for new callers and is used by
BackboneModel. The compatibility fallback intentionally preserves the original
"latest normalization in this context" sequential behavior for direct RevIN
callers.

This does not change checkpoint keys or parameters.

## Tests

- `PYTHONPATH=. .venv/bin/python -m pytest sdk/tests/test_revin_concurrency.py sdk/tests/test_forecasting.py::test_normalization_statistics_gradient_is_scoped -q --tb=short`
  - 14 passed
  - Covers explicit and legacy round trips, concurrent legacy isolation,
    async inherited-context copy-on-write, weak-key cleanup, exact forward
    math, finite clamp gradients, enabled/disabled nesting, true threaded
    enabled-vs-disabled requests, and non-LIFO overlapping-context cleanup.
- `PYTHONPATH=. .venv/bin/python -m pytest sdk/tests examples/tests -q --tb=short` from `forecasting/`
  - 76 passed
- `PYTHONPATH=. .venv/bin/python -m pytest sdk/tests examples/tests -q --tb=short` from `ad_diffusion/`
  - 25 passed
- `make lint`
  - passed
- `make spdx-check`
  - passed
- `pyright sdk/tests/test_revin_concurrency.py --outputjson`
  - 0 errors
- Broad Pyright diagnostics in the changed implementation ranges
  - 0 errors

`pre-commit run --files ...` was also attempted, but this repository does not
contain a `.pre-commit-config.yaml`.
