### PR TITLE
Sync adaptive normalizer serialization support

### DIFF
--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -180,6 +180,7 @@ ad_diffusion/
 │   └── utils.py               # Model evaluation utilities
 ├── utils/                      # Utility functions and tools
 │   ├── tsb_ad_preprocessor.py # Data preprocessing
+│   ├── adaptive_normalizer.py # Distribution-aware normalization
 │   ├── json_utils.py          # Model loading/saving
 │   ├── adaptive_threshold.py  # SCS and MACS implementations
 │   └── dpm_solver_pytorch.py  # DPM-Solver for fast inference

--- a/ad_diffusion/sdk/tests/test_json_serialization.py
+++ b/ad_diffusion/sdk/tests/test_json_serialization.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import numpy as np
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import PowerTransformer, QuantileTransformer, RobustScaler, StandardScaler
-
 from utils.adaptive_normalizer import AdaptiveNormalizer
 from utils.json_utils import (
     _deserialize_sklearn_model,

--- a/ad_diffusion/sdk/tests/test_json_serialization.py
+++ b/ad_diffusion/sdk/tests/test_json_serialization.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for JSON serialization of sklearn preprocessing models."""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import PowerTransformer, QuantileTransformer, RobustScaler, StandardScaler
+
+from utils.adaptive_normalizer import AdaptiveNormalizer
+from utils.json_utils import (
+    _deserialize_sklearn_model,
+    _serialize_sklearn_model,
+    deserialize_adaptive_normalizer,
+    load_preprocessing_models,
+    save_preprocessing_models,
+    serialize_adaptive_normalizer,
+)
+
+RNG = np.random.default_rng(42)
+X = RNG.normal(loc=50, scale=10, size=(200, 5))
+X_TEST = RNG.normal(loc=50, scale=10, size=(50, 5))
+
+
+def test_robust_scaler() -> None:
+    scaler = RobustScaler().fit(X)
+    restored = _deserialize_sklearn_model(_serialize_sklearn_model(scaler))
+
+    assert np.allclose(scaler.transform(X_TEST), restored.transform(X_TEST))
+
+
+def test_standard_scaler() -> None:
+    scaler = StandardScaler().fit(X)
+    restored = _deserialize_sklearn_model(_serialize_sklearn_model(scaler))
+
+    assert np.allclose(scaler.transform(X_TEST), restored.transform(X_TEST))
+
+
+def test_quantile_transformer() -> None:
+    transformer = QuantileTransformer(n_quantiles=100, output_distribution="normal").fit(X)
+    restored = _deserialize_sklearn_model(_serialize_sklearn_model(transformer))
+
+    assert np.allclose(transformer.transform(X_TEST), restored.transform(X_TEST))
+
+
+def test_power_transformer() -> None:
+    transformer = PowerTransformer(method="yeo-johnson").fit(X)
+    restored = _deserialize_sklearn_model(_serialize_sklearn_model(transformer))
+
+    assert np.allclose(transformer.transform(X_TEST), restored.transform(X_TEST))
+
+
+def test_pca() -> None:
+    pca = PCA(n_components=3).fit(X)
+    restored = _deserialize_sklearn_model(_serialize_sklearn_model(pca))
+
+    assert np.allclose(pca.transform(X_TEST), restored.transform(X_TEST))
+
+
+def test_adaptive_normalizer() -> None:
+    normalizer = AdaptiveNormalizer(target_range=100)
+    normalizer.fit(X[:, 0])
+    restored = deserialize_adaptive_normalizer(
+        serialize_adaptive_normalizer(normalizer),
+        AdaptiveNormalizer,
+    )
+
+    assert np.allclose(normalizer.transform(X_TEST[:, 0]), restored.transform(X_TEST[:, 0]))
+
+
+def test_save_load_preprocessing_models() -> None:
+    normalizer = AdaptiveNormalizer(target_range=100)
+    normalizer.fit(X[:, 0])
+    pca = PCA(n_components=3).fit(X)
+    models = {
+        "normalizers": {"test_domain": {"features_5": normalizer}},
+        "pca_models": {"test_domain_features_5": pca},
+        "target_dim": 25,
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "preprocessing_models.json"
+        save_preprocessing_models(models, path)
+        loaded = load_preprocessing_models(path, normalizer_class=AdaptiveNormalizer)
+
+    loaded_normalizer = loaded["normalizers"]["test_domain"]["features_5"]
+    assert np.allclose(normalizer.transform(X_TEST[:, 0]), loaded_normalizer.transform(X_TEST[:, 0]))
+    assert np.allclose(pca.transform(X_TEST), loaded["pca_models"]["test_domain_features_5"].transform(X_TEST))
+    assert loaded["target_dim"] == 25

--- a/ad_diffusion/utils/adaptive_normalizer.py
+++ b/ad_diffusion/utils/adaptive_normalizer.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable adaptive normalization for diffusion preprocessing."""
+
+import numpy as np
+from scipy import stats
+from sklearn.preprocessing import PowerTransformer, QuantileTransformer
+
+
+class AdaptiveNormalizer:
+    """Select and fit a distribution-aware transform without hard clipping."""
+
+    def __init__(self, target_range=100):
+        self.target_range = target_range
+        self.method = None
+        self.params = {}
+
+    def fit(self, data):
+        """Fit the normalizer based on the observed distribution."""
+        if data.ndim > 1:
+            data = data.ravel()
+
+        valid_data = data[~np.isnan(data)]
+        if len(valid_data) == 0:
+            self.method = "zeros"
+            return self
+
+        if np.all(valid_data == valid_data[0]):
+            self.method = "constant"
+            self.params["constant_value"] = valid_data[0]
+            return self
+
+        skewness = stats.skew(valid_data)
+        kurtosis = stats.kurtosis(valid_data)
+        self.params["median"] = np.median(valid_data)
+        self.params["mad"] = np.median(np.abs(valid_data - self.params["median"]))
+        if self.params["mad"] == 0:
+            self.params["mad"] = np.std(valid_data) / 1.4826
+            if self.params["mad"] == 0:
+                self.params["mad"] = 1.0
+        self.params["q1"] = np.percentile(valid_data, 25)
+        self.params["q3"] = np.percentile(valid_data, 75)
+        self.params["iqr"] = self.params["q3"] - self.params["q1"]
+
+        if abs(skewness) > 2 or kurtosis > 7:
+            n_unique = len(np.unique(valid_data))
+            if n_unique > 10:
+                self.method = "quantile"
+                transformer = QuantileTransformer(
+                    n_quantiles=min(n_unique, len(valid_data), 10000),
+                    output_distribution="normal",
+                    subsample=100000,
+                )
+                transformer.fit(valid_data.reshape(-1, 1))
+                self.params["quantile_transformer"] = transformer
+            else:
+                self.method = "robust-zscore"
+        elif abs(skewness) > 1:
+            self.method = "yeo-johnson"
+            transformer = PowerTransformer(method="yeo-johnson")
+            transformer.fit(valid_data.reshape(-1, 1))
+            self.params["power_transformer"] = transformer
+        else:
+            self.method = "robust-zscore"
+
+        return self
+
+    def transform(self, data):
+        """Transform data using the fitted parameters."""
+        original_shape = data.shape
+        data = data.ravel()
+
+        if self.method in {"zeros", "constant"}:
+            return np.zeros_like(data).reshape(original_shape)
+
+        nan_mask = np.isnan(data)
+        result = np.zeros_like(data)
+        if np.all(nan_mask):
+            return result.reshape(original_shape)
+
+        valid_data = data[~nan_mask]
+        if self.method == "quantile":
+            transformed = self.params["quantile_transformer"].transform(valid_data.reshape(-1, 1)).ravel()
+            transformed *= self.target_range / 3
+        elif self.method == "yeo-johnson":
+            transformed = self.params["power_transformer"].transform(valid_data.reshape(-1, 1)).ravel()
+            std_transformed = np.std(transformed)
+            if std_transformed > 0:
+                transformed *= min(self.target_range / (3 * std_transformed), 1.0)
+            else:
+                transformed = np.zeros_like(transformed)
+        else:
+            median = self.params["median"]
+            mad = self.params["mad"] + 1e-8
+            extreme_low = valid_data < (self.params["q1"] - 3 * self.params["iqr"])
+            extreme_high = valid_data > (self.params["q3"] + 3 * self.params["iqr"])
+            extreme_mask = extreme_low | extreme_high
+            transformed = (valid_data - median) / (1.4826 * mad)
+
+            if np.any(extreme_mask):
+                extreme_values = valid_data[extreme_mask]
+                signs = np.sign(extreme_values - median)
+                log_values = np.log1p(np.abs(extreme_values - median) / mad)
+                transformed[extreme_mask] = signs * log_values * 3
+
+            percentile = np.percentile(np.abs(transformed), 99.9)
+            if percentile > 0:
+                transformed *= min(self.target_range / percentile, 1.0)
+            else:
+                transformed = np.zeros_like(transformed)
+
+        scale_factor = self.target_range * (2 / np.pi)
+        transformed = np.arctan(transformed / (self.target_range * 0.5)) * scale_factor
+        result[~nan_mask] = transformed
+        return result.reshape(original_shape)
+
+    def fit_transform(self, data):
+        """Fit the normalizer and transform the same data."""
+        return self.fit(data).transform(data)

--- a/ad_diffusion/utils/json_utils.py
+++ b/ad_diffusion/utils/json_utils.py
@@ -277,7 +277,7 @@ def serialize_adaptive_normalizer(normalizer):
             serialized_params[k] = _serialize_numpy_for_json(v)
     data["params"] = serialized_params
 
-    # Handle scalers list (merge_tsb_ad_m.py AdaptiveNormalizer)
+    # Preserve optional extended normalizer state for backward compatibility.
     if hasattr(normalizer, "scalers"):
         data["scalers"] = [_serialize_sklearn_model(s) for s in normalizer.scalers]
     if hasattr(normalizer, "n_features"):

--- a/ad_diffusion/utils/tsb_ad_preprocessor.py
+++ b/ad_diffusion/utils/tsb_ad_preprocessor.py
@@ -21,12 +21,10 @@ from sklearn.decomposition import PCA
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Import utilities from utils directory
+from utils.adaptive_normalizer import AdaptiveNormalizer
 from utils.json_utils import load_preprocessing_models
 
 logger = logging.getLogger(__name__)
-
-ORIGINAL_NORMALIZER_AVAILABLE = True
 
 # Constants from original merger
 TARGET_FEATURES = 38
@@ -48,23 +46,9 @@ SENSOR_DOMAINS = ["Sensor", "Medical", "Facility"]
 BOUNDED_DOMAINS = ["Synthetic", "HumanActivity", "Environment"]
 
 
-class AdaptiveNormalizerCompat:
-    """Compatibility class for deserialized AdaptiveNormalizer objects"""
-
-    def __init__(self):
-        self.target_range = 100
-        self.method = None
-        self.params = {}
-
-    def transform(self, data):
-        """Use SimpleAdaptiveNormalizer for transform"""
-        normalizer = SimpleAdaptiveNormalizer({"method": self.method, "target_range": self.target_range, **self.params})
-        return normalizer.transform(data)
-
-
 def _load_normalizers(filepath):
-    """Load normalizers from JSON file using the inference-only compat class."""
-    return load_preprocessing_models(filepath, normalizer_class=AdaptiveNormalizerCompat)
+    """Load normalizers from a JSON preprocessing artifact."""
+    return load_preprocessing_models(filepath, normalizer_class=AdaptiveNormalizer)
 
 
 def detect_domain(data):


### PR DESCRIPTION
## Summary

- Add the reusable AdaptiveNormalizer implementation used by the internal SDK.
- Load serialized preprocessing artifacts with the real normalizer instead of the compatibility shim.
- Add JSON round-trip coverage for sklearn preprocessors, PCA, and AdaptiveNormalizer.
- Retain optional extended normalizer state for backward compatibility.

This is the NV-Tesseract companion to GitLab MR nv-tesseract/tesseract!380.

## Validation

- Full test suite: 32 passed.
- SDK test suite: 28 passed.
- Ruff checks passed.