### PR TITLE
Add explainability metrics to anomaly reports

### DIFF
--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -59,9 +59,11 @@ print(f"Detected {results['Anomaly'].sum()} anomalies")
 With `explain=True`, the result also includes `TopContributors`,
 `ContributionShares`, `ExplanationCoverage`, and `ExplanationMethod`. These
 columns are derived from the existing target and reconstruction, so explanation
-does not run the detector again. When preprocessing changes the feature space,
-contributors use conservative `component_N` labels instead of claiming an
-incorrect mapping to the original signals.
+does not run the detector again. Inputs with any feature count up to the model's
+target dimension retain their original column names; right-padded model dimensions
+remain part of the MAE denominator but are not presented as input features. When
+PCA or feature engineering changes the feature space, contributors use conservative
+`component_N` labels instead of claiming an incorrect mapping to original signals.
 
 Generate a PDF report with the original signals, detected anomalies, MAE, and
 ground truth when a conventional label column such as `GT` is present:

--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -9,6 +9,7 @@ A package for anomaly detection using NV-Tesseract diffusion models.
 - **Multi-GPU Support**: Automatic multi-GPU inference with shared memory optimization
 - **Fast Inference**: Supports DPM-Solver for 50-100x speedup over standard diffusion
 - **Preprocessing Pipeline**: Complete TSB-AD compatible preprocessing with domain adaptation
+- **Model-agnostic Explainability**: Attributes each detected anomaly's MAE to its largest reconstruction errors
 - **Auto-download from Hugging Face**: Pretrained weights are fetched automatically from [`nvidia/nv-tesseract-ad-diffusion`](https://huggingface.co/nvidia/nv-tesseract-ad-diffusion) on first use
 - **Simple Structure**: Organized as modules without Python package complexity - easy to use and modify
 
@@ -47,11 +48,20 @@ results = perform_anomaly_analysis_with_diffusion(
     # config_path="path/to/config.yaml",      # optional; defaults to curriculum_medium.yaml
     nsample=15,
     preprocess_model_dir="path/to/preprocessing/models",  # optional
+    explain=True,
+    explanation_top_k=3,
 )
 
 # Results contain original data plus anomaly detection results
 print(f"Detected {results['Anomaly'].sum()} anomalies")
 ```
+
+With `explain=True`, the result also includes `TopContributors`,
+`ContributionShares`, `ExplanationCoverage`, and `ExplanationMethod`. These
+columns are derived from the existing target and reconstruction, so explanation
+does not run the detector again. When preprocessing changes the feature space,
+contributors use conservative `component_N` labels instead of claiming an
+incorrect mapping to the original signals.
 
 Generate a PDF report with the original signals, detected anomalies, MAE, and
 ground truth when a conventional label column such as `GT` is present:
@@ -63,12 +73,15 @@ results = perform_anomaly_analysis_with_diffusion(
     report_path="output/pdf/anomaly_detection_report.pdf",
     timestamp_column="timestamp",
     ground_truth_column="GT",
+    explain=True,
 )
 ```
 
 Timestamp and ground-truth columns used for the report are excluded from model
 features but preserved in the returned DataFrame. Existing callers are unchanged
 because PDF generation is disabled unless `report_path` is supplied.
+When explanations are enabled, the PDF adds contributor-share graphs and writes
+the complete row-level explanation data to a companion CSV.
 
 An existing AD result or CSV can also be rendered after inference:
 
@@ -171,8 +184,10 @@ uv run ruff check .
 ad_diffusion/
 ├── sdk/                        # Main inference functions
 │   ├── anomaly_analysis.py     # Main API function
+│   ├── explainability.py       # Reconstruction-error contribution explanations
 │   ├── inference_ad.py         # Core inference engine
 │   ├── inference_worker.py     # Multi-GPU worker
+│   ├── reporting.py            # PDF and companion CSV report generation
 │   └── thresholds.py          # Threshold strategies (SCS, MACS)
 ├── models/                     # Diffusion model implementations
 │   ├── main_model.py          # TSDiffuser_Generic model

--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -74,6 +74,8 @@ results = perform_anomaly_analysis_with_diffusion(
     timestamp_column="timestamp",
     ground_truth_column="GT",
     explain=True,
+    report_max_pages=10,
+    report_consolidated_top_k=5,
 )
 ```
 
@@ -81,7 +83,10 @@ Timestamp and ground-truth columns used for the report are excluded from model
 features but preserved in the returned DataFrame. Existing callers are unchanged
 because PDF generation is disabled unless `report_path` is supplied.
 When explanations are enabled, the PDF adds contributor-share graphs and writes
-the complete row-level explanation data to a companion CSV.
+the complete row-level explanation data to a companion CSV. If per-anomaly
+charts would make the PDF exceed `report_max_pages` (10 by default), the PDF
+uses one consolidated, MAE-weighted top-contributors page instead; the companion
+CSV still contains every detected anomaly.
 
 An existing AD result or CSV can also be rendered after inference:
 

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -39,6 +39,7 @@ def perform_anomaly_analysis_with_diffusion(
     timestamp_column: str | None = None,
     ground_truth_column: str | None = None,
     report_title: str = "Anomaly Detection Report",
+    report_explanation_csv_path: str | Path | None = None,
 ) -> pd.DataFrame:
     """
     Perform anomaly analysis using Tesseract AD Diffusion Model.
@@ -62,6 +63,8 @@ def perform_anomaly_analysis_with_diffusion(
         ground_truth_column: Optional binary-label column used only for report
             plotting. When report_path is set, conventional label names are auto-detected.
         report_title: Title shown on the generated PDF report.
+        report_explanation_csv_path: Optional destination for the full
+            explainability CSV. When omitted, it is written beside the PDF.
 
     Returns:
         DataFrame with original data and anomaly detection results
@@ -177,6 +180,7 @@ def perform_anomaly_analysis_with_diffusion(
             timestamp_column=resolved_timestamp_column,
             ground_truth_column=resolved_ground_truth_column,
             title=report_title,
+            explanation_csv_path=report_explanation_csv_path,
         )
 
     return result_df

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -11,6 +11,7 @@ from pathlib import Path  # noqa: TC003
 import pandas as pd
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from sdk.explainability import explain_reconstruction_anomalies
 from sdk.inference_ad import (
     _resolve_model_paths,
     get_model_target_dim,
@@ -40,6 +41,8 @@ def perform_anomaly_analysis_with_diffusion(
     ground_truth_column: str | None = None,
     report_title: str = "Anomaly Detection Report",
     report_explanation_csv_path: str | Path | None = None,
+    explain: bool = False,
+    explanation_top_k: int = 3,
 ) -> pd.DataFrame:
     """
     Perform anomaly analysis using Tesseract AD Diffusion Model.
@@ -65,6 +68,8 @@ def perform_anomaly_analysis_with_diffusion(
         report_title: Title shown on the generated PDF report.
         report_explanation_csv_path: Optional destination for the full
             explainability CSV. When omitted, it is written beside the PDF.
+        explain: Whether to add reconstruction-error explanations for detected anomalies.
+        explanation_top_k: Maximum number of contributors returned per anomaly.
 
     Returns:
         DataFrame with original data and anomaly detection results
@@ -171,6 +176,34 @@ def perform_anomaly_analysis_with_diffusion(
 
     result_df["Anomaly"] = anomalies
     result_df["MAE"] = residual_scores  # Using residual (MAE) as anomaly score
+
+    if explain:
+        reconstruction = results.get("recon")
+        if reconstruction is None:
+            raise ValueError("Inference results must include 'recon' when explain=True.")
+
+        explanation_length = min(original_length, len(target_data), len(reconstruction), len(anomalies))
+        target_for_explanation = target_data[:explanation_length]
+        reconstruction_for_explanation = reconstruction[:explanation_length]
+        target_feature_count = target_for_explanation.shape[1] if target_for_explanation.ndim > 1 else 1
+        feature_names = list(input_df.columns) if target_feature_count == len(input_df.columns) else None
+        explanations = explain_reconstruction_anomalies(
+            target_for_explanation,
+            reconstruction_for_explanation,
+            anomaly_mask=anomalies[:explanation_length],
+            feature_names=feature_names,
+            top_k=explanation_top_k,
+        )
+        explanations = explanations.reindex(range(original_length)).fillna(
+            {
+                "TopContributors": "[]",
+                "ContributionShares": "[]",
+                "ExplanationCoverage": 0.0,
+                "ExplanationMethod": "",
+            }
+        )
+        for column in explanations.columns:
+            result_df[column] = explanations[column].to_numpy()
 
     if report_path is not None:
         generate_anomaly_detection_report(

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -190,12 +190,16 @@ def perform_anomaly_analysis_with_diffusion(
         target_for_explanation = target_data[:explanation_length]
         reconstruction_for_explanation = reconstruction[:explanation_length]
         target_feature_count = target_for_explanation.shape[1] if target_for_explanation.ndim > 1 else 1
-        feature_names = list(input_df.columns) if target_feature_count == len(input_df.columns) else None
+        input_feature_count = len(input_df.columns)
+        directly_mapped = preprocess_model_dir is None and input_feature_count <= target_feature_count
+        feature_names = list(input_df.columns) if directly_mapped else None
+        feature_indices = list(range(input_feature_count)) if directly_mapped else None
         explanations = explain_reconstruction_anomalies(
             target_for_explanation,
             reconstruction_for_explanation,
             anomaly_mask=anomalies[:explanation_length],
             feature_names=feature_names,
+            feature_indices=feature_indices,
             top_k=explanation_top_k,
         )
         explanations = explanations.reindex(range(original_length)).fillna(

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -41,6 +41,8 @@ def perform_anomaly_analysis_with_diffusion(
     ground_truth_column: str | None = None,
     report_title: str = "Anomaly Detection Report",
     report_explanation_csv_path: str | Path | None = None,
+    report_max_pages: int = 10,
+    report_consolidated_top_k: int = 5,
     explain: bool = False,
     explanation_top_k: int = 3,
 ) -> pd.DataFrame:
@@ -68,6 +70,8 @@ def perform_anomaly_analysis_with_diffusion(
         report_title: Title shown on the generated PDF report.
         report_explanation_csv_path: Optional destination for the full
             explainability CSV. When omitted, it is written beside the PDF.
+        report_max_pages: Maximum PDF page count. Excess anomaly details are consolidated.
+        report_consolidated_top_k: Number of overall contributors shown when details are consolidated.
         explain: Whether to add reconstruction-error explanations for detected anomalies.
         explanation_top_k: Maximum number of contributors returned per anomaly.
 
@@ -214,6 +218,8 @@ def perform_anomaly_analysis_with_diffusion(
             ground_truth_column=resolved_ground_truth_column,
             title=report_title,
             explanation_csv_path=report_explanation_csv_path,
+            max_report_pages=report_max_pages,
+            consolidated_top_k=report_consolidated_top_k,
         )
 
     return result_df

--- a/ad_diffusion/sdk/explainability.py
+++ b/ad_diffusion/sdk/explainability.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Explanations for reconstruction-based anomaly scores."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from numpy.typing import ArrayLike, NDArray
+
+
+def _as_feature_matrix(values: ArrayLike, *, name: str) -> NDArray[np.float64]:
+    """Convert one- or two-dimensional values to a feature matrix."""
+    matrix = np.asarray(values, dtype=np.float64)
+    if matrix.ndim == 1:
+        matrix = matrix[:, np.newaxis]
+    if matrix.ndim != 2:
+        raise ValueError(f"{name} must be a one- or two-dimensional array, got shape {matrix.shape}.")
+    return matrix
+
+
+def _resolve_feature_names(feature_names: Sequence[str] | None, feature_count: int) -> list[str]:
+    """Return validated feature names or conservative component labels."""
+    if feature_names is None:
+        return [f"component_{index}" for index in range(feature_count)]
+
+    names = [str(feature_name) for feature_name in feature_names]
+    if len(names) != feature_count:
+        raise ValueError(
+            f"feature_names has {len(names)} entries, but target and reconstruction have {feature_count} features."
+        )
+    return names
+
+
+def explain_reconstruction_anomalies(
+    target: ArrayLike,
+    reconstruction: ArrayLike,
+    *,
+    anomaly_mask: ArrayLike | None = None,
+    feature_names: Sequence[str] | None = None,
+    top_k: int = 3,
+) -> pd.DataFrame:
+    """Explain MAE scores with exact per-feature reconstruction-error shares."""
+    target_matrix = _as_feature_matrix(target, name="target")
+    reconstruction_matrix = _as_feature_matrix(reconstruction, name="reconstruction")
+    if target_matrix.shape != reconstruction_matrix.shape:
+        raise ValueError(
+            "target and reconstruction must have the same shape, "
+            f"got {target_matrix.shape} and {reconstruction_matrix.shape}."
+        )
+    if not isinstance(top_k, int) or isinstance(top_k, bool):
+        raise TypeError(f"top_k must be an integer >= 1, got {type(top_k).__name__}.")
+    if top_k < 1:
+        raise ValueError(f"top_k must be at least 1, got {top_k}.")
+
+    row_count, feature_count = target_matrix.shape
+    names = _resolve_feature_names(feature_names, feature_count)
+    selected_count = min(top_k, feature_count)
+
+    if anomaly_mask is None:
+        explain_rows = np.ones(row_count, dtype=bool)
+    else:
+        explain_rows = np.asarray(anomaly_mask, dtype=bool).reshape(-1)
+        if len(explain_rows) != row_count:
+            raise ValueError(f"anomaly_mask has length {len(explain_rows)}, expected {row_count}.")
+
+    with np.errstate(invalid="ignore", over="ignore"):
+        absolute_errors = np.abs(target_matrix - reconstruction_matrix)
+    if not np.isfinite(absolute_errors).all():
+        raise ValueError("target and reconstruction must produce only finite reconstruction errors.")
+    error_totals = absolute_errors.sum(axis=1)
+    contribution_shares = np.divide(
+        absolute_errors,
+        error_totals[:, np.newaxis],
+        out=np.zeros_like(absolute_errors),
+        where=error_totals[:, np.newaxis] > 0,
+    )
+    ranked_indices = np.argsort(-contribution_shares, axis=1, kind="stable")[:, :selected_count]
+
+    contributors: list[str] = []
+    shares: list[str] = []
+    coverage = np.zeros(row_count, dtype=np.float64)
+    methods: list[str] = []
+    for row_index, is_explained in enumerate(explain_rows):
+        if not is_explained:
+            contributors.append("[]")
+            shares.append("[]")
+            methods.append("")
+            continue
+
+        indices = ranked_indices[row_index]
+        row_shares = contribution_shares[row_index, indices]
+        contributors.append(json.dumps([names[index] for index in indices], separators=(",", ":")))
+        shares.append(json.dumps([round(float(value), 6) for value in row_shares], separators=(",", ":")))
+        coverage[row_index] = float(row_shares.sum())
+        methods.append("reconstruction_error")
+
+    return pd.DataFrame(
+        {
+            "TopContributors": contributors,
+            "ContributionShares": shares,
+            "ExplanationCoverage": coverage,
+            "ExplanationMethod": methods,
+        }
+    )

--- a/ad_diffusion/sdk/explainability.py
+++ b/ad_diffusion/sdk/explainability.py
@@ -46,9 +46,15 @@ def explain_reconstruction_anomalies(
     *,
     anomaly_mask: ArrayLike | None = None,
     feature_names: Sequence[str] | None = None,
+    feature_indices: Sequence[int] | None = None,
     top_k: int = 3,
 ) -> pd.DataFrame:
-    """Explain MAE scores with exact per-feature reconstruction-error shares."""
+    """Explain MAE scores with exact per-feature reconstruction-error shares.
+
+    ``feature_indices`` limits the ranked contributors while retaining all model
+    dimensions in the MAE denominator. This maps real input columns through
+    right-padding without pretending that padding dimensions are input features.
+    """
     target_matrix = _as_feature_matrix(target, name="target")
     reconstruction_matrix = _as_feature_matrix(reconstruction, name="reconstruction")
     if target_matrix.shape != reconstruction_matrix.shape:
@@ -62,8 +68,21 @@ def explain_reconstruction_anomalies(
         raise ValueError(f"top_k must be at least 1, got {top_k}.")
 
     row_count, feature_count = target_matrix.shape
-    names = _resolve_feature_names(feature_names, feature_count)
-    selected_count = min(top_k, feature_count)
+    if feature_indices is None:
+        resolved_indices = np.arange(feature_count, dtype=int)
+    else:
+        raw_indices = list(feature_indices)
+        if not raw_indices:
+            raise ValueError("feature_indices must contain at least one model dimension.")
+        if any(not isinstance(index, int | np.integer) or isinstance(index, bool) for index in raw_indices):
+            raise TypeError("feature_indices must contain only integers.")
+        resolved_indices = np.asarray(raw_indices, dtype=int)
+        if len(np.unique(resolved_indices)) != len(resolved_indices):
+            raise ValueError("feature_indices must not contain duplicates.")
+        if ((resolved_indices < 0) | (resolved_indices >= feature_count)).any():
+            raise ValueError(f"feature_indices must be between 0 and {feature_count - 1}.")
+    names = _resolve_feature_names(feature_names, len(resolved_indices))
+    selected_count = min(top_k, len(resolved_indices))
 
     if anomaly_mask is None:
         explain_rows = np.ones(row_count, dtype=bool)
@@ -83,7 +102,8 @@ def explain_reconstruction_anomalies(
         out=np.zeros_like(absolute_errors),
         where=error_totals[:, np.newaxis] > 0,
     )
-    ranked_indices = np.argsort(-contribution_shares, axis=1, kind="stable")[:, :selected_count]
+    eligible_shares = contribution_shares[:, resolved_indices]
+    ranked_indices = np.argsort(-eligible_shares, axis=1, kind="stable")[:, :selected_count]
 
     contributors: list[str] = []
     shares: list[str] = []
@@ -97,7 +117,7 @@ def explain_reconstruction_anomalies(
             continue
 
         indices = ranked_indices[row_index]
-        row_shares = contribution_shares[row_index, indices]
+        row_shares = eligible_shares[row_index, indices]
         contributors.append(json.dumps([names[index] for index in indices], separators=(",", ":")))
         shares.append(json.dumps([round(float(value), 6) for value in row_shares], separators=(",", ":")))
         coverage[row_index] = float(row_shares.sum())

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -334,82 +334,6 @@ def _create_feature_page(
     return figure
 
 
-def _create_explanation_page(
-    rows: Sequence[tuple[str, str, str, str]],
-    *,
-    page_number: int,
-    explanation_page_number: int,
-    explanation_page_count: int,
-) -> Figure:
-    figure = Figure(figsize=(11.0, 8.5), facecolor="white")
-    axis = figure.add_axes((0.07, 0.10, 0.86, 0.76))
-    axis.axis("off")
-    figure.suptitle(
-        f"Anomaly explanations ({explanation_page_number}/{explanation_page_count})",
-        x=0.07,
-        y=0.955,
-        ha="left",
-        fontsize=18,
-        fontweight="bold",
-        color="#17365D",
-    )
-    figure.text(
-        0.07,
-        0.895,
-        "Reconstruction-error attribution for each detected anomaly",
-        fontsize=10,
-        color="#667085",
-    )
-
-    if rows:
-        table_height = min(0.90, 0.115 * (len(rows) + 1))
-        table = axis.table(
-            cellText=rows,
-            colLabels=("Anomalous timestamp", "Top contributors", "Contribution share", "Explanation coverage"),
-            colWidths=(0.18, 0.34, 0.22, 0.20),
-            cellLoc="left",
-            colLoc="left",
-            loc="upper left",
-            bbox=(0.0, 0.98 - table_height, 1.0, table_height),
-        )
-        table.auto_set_font_size(False)
-        table.set_fontsize(8)
-        row_height = table_height / (len(rows) + 1)
-        for (row_index, _), cell in table.get_celld().items():
-            cell.set_height(row_height)
-            cell.set_edgecolor("#D0D5DD")
-            cell.set_linewidth(0.6)
-            cell.PAD = 0.08
-            cell.get_text().set_verticalalignment("center")
-            if row_index == 0:
-                cell.set_facecolor("#EAF2F8")
-                cell.get_text().set_color("#17365D")
-                cell.get_text().set_fontweight("bold")
-            else:
-                cell.set_facecolor("#FFFFFF" if row_index % 2 else "#F9FAFB")
-                cell.get_text().set_color("#344054")
-    else:
-        axis.text(
-            0.0,
-            0.88,
-            "No detected anomalies were available to explain.",
-            fontsize=11,
-            color="#475467",
-            va="top",
-        )
-
-    figure.text(
-        0.07,
-        0.065,
-        "Contribution shares correspond to the contributors in the same order. Coverage is the fraction of total "
-        "reconstruction error represented by the listed contributors.",
-        fontsize=7.5,
-        color="#667085",
-    )
-    _add_footer(figure, page_number)
-    return figure
-
-
 def _create_contribution_graph_page(
     rows: Sequence[tuple[str, str, str, str]],
     *,
@@ -524,6 +448,42 @@ def _create_contribution_graph_page(
     return figure
 
 
+def _write_explanation_csv(
+    result_df: pd.DataFrame,
+    detected: np.ndarray,
+    x_values,
+    output_path: Path,
+    *,
+    is_datetime: bool,
+) -> Path:
+    columns = (
+        "Anomalous timestamp",
+        "Top contributors",
+        "Contribution shares",
+        "Explanation coverage",
+    )
+    records = []
+    x_array = np.asarray(x_values)
+    for row_index in np.flatnonzero(detected):
+        contributors = _parse_explanation_list(result_df.iloc[row_index]["TopContributors"], name="TopContributors")
+        shares = _parse_explanation_list(result_df.iloc[row_index]["ContributionShares"], name="ContributionShares")
+        coverage = float(result_df.iloc[row_index]["ExplanationCoverage"])
+        records.append(
+            {
+                "Anomalous timestamp": _format_explanation_sample(x_array[row_index], is_datetime=is_datetime).replace(
+                    "\n", " "
+                ),
+                "Top contributors": json.dumps([str(value) for value in contributors], separators=(",", ":")),
+                "Contribution shares": json.dumps([float(value) for value in shares], separators=(",", ":")),
+                "Explanation coverage": coverage,
+            }
+        )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame.from_records(records, columns=columns).to_csv(output_path, index=False)
+    return output_path
+
+
 def _create_mae_note_page(*, page_number: int) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
     axis = figure.add_axes((0.09, 0.12, 0.82, 0.76))
@@ -575,11 +535,14 @@ def generate_anomaly_detection_report(
     score_column: str = "MAE",
     title: str = "Anomaly Detection Report",
     max_features_per_page: int = 4,
+    explanation_csv_path: str | Path | None = None,
 ) -> Path:
     """Create a PDF report from an anomaly-analysis result DataFrame.
 
     The report contains a score overview followed by original-signal plots with
     detected anomalies and, when available, ground-truth anomalies overlaid.
+    Explainability metrics are plotted in the PDF and exported in full to a
+    companion CSV when explanation columns are available.
     Timestamp and ground-truth columns are inferred from conventional names when
     they are not supplied explicitly.
     """
@@ -630,6 +593,19 @@ def generate_anomaly_detection_report(
 
     destination = Path(output_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
+    if explanation_rows is not None:
+        csv_destination = (
+            Path(explanation_csv_path)
+            if explanation_csv_path is not None
+            else destination.with_name(f"{destination.stem}_explanations.csv")
+        )
+        _write_explanation_csv(
+            result_df,
+            detected,
+            x_values,
+            csv_destination,
+            is_datetime=is_datetime,
+        )
     feature_groups = [
         resolved_features[index : index + max_features_per_page]
         for index in range(0, len(resolved_features), max_features_per_page)
@@ -642,7 +618,7 @@ def generate_anomaly_detection_report(
         if explanation_rows
         else ([[]] if explanation_rows is not None else [])
     )
-    page_count = 2 + len(feature_groups) + 2 * len(explanation_groups)
+    page_count = 2 + len(feature_groups) + len(explanation_groups)
 
     with PdfPages(destination, metadata={"Title": title, "Subject": "Time-series anomaly detection report"}) as pdf:
         pdf.savefig(
@@ -680,16 +656,6 @@ def generate_anomaly_detection_report(
                     page_number=page_number,
                     graph_page_number=graph_page_number,
                     graph_page_count=len(explanation_groups),
-                )
-            )
-        for explanation_page_number, group in enumerate(explanation_groups, start=1):
-            page_number = 1 + len(feature_groups) + len(explanation_groups) + explanation_page_number
-            pdf.savefig(
-                _create_explanation_page(
-                    group,
-                    page_number=page_number,
-                    explanation_page_number=explanation_page_number,
-                    explanation_page_count=len(explanation_groups),
                 )
             )
         pdf.savefig(_create_mae_note_page(page_number=page_count))

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -479,7 +479,7 @@ def _write_explanation_csv(
     return output_path
 
 
-def _create_mae_note_page(*, page_number: int) -> Figure:
+def _create_mae_note_page(*, page_number: int, uses_row_numbers: bool = False) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
     axis = figure.add_axes((0.09, 0.12, 0.82, 0.76))
     axis.axis("off")
@@ -509,9 +509,13 @@ def _create_mae_note_page(*, page_number: int) -> Figure:
         "MAE scale depends on preprocessing and feature scaling, so values should be interpreted in the context of the same model and data pipeline.",
         "A high MAE identifies unusual reconstruction behavior; by itself, it does not establish physical causality or root cause.",
     ]
+    if uses_row_numbers:
+        notes.append(
+            "No usable timestamp column was provided, so time steps in this report are zero-based DataFrame row numbers."
+        )
     axis.text(0.0, 0.48, "Interpretation notes", fontsize=12, fontweight="bold", color="#175CD3", va="top")
     for note_index, note in enumerate(notes):
-        y_position = 0.39 - note_index * 0.10
+        y_position = 0.39 - note_index * 0.08
         axis.text(0.0, y_position, "-", fontsize=12, color="#175CD3", va="top")
         axis.text(0.035, y_position, note, fontsize=10, color="#344054", va="top", wrap=True)
 
@@ -665,5 +669,10 @@ def generate_anomaly_detection_report(
                     feature_colors=explanation_feature_colors,
                 )
             )
-        pdf.savefig(_create_mae_note_page(page_number=page_count))
+        pdf.savefig(
+            _create_mae_note_page(
+                page_number=page_count,
+                uses_row_numbers=x_label.startswith("Row number"),
+            )
+        )
     return destination

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.figure import Figure
+from matplotlib.patches import Patch
 
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
@@ -28,6 +29,7 @@ EXPLANATION_COLUMNS = {
 }
 REQUIRED_EXPLANATION_COLUMNS = ("TopContributors", "ContributionShares", "ExplanationCoverage")
 MAX_EXPLANATIONS_PER_PAGE = 7
+CONTRIBUTOR_RANK_COLORS = ("#175CD3", "#12B76A", "#F79009", "#7F56D9", "#06AED4")
 
 
 def infer_ground_truth_column(df: pd.DataFrame) -> str | None:
@@ -408,6 +410,120 @@ def _create_explanation_page(
     return figure
 
 
+def _create_contribution_graph_page(
+    rows: Sequence[tuple[str, str, str, str]],
+    *,
+    page_number: int,
+    graph_page_number: int,
+    graph_page_count: int,
+) -> Figure:
+    figure = Figure(figsize=(11.0, 8.5), facecolor="white")
+    axis = figure.add_axes((0.28, 0.14, 0.64, 0.66))
+    figure.suptitle(
+        f"Feature contributions by anomaly ({graph_page_number}/{graph_page_count})",
+        x=0.07,
+        y=0.955,
+        ha="left",
+        fontsize=18,
+        fontweight="bold",
+        color="#17365D",
+    )
+    figure.text(
+        0.07,
+        0.895,
+        "Stacked shares of total reconstruction error; gray shows error outside the displayed contributors",
+        fontsize=10,
+        color="#667085",
+    )
+    if not rows:
+        axis.axis("off")
+        axis.text(
+            0.0,
+            0.88,
+            "No detected anomalies were available to graph.",
+            fontsize=11,
+            color="#475467",
+            va="top",
+        )
+        _add_footer(figure, page_number)
+        return figure
+
+    y_positions = np.arange(
+        MAX_EXPLANATIONS_PER_PAGE - 1,
+        MAX_EXPLANATIONS_PER_PAGE - len(rows) - 1,
+        -1,
+    )
+    y_labels = []
+    max_contributors = 0
+    for y_position, (timestamp, contributor_text, share_text, coverage_text) in zip(y_positions, rows, strict=True):
+        contributors = contributor_text.splitlines() if contributor_text != "Not available" else []
+        shares = (
+            [float(value.removesuffix("%")) / 100 for value in share_text.splitlines()]
+            if share_text != "Not available"
+            else []
+        )
+        max_contributors = max(max_contributors, len(contributors))
+        left = 0.0
+        for rank, share in enumerate(shares):
+            color = CONTRIBUTOR_RANK_COLORS[rank % len(CONTRIBUTOR_RANK_COLORS)]
+            axis.barh(y_position, share, left=left, height=0.58, color=color, edgecolor="white", linewidth=0.8)
+            if share >= 0.055:
+                axis.text(
+                    left + share / 2,
+                    y_position,
+                    f"{share:.0%}",
+                    ha="center",
+                    va="center",
+                    fontsize=7,
+                    fontweight="bold",
+                    color="white" if rank != 2 else "#101828",
+                )
+            left += share
+
+        uncovered = max(0.0, 1.0 - left)
+        axis.barh(
+            y_position,
+            uncovered,
+            left=left,
+            height=0.58,
+            color="#D0D5DD",
+            edgecolor="white",
+            linewidth=0.8,
+        )
+        axis.text(1.015, y_position, f"{coverage_text} covered", va="center", fontsize=7.5, color="#475467")
+        ranked_names = (
+            " > ".join(f"{rank + 1}. {name[:18]}" for rank, name in enumerate(contributors)) or "No contributors"
+        )
+        y_labels.append(f"{timestamp.replace(chr(10), ' ')}\n{ranked_names}")
+
+    axis.set_yticks(y_positions, labels=y_labels)
+    axis.set_ylim(-0.75, MAX_EXPLANATIONS_PER_PAGE - 0.25)
+    axis.set_xlim(0.0, 1.15)
+    axis.set_xticks(np.linspace(0.0, 1.0, 6), labels=[f"{value:.0%}" for value in np.linspace(0.0, 1.0, 6)])
+    axis.set_xlabel("Contribution share of total reconstruction error", fontsize=9, color="#344054")
+    axis.grid(axis="x", color="#D8DEE9", linewidth=0.6, alpha=0.8)
+    axis.set_axisbelow(True)
+    axis.spines[["top", "right", "left"]].set_visible(False)
+    axis.tick_params(axis="y", length=0, labelsize=7.5, colors="#344054", pad=8)
+    axis.tick_params(axis="x", labelsize=8, colors="#667085")
+
+    legend_handles = [
+        Patch(color=CONTRIBUTOR_RANK_COLORS[rank], label=f"Contributor rank {rank + 1}")
+        for rank in range(max_contributors)
+    ]
+    legend_handles.append(Patch(color="#D0D5DD", label="Uncovered"))
+    axis.legend(
+        handles=legend_handles,
+        loc="lower left",
+        bbox_to_anchor=(0.0, 1.03),
+        frameon=False,
+        fontsize=8,
+        ncols=min(4, len(legend_handles)),
+    )
+    _add_footer(figure, page_number)
+    return figure
+
+
 def _create_mae_note_page(*, page_number: int) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
     axis = figure.add_axes((0.09, 0.12, 0.82, 0.76))
@@ -526,7 +642,7 @@ def generate_anomaly_detection_report(
         if explanation_rows
         else ([[]] if explanation_rows is not None else [])
     )
-    page_count = 2 + len(feature_groups) + len(explanation_groups)
+    page_count = 2 + len(feature_groups) + 2 * len(explanation_groups)
 
     with PdfPages(destination, metadata={"Title": title, "Subject": "Time-series anomaly detection report"}) as pdf:
         pdf.savefig(
@@ -556,8 +672,18 @@ def generate_anomaly_detection_report(
                     feature_page_count=len(feature_groups),
                 )
             )
+        for graph_page_number, group in enumerate(explanation_groups, start=1):
+            page_number = 1 + len(feature_groups) + graph_page_number
+            pdf.savefig(
+                _create_contribution_graph_page(
+                    group,
+                    page_number=page_number,
+                    graph_page_number=graph_page_number,
+                    graph_page_count=len(explanation_groups),
+                )
+            )
         for explanation_page_number, group in enumerate(explanation_groups, start=1):
-            page_number = 1 + len(feature_groups) + explanation_page_number
+            page_number = 1 + len(feature_groups) + len(explanation_groups) + explanation_page_number
             pdf.savefig(
                 _create_explanation_page(
                     group,

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -134,7 +134,7 @@ def _parse_explanation_list(value, *, name: str) -> list:
             value = json.loads(value)
         except json.JSONDecodeError as error:
             raise ValueError(f"{name} must contain a valid JSON list.") from error
-    if not isinstance(value, (list, tuple, np.ndarray)):
+    if not isinstance(value, list | tuple | np.ndarray):
         raise TypeError(f"{name} must contain a list for each detected anomaly.")
     return list(value)
 

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -363,7 +363,7 @@ def _create_explanation_page(
         table_height = min(0.90, 0.115 * (len(rows) + 1))
         table = axis.table(
             cellText=rows,
-            colLabels=("Sample / time", "Top contributors", "Contribution share", "Explanation coverage"),
+            colLabels=("Anomalous timestamp", "Top contributors", "Contribution share", "Explanation coverage"),
             colWidths=(0.18, 0.34, 0.22, 0.20),
             cellLoc="left",
             colLoc="left",

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -25,6 +26,8 @@ EXPLANATION_COLUMNS = {
     "ExplanationCoverage",
     "ExplanationMethod",
 }
+REQUIRED_EXPLANATION_COLUMNS = ("TopContributors", "ContributionShares", "ExplanationCoverage")
+MAX_EXPLANATIONS_PER_PAGE = 7
 
 
 def infer_ground_truth_column(df: pd.DataFrame) -> str | None:
@@ -121,6 +124,63 @@ def _classification_summary(detected: np.ndarray, ground_truth: np.ndarray | Non
             ("Precision / Recall / F1", f"{precision:.3f} / {recall:.3f} / {f1:.3f}"),
         ]
     )
+    return rows
+
+
+def _parse_explanation_list(value, *, name: str) -> list:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"{name} must contain a valid JSON list.") from error
+    if not isinstance(value, (list, tuple, np.ndarray)):
+        raise TypeError(f"{name} must contain a list for each detected anomaly.")
+    return list(value)
+
+
+def _format_explanation_sample(value, *, is_datetime: bool) -> str:
+    if is_datetime:
+        return pd.Timestamp(value).strftime("%Y-%m-%d\n%H:%M:%S")
+    return str(value)
+
+
+def _resolve_explanation_rows(
+    result_df: pd.DataFrame,
+    detected: np.ndarray,
+    x_values,
+    *,
+    is_datetime: bool,
+) -> list[tuple[str, str, str, str]] | None:
+    present = [column for column in REQUIRED_EXPLANATION_COLUMNS if column in result_df.columns]
+    if not present:
+        return None
+    missing = [column for column in REQUIRED_EXPLANATION_COLUMNS if column not in result_df.columns]
+    if missing:
+        raise ValueError(f"Explainability report data is missing columns: {missing}.")
+
+    rows = []
+    x_array = np.asarray(x_values)
+    for row_index in np.flatnonzero(detected):
+        contributors = _parse_explanation_list(result_df.iloc[row_index]["TopContributors"], name="TopContributors")
+        shares = _parse_explanation_list(result_df.iloc[row_index]["ContributionShares"], name="ContributionShares")
+        if len(contributors) != len(shares):
+            raise ValueError("TopContributors and ContributionShares must have matching lengths.")
+
+        numeric_shares = np.asarray(shares, dtype=float)
+        if not np.isfinite(numeric_shares).all() or ((numeric_shares < 0) | (numeric_shares > 1)).any():
+            raise ValueError("ContributionShares must contain only finite values between 0 and 1.")
+        coverage = pd.to_numeric(result_df.iloc[row_index]["ExplanationCoverage"], errors="coerce")
+        if not np.isfinite(coverage) or not 0 <= coverage <= 1:
+            raise ValueError("ExplanationCoverage must contain only finite values between 0 and 1.")
+
+        rows.append(
+            (
+                _format_explanation_sample(x_array[row_index], is_datetime=is_datetime),
+                "\n".join(map(str, contributors)) or "Not available",
+                "\n".join(f"{share:.1%}" for share in numeric_shares) or "Not available",
+                f"{coverage:.1%}",
+            )
+        )
     return rows
 
 
@@ -272,6 +332,82 @@ def _create_feature_page(
     return figure
 
 
+def _create_explanation_page(
+    rows: Sequence[tuple[str, str, str, str]],
+    *,
+    page_number: int,
+    explanation_page_number: int,
+    explanation_page_count: int,
+) -> Figure:
+    figure = Figure(figsize=(11.0, 8.5), facecolor="white")
+    axis = figure.add_axes((0.07, 0.10, 0.86, 0.76))
+    axis.axis("off")
+    figure.suptitle(
+        f"Anomaly explanations ({explanation_page_number}/{explanation_page_count})",
+        x=0.07,
+        y=0.955,
+        ha="left",
+        fontsize=18,
+        fontweight="bold",
+        color="#17365D",
+    )
+    figure.text(
+        0.07,
+        0.895,
+        "Reconstruction-error attribution for each detected anomaly",
+        fontsize=10,
+        color="#667085",
+    )
+
+    if rows:
+        table_height = min(0.90, 0.115 * (len(rows) + 1))
+        table = axis.table(
+            cellText=rows,
+            colLabels=("Sample / time", "Top contributors", "Contribution share", "Explanation coverage"),
+            colWidths=(0.18, 0.34, 0.22, 0.20),
+            cellLoc="left",
+            colLoc="left",
+            loc="upper left",
+            bbox=(0.0, 0.98 - table_height, 1.0, table_height),
+        )
+        table.auto_set_font_size(False)
+        table.set_fontsize(8)
+        row_height = table_height / (len(rows) + 1)
+        for (row_index, _), cell in table.get_celld().items():
+            cell.set_height(row_height)
+            cell.set_edgecolor("#D0D5DD")
+            cell.set_linewidth(0.6)
+            cell.PAD = 0.08
+            cell.get_text().set_verticalalignment("center")
+            if row_index == 0:
+                cell.set_facecolor("#EAF2F8")
+                cell.get_text().set_color("#17365D")
+                cell.get_text().set_fontweight("bold")
+            else:
+                cell.set_facecolor("#FFFFFF" if row_index % 2 else "#F9FAFB")
+                cell.get_text().set_color("#344054")
+    else:
+        axis.text(
+            0.0,
+            0.88,
+            "No detected anomalies were available to explain.",
+            fontsize=11,
+            color="#475467",
+            va="top",
+        )
+
+    figure.text(
+        0.07,
+        0.065,
+        "Contribution shares correspond to the contributors in the same order. Coverage is the fraction of total "
+        "reconstruction error represented by the listed contributors.",
+        fontsize=7.5,
+        color="#667085",
+    )
+    _add_footer(figure, page_number)
+    return figure
+
+
 def _create_mae_note_page(*, page_number: int) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
     axis = figure.add_axes((0.09, 0.12, 0.82, 0.76))
@@ -369,6 +505,12 @@ def generate_anomaly_detection_report(
     if not np.isfinite(scores).all():
         raise ValueError(f"{score_column} must contain only finite numeric values.")
     x_values, x_label, is_datetime = _resolve_x_axis(result_df, resolved_timestamp)
+    explanation_rows = _resolve_explanation_rows(
+        result_df,
+        detected,
+        x_values,
+        is_datetime=is_datetime,
+    )
 
     destination = Path(output_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -376,7 +518,15 @@ def generate_anomaly_detection_report(
         resolved_features[index : index + max_features_per_page]
         for index in range(0, len(resolved_features), max_features_per_page)
     ]
-    page_count = 2 + len(feature_groups)
+    explanation_groups = (
+        [
+            explanation_rows[index : index + MAX_EXPLANATIONS_PER_PAGE]
+            for index in range(0, len(explanation_rows), MAX_EXPLANATIONS_PER_PAGE)
+        ]
+        if explanation_rows
+        else ([[]] if explanation_rows is not None else [])
+    )
+    page_count = 2 + len(feature_groups) + len(explanation_groups)
 
     with PdfPages(destination, metadata={"Title": title, "Subject": "Time-series anomaly detection report"}) as pdf:
         pdf.savefig(
@@ -404,6 +554,16 @@ def generate_anomaly_detection_report(
                     page_number=page_number,
                     feature_page_number=feature_page_number,
                     feature_page_count=len(feature_groups),
+                )
+            )
+        for explanation_page_number, group in enumerate(explanation_groups, start=1):
+            page_number = 1 + len(feature_groups) + explanation_page_number
+            pdf.savefig(
+                _create_explanation_page(
+                    group,
+                    page_number=page_number,
+                    explanation_page_number=explanation_page_number,
+                    explanation_page_count=len(explanation_groups),
                 )
             )
         pdf.savefig(_create_mae_note_page(page_number=page_count))

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -14,7 +14,6 @@ import numpy as np
 import pandas as pd
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.figure import Figure
-from matplotlib.patches import Patch
 
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
@@ -29,7 +28,7 @@ EXPLANATION_COLUMNS = {
 }
 REQUIRED_EXPLANATION_COLUMNS = ("TopContributors", "ContributionShares", "ExplanationCoverage")
 MAX_EXPLANATIONS_PER_PAGE = 7
-CONTRIBUTOR_RANK_COLORS = ("#175CD3", "#12B76A", "#F79009", "#7F56D9", "#06AED4")
+FEATURE_COLORS = ("#175CD3", "#039855", "#F79009", "#7F56D9", "#0E9384", "#D92D20", "#444CE7", "#C11574")
 
 
 def infer_ground_truth_column(df: pd.DataFrame) -> str | None:
@@ -340,6 +339,7 @@ def _create_contribution_graph_page(
     page_number: int,
     graph_page_number: int,
     graph_page_count: int,
+    feature_colors: dict[str, str] | None = None,
 ) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
     axis = figure.add_axes((0.28, 0.14, 0.64, 0.66))
@@ -355,7 +355,7 @@ def _create_contribution_graph_page(
     figure.text(
         0.07,
         0.895,
-        "Stacked shares of total reconstruction error; gray shows error outside the displayed contributors",
+        "Each segment shows the contributing feature and its share; gray shows error outside the displayed features",
         fontsize=10,
         color="#667085",
     )
@@ -378,7 +378,18 @@ def _create_contribution_graph_page(
         -1,
     )
     y_labels = []
-    max_contributors = 0
+    if feature_colors is None:
+        ordered_features = list(
+            dict.fromkeys(
+                feature
+                for _, contributor_text, _, _ in rows
+                for feature in contributor_text.splitlines()
+                if contributor_text != "Not available"
+            )
+        )
+        feature_colors = {
+            feature: FEATURE_COLORS[index % len(FEATURE_COLORS)] for index, feature in enumerate(ordered_features)
+        }
     for y_position, (timestamp, contributor_text, share_text, coverage_text) in zip(y_positions, rows, strict=True):
         contributors = contributor_text.splitlines() if contributor_text != "Not available" else []
         shares = (
@@ -386,21 +397,22 @@ def _create_contribution_graph_page(
             if share_text != "Not available"
             else []
         )
-        max_contributors = max(max_contributors, len(contributors))
         left = 0.0
-        for rank, share in enumerate(shares):
-            color = CONTRIBUTOR_RANK_COLORS[rank % len(CONTRIBUTOR_RANK_COLORS)]
+        for contributor, share in zip(contributors, shares, strict=True):
+            color = feature_colors[contributor]
             axis.barh(y_position, share, left=left, height=0.58, color=color, edgecolor="white", linewidth=0.8)
-            if share >= 0.055:
+            if share >= 0.075:
+                display_name = contributor if len(contributor) <= 14 else f"{contributor[:12]}..."
                 axis.text(
                     left + share / 2,
                     y_position,
-                    f"{share:.0%}",
+                    f"{display_name}\n{share:.0%}",
                     ha="center",
                     va="center",
-                    fontsize=7,
+                    fontsize=6.5,
                     fontweight="bold",
-                    color="white" if rank != 2 else "#101828",
+                    color="#101828" if color == "#F79009" else "white",
+                    linespacing=0.9,
                 )
             left += share
 
@@ -415,10 +427,7 @@ def _create_contribution_graph_page(
             linewidth=0.8,
         )
         axis.text(1.015, y_position, f"{coverage_text} covered", va="center", fontsize=7.5, color="#475467")
-        ranked_names = (
-            " > ".join(f"{rank + 1}. {name[:18]}" for rank, name in enumerate(contributors)) or "No contributors"
-        )
-        y_labels.append(f"{timestamp.replace(chr(10), ' ')}\n{ranked_names}")
+        y_labels.append(timestamp.replace("\n", " "))
 
     axis.set_yticks(y_positions, labels=y_labels)
     axis.set_ylim(-0.75, MAX_EXPLANATIONS_PER_PAGE - 0.25)
@@ -430,20 +439,6 @@ def _create_contribution_graph_page(
     axis.spines[["top", "right", "left"]].set_visible(False)
     axis.tick_params(axis="y", length=0, labelsize=7.5, colors="#344054", pad=8)
     axis.tick_params(axis="x", labelsize=8, colors="#667085")
-
-    legend_handles = [
-        Patch(color=CONTRIBUTOR_RANK_COLORS[rank], label=f"Contributor rank {rank + 1}")
-        for rank in range(max_contributors)
-    ]
-    legend_handles.append(Patch(color="#D0D5DD", label="Uncovered"))
-    axis.legend(
-        handles=legend_handles,
-        loc="lower left",
-        bbox_to_anchor=(0.0, 1.03),
-        frameon=False,
-        fontsize=8,
-        ncols=min(4, len(legend_handles)),
-    )
     _add_footer(figure, page_number)
     return figure
 
@@ -618,6 +613,17 @@ def generate_anomaly_detection_report(
         if explanation_rows
         else ([[]] if explanation_rows is not None else [])
     )
+    explanation_features = list(
+        dict.fromkeys(
+            feature
+            for _, contributor_text, _, _ in (explanation_rows or [])
+            for feature in contributor_text.splitlines()
+            if contributor_text != "Not available"
+        )
+    )
+    explanation_feature_colors = {
+        feature: FEATURE_COLORS[index % len(FEATURE_COLORS)] for index, feature in enumerate(explanation_features)
+    }
     page_count = 2 + len(feature_groups) + len(explanation_groups)
 
     with PdfPages(destination, metadata={"Title": title, "Subject": "Time-series anomaly detection report"}) as pdf:
@@ -656,6 +662,7 @@ def generate_anomaly_detection_report(
                     page_number=page_number,
                     graph_page_number=graph_page_number,
                     graph_page_count=len(explanation_groups),
+                    feature_colors=explanation_feature_colors,
                 )
             )
         pdf.savefig(_create_mae_note_page(page_number=page_count))

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -28,6 +28,8 @@ EXPLANATION_COLUMNS = {
 }
 REQUIRED_EXPLANATION_COLUMNS = ("TopContributors", "ContributionShares", "ExplanationCoverage")
 MAX_EXPLANATIONS_PER_PAGE = 7
+DEFAULT_MAX_REPORT_PAGES = 10
+DEFAULT_CONSOLIDATED_TOP_K = 5
 FEATURE_COLORS = ("#175CD3", "#039855", "#F79009", "#7F56D9", "#0E9384", "#D92D20", "#444CE7", "#C11574")
 
 
@@ -278,7 +280,7 @@ def _create_feature_page(
 ) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
     axes = figure.subplots(len(feature_columns), 1, sharex=True, squeeze=False)
-    figure.subplots_adjust(left=0.09, right=0.96, top=0.90, bottom=0.10, hspace=0.42)
+    figure.subplots_adjust(left=0.09, right=0.96, top=0.84, bottom=0.10, hspace=0.42)
     figure.suptitle(
         f"Original signals with anomaly overlays ({feature_page_number}/{feature_page_count})",
         x=0.09,
@@ -443,6 +445,107 @@ def _create_contribution_graph_page(
     return figure
 
 
+def _aggregate_explanation_contributions(
+    result_df: pd.DataFrame,
+    detected: np.ndarray,
+    *,
+    score_column: str,
+    top_k: int,
+) -> tuple[list[tuple[str, float]], float]:
+    """Aggregate contributor shares across anomalies, weighted by anomaly MAE."""
+    scores = pd.to_numeric(result_df[score_column], errors="coerce").to_numpy(dtype=float)
+    total_anomaly_score = float(scores[detected].sum())
+    weighted_contributions: dict[str, float] = {}
+    for row_index in np.flatnonzero(detected):
+        contributors = _parse_explanation_list(result_df.iloc[row_index]["TopContributors"], name="TopContributors")
+        shares = _parse_explanation_list(result_df.iloc[row_index]["ContributionShares"], name="ContributionShares")
+        for contributor, share in zip(contributors, shares, strict=True):
+            feature = str(contributor)
+            weighted_contributions[feature] = weighted_contributions.get(feature, 0.0) + scores[row_index] * float(
+                share
+            )
+
+    ranked = sorted(weighted_contributions.items(), key=lambda item: (-item[1], item[0]))[:top_k]
+    if total_anomaly_score <= 0:
+        contributions = [(feature, 0.0) for feature, _ in ranked]
+    else:
+        contributions = [(feature, value / total_anomaly_score) for feature, value in ranked]
+    return contributions, sum(share for _, share in contributions)
+
+
+def _create_consolidated_contribution_page(
+    contributions: Sequence[tuple[str, float]],
+    *,
+    coverage: float,
+    anomaly_count: int,
+    page_number: int,
+    max_report_pages: int,
+) -> Figure:
+    """Create one page summarizing the strongest contributors across all anomalies."""
+    figure = Figure(figsize=(11.0, 8.5), facecolor="white")
+    axis = figure.add_axes((0.25, 0.20, 0.66, 0.55))
+    figure.suptitle(
+        "Overall anomaly feature contributions",
+        x=0.07,
+        y=0.955,
+        ha="left",
+        fontsize=18,
+        fontweight="bold",
+        color="#17365D",
+    )
+    figure.text(
+        0.07,
+        0.895,
+        f"Top {len(contributions)} contributors across {anomaly_count:,} detected anomalies, weighted by anomaly MAE.",
+        fontsize=10,
+        color="#667085",
+    )
+    figure.text(
+        0.07,
+        0.855,
+        f"Per-anomaly charts were consolidated to keep this report within {max_report_pages} pages; full details are in the companion CSV.",
+        fontsize=9,
+        color="#667085",
+    )
+    if not contributions:
+        axis.axis("off")
+        axis.text(0.0, 0.8, "No contributor data was available to summarize.", fontsize=11, color="#475467")
+        _add_footer(figure, page_number)
+        return figure
+
+    features = [feature for feature, _ in contributions][::-1]
+    shares = np.asarray([share for _, share in contributions][::-1], dtype=float)
+    colors = [FEATURE_COLORS[index % len(FEATURE_COLORS)] for index in range(len(features))]
+    bars = axis.barh(np.arange(len(features)), shares, color=colors, height=0.62)
+    axis.set_yticks(np.arange(len(features)), labels=features)
+    axis.set_xlim(0.0, max(0.05, min(1.0, float(shares.max()) * 1.22)))
+    axis.xaxis.set_major_formatter(lambda value, _position: f"{value:.0%}")
+    axis.set_xlabel("Share of total detected-anomaly MAE", fontsize=9, color="#344054")
+    axis.grid(axis="x", color="#D8DEE9", linewidth=0.6, alpha=0.8)
+    axis.set_axisbelow(True)
+    axis.spines[["top", "right", "left"]].set_visible(False)
+    axis.tick_params(axis="y", length=0, labelsize=8, colors="#344054", pad=8)
+    axis.tick_params(axis="x", labelsize=8, colors="#667085")
+    for bar, share in zip(bars, shares, strict=True):
+        axis.text(
+            bar.get_width() + axis.get_xlim()[1] * 0.015,
+            bar.get_y() + bar.get_height() / 2,
+            f"{share:.1%}",
+            va="center",
+            fontsize=8,
+            color="#344054",
+        )
+    figure.text(
+        0.25,
+        0.125,
+        f"Displayed features explain {coverage:.1%} of total detected-anomaly MAE; the remainder is outside the displayed contributors.",
+        fontsize=9,
+        color="#475467",
+    )
+    _add_footer(figure, page_number)
+    return figure
+
+
 def _write_explanation_csv(
     result_df: pd.DataFrame,
     detected: np.ndarray,
@@ -535,6 +638,8 @@ def generate_anomaly_detection_report(
     title: str = "Anomaly Detection Report",
     max_features_per_page: int = 4,
     explanation_csv_path: str | Path | None = None,
+    max_report_pages: int = DEFAULT_MAX_REPORT_PAGES,
+    consolidated_top_k: int = DEFAULT_CONSOLIDATED_TOP_K,
 ) -> Path:
     """Create a PDF report from an anomaly-analysis result DataFrame.
 
@@ -553,6 +658,14 @@ def generate_anomaly_detection_report(
         raise TypeError("max_features_per_page must be an integer.")
     if max_features_per_page < 1:
         raise ValueError("max_features_per_page must be at least 1.")
+    if not isinstance(max_report_pages, int) or isinstance(max_report_pages, bool):
+        raise TypeError("max_report_pages must be an integer.")
+    if max_report_pages < 4:
+        raise ValueError("max_report_pages must be at least 4.")
+    if not isinstance(consolidated_top_k, int) or isinstance(consolidated_top_k, bool):
+        raise TypeError("consolidated_top_k must be an integer.")
+    if consolidated_top_k < 1:
+        raise ValueError("consolidated_top_k must be at least 1.")
 
     resolved_timestamp = _resolve_column(
         result_df,
@@ -605,9 +718,15 @@ def generate_anomaly_detection_report(
             csv_destination,
             is_datetime=is_datetime,
         )
+    reserved_pages = 2 + (1 if explanation_rows is not None else 0)
+    available_feature_pages = max(1, max_report_pages - reserved_pages)
+    effective_features_per_page = max(
+        max_features_per_page,
+        int(np.ceil(len(resolved_features) / available_feature_pages)),
+    )
     feature_groups = [
-        resolved_features[index : index + max_features_per_page]
-        for index in range(0, len(resolved_features), max_features_per_page)
+        resolved_features[index : index + effective_features_per_page]
+        for index in range(0, len(resolved_features), effective_features_per_page)
     ]
     explanation_groups = (
         [
@@ -628,7 +747,20 @@ def generate_anomaly_detection_report(
     explanation_feature_colors = {
         feature: FEATURE_COLORS[index % len(FEATURE_COLORS)] for index, feature in enumerate(explanation_features)
     }
-    page_count = 2 + len(feature_groups) + len(explanation_groups)
+    detailed_page_count = 2 + len(feature_groups) + len(explanation_groups)
+    use_consolidated_explanations = explanation_rows is not None and detailed_page_count > max_report_pages
+    consolidated_contributions: list[tuple[str, float]] = []
+    consolidated_coverage = 0.0
+    if use_consolidated_explanations:
+        consolidated_contributions, consolidated_coverage = _aggregate_explanation_contributions(
+            result_df,
+            detected,
+            score_column=score_column,
+            top_k=consolidated_top_k,
+        )
+        page_count = 3 + len(feature_groups)
+    else:
+        page_count = detailed_page_count
 
     with PdfPages(destination, metadata={"Title": title, "Subject": "Time-series anomaly detection report"}) as pdf:
         pdf.savefig(
@@ -658,7 +790,20 @@ def generate_anomaly_detection_report(
                     feature_page_count=len(feature_groups),
                 )
             )
-        for graph_page_number, group in enumerate(explanation_groups, start=1):
+        if use_consolidated_explanations:
+            pdf.savefig(
+                _create_consolidated_contribution_page(
+                    consolidated_contributions,
+                    coverage=consolidated_coverage,
+                    anomaly_count=int(detected.sum()),
+                    page_number=2 + len(feature_groups),
+                    max_report_pages=max_report_pages,
+                )
+            )
+        for graph_page_number, group in enumerate(
+            [] if use_consolidated_explanations else explanation_groups,
+            start=1,
+        ):
             page_number = 1 + len(feature_groups) + graph_page_number
             pdf.savefig(
                 _create_contribution_graph_page(

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -18,7 +18,7 @@ from matplotlib.figure import Figure
 if TYPE_CHECKING:
     from collections.abc import Hashable, Sequence
 
-GROUND_TRUTH_CANDIDATES = ("GT", "ground_truth", "is_anomaly", "label", "Label")
+GROUND_TRUTH_CANDIDATES = ("GT", "ground_truth", "is_anomaly", "anomaly", "label", "Label")
 TIMESTAMP_CANDIDATES = ("timestamp", "Timestamp", "time", "Time", "ts", "datetime", "date")
 EXPLANATION_COLUMNS = {
     "TopContributors",
@@ -60,7 +60,7 @@ def _resolve_x_axis(df: pd.DataFrame, timestamp_column: str | None) -> tuple[np.
     if timestamp_column is None:
         if isinstance(df.index, pd.DatetimeIndex):
             return pd.Series(df.index, index=df.index), "Time", True
-        return np.arange(len(df)), "Sample", False
+        return np.arange(len(df)), "Row number (no timestamp column)", False
 
     values = df[timestamp_column]
     if pd.api.types.is_numeric_dtype(values):
@@ -69,7 +69,7 @@ def _resolve_x_axis(df: pd.DataFrame, timestamp_column: str | None) -> tuple[np.
     parsed = pd.to_datetime(values, errors="coerce")
     if parsed.notna().all():
         return parsed, timestamp_column, True
-    return np.arange(len(df)), f"Sample ({timestamp_column} unavailable as time)", False
+    return np.arange(len(df)), f"Row number ({timestamp_column} unavailable as time)", False
 
 
 def _resolve_feature_columns(

--- a/ad_diffusion/sdk/tests/test_anomaly_analysis.py
+++ b/ad_diffusion/sdk/tests/test_anomaly_analysis.py
@@ -188,6 +188,41 @@ def test_optional_pdf_report_excludes_metadata_from_inference(monkeypatch, infer
     assert destination.read_bytes().startswith(b"%PDF")
 
 
+def test_lowercase_anomaly_metadata_is_excluded_from_inference(monkeypatch, inference_results, tmp_path):
+    """A lowercase anomaly label should not replace valid signal names with model components."""
+    feature_names = [
+        "x",
+        "y",
+        "z",
+        "010-000-024-033",
+        "010-000-030-096",
+        "020-000-032-221",
+        "020-000-033-111",
+    ]
+    input_df = pd.DataFrame(np.ones((5, len(feature_names))), columns=feature_names)
+    input_df["anomaly"] = [0, 1, 0, 0, 1]
+    mock_inference = Mock(return_value=inference_results)
+    monkeypatch.setattr(anomaly_analysis, "inference_ad_tesseract2_mp", mock_inference)
+
+    mock_thresholder = Mock()
+    mock_thresholder.detect_anomalies.return_value = np.array([False, True, False, False, True])
+    mock_strategy = Mock()
+    mock_strategy.scs_thresholder = mock_thresholder
+    monkeypatch.setattr(anomaly_analysis, "SCSThresholdStrategy", Mock(return_value=mock_strategy))
+    monkeypatch.setattr(anomaly_analysis, "generate_anomaly_detection_report", Mock())
+
+    anomaly_analysis.perform_anomaly_analysis_with_diffusion(
+        input_df,
+        threshold_strategy="scs",
+        model_path="model.pth",
+        config_path="config.yaml",
+        report_path=tmp_path / "report.pdf",
+    )
+
+    inference_df = mock_inference.call_args.kwargs["data"]
+    assert list(inference_df.columns) == feature_names
+
+
 def test_report_metadata_arguments_are_ignored_without_report_path(monkeypatch, inference_results):
     """Report-only arguments must not alter the default inference feature set."""
     input_df = pd.DataFrame(

--- a/ad_diffusion/sdk/tests/test_anomaly_analysis.py
+++ b/ad_diffusion/sdk/tests/test_anomaly_analysis.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import sys
 from pathlib import Path
 from unittest.mock import Mock
@@ -188,8 +189,8 @@ def test_optional_pdf_report_excludes_metadata_from_inference(monkeypatch, infer
     assert destination.read_bytes().startswith(b"%PDF")
 
 
-def test_lowercase_anomaly_metadata_is_excluded_from_inference(monkeypatch, inference_results, tmp_path):
-    """A lowercase anomaly label should not replace valid signal names with model components."""
+def test_explain_toggle_preserves_numeric_feature_names(monkeypatch, tmp_path):
+    """The full analysis path should explain anomalies using the input signal names."""
     feature_names = [
         "x",
         "y",
@@ -201,6 +202,15 @@ def test_lowercase_anomaly_metadata_is_excluded_from_inference(monkeypatch, infe
     ]
     input_df = pd.DataFrame(np.ones((5, len(feature_names))), columns=feature_names)
     input_df["anomaly"] = [0, 1, 0, 0, 1]
+    target = np.zeros((5, len(feature_names)))
+    reconstruction = np.zeros_like(target)
+    reconstruction[1] = [0, 0, 0, 7, 6, 5, 4]
+    reconstruction[4] = [1, 2, 3, 4, 5, 6, 7]
+    inference_results = {
+        "residual": np.array([0.0, 22 / 7, 0.0, 0.0, 4.0]),
+        "target": target,
+        "recon": reconstruction,
+    }
     mock_inference = Mock(return_value=inference_results)
     monkeypatch.setattr(anomaly_analysis, "inference_ad_tesseract2_mp", mock_inference)
 
@@ -211,16 +221,24 @@ def test_lowercase_anomaly_metadata_is_excluded_from_inference(monkeypatch, infe
     monkeypatch.setattr(anomaly_analysis, "SCSThresholdStrategy", Mock(return_value=mock_strategy))
     monkeypatch.setattr(anomaly_analysis, "generate_anomaly_detection_report", Mock())
 
-    anomaly_analysis.perform_anomaly_analysis_with_diffusion(
+    result = anomaly_analysis.perform_anomaly_analysis_with_diffusion(
         input_df,
         threshold_strategy="scs",
         model_path="model.pth",
         config_path="config.yaml",
         report_path=tmp_path / "report.pdf",
+        explain=True,
+        explanation_top_k=3,
     )
 
     inference_df = mock_inference.call_args.kwargs["data"]
     assert list(inference_df.columns) == feature_names
+    assert result.loc[0, "TopContributors"] == "[]"
+    assert result.loc[1, "TopContributors"] == ('["010-000-024-033","010-000-030-096","020-000-032-221"]')
+    assert json.loads(result.loc[1, "ContributionShares"]) == pytest.approx([7 / 22, 6 / 22, 5 / 22], abs=1e-6)
+    assert result.loc[1, "ExplanationCoverage"] == pytest.approx(18 / 22)
+    assert result.loc[1, "ExplanationMethod"] == "reconstruction_error"
+    mock_inference.assert_called_once()
 
 
 def test_report_metadata_arguments_are_ignored_without_report_path(monkeypatch, inference_results):

--- a/ad_diffusion/sdk/tests/test_anomaly_analysis.py
+++ b/ad_diffusion/sdk/tests/test_anomaly_analysis.py
@@ -202,12 +202,13 @@ def test_explain_toggle_preserves_numeric_feature_names(monkeypatch, tmp_path):
     ]
     input_df = pd.DataFrame(np.ones((5, len(feature_names))), columns=feature_names)
     input_df["anomaly"] = [0, 1, 0, 0, 1]
-    target = np.zeros((5, len(feature_names)))
+    target = np.zeros((5, 40))
     reconstruction = np.zeros_like(target)
-    reconstruction[1] = [0, 0, 0, 7, 6, 5, 4]
-    reconstruction[4] = [1, 2, 3, 4, 5, 6, 7]
+    reconstruction[1, :7] = [0, 0, 0, 7, 6, 5, 4]
+    reconstruction[1, 27] = 100
+    reconstruction[4, :7] = [1, 2, 3, 4, 5, 6, 7]
     inference_results = {
-        "residual": np.array([0.0, 22 / 7, 0.0, 0.0, 4.0]),
+        "residual": np.array([0.0, 122 / 40, 0.0, 0.0, 28 / 40]),
         "target": target,
         "recon": reconstruction,
     }
@@ -235,10 +236,44 @@ def test_explain_toggle_preserves_numeric_feature_names(monkeypatch, tmp_path):
     assert list(inference_df.columns) == feature_names
     assert result.loc[0, "TopContributors"] == "[]"
     assert result.loc[1, "TopContributors"] == ('["010-000-024-033","010-000-030-096","020-000-032-221"]')
-    assert json.loads(result.loc[1, "ContributionShares"]) == pytest.approx([7 / 22, 6 / 22, 5 / 22], abs=1e-6)
-    assert result.loc[1, "ExplanationCoverage"] == pytest.approx(18 / 22)
+    assert json.loads(result.loc[1, "ContributionShares"]) == pytest.approx([7 / 122, 6 / 122, 5 / 122], abs=1e-6)
+    assert result.loc[1, "ExplanationCoverage"] == pytest.approx(18 / 122)
     assert result.loc[1, "ExplanationMethod"] == "reconstruction_error"
     mock_inference.assert_called_once()
+
+
+@pytest.mark.parametrize("input_feature_count", [1, 7, 39, 40])
+def test_explain_toggle_maps_any_supported_input_width(monkeypatch, input_feature_count):
+    """Every directly mapped width up to target_dim should retain its input names."""
+    sample_count = 40
+    feature_names = [f"signal_{index}" for index in range(input_feature_count)]
+    input_df = pd.DataFrame(np.ones((sample_count, input_feature_count)), columns=feature_names)
+    target = np.zeros((sample_count, 40))
+    reconstruction = np.zeros_like(target)
+    reconstruction[0, :input_feature_count] = np.arange(1, input_feature_count + 1)
+    inference_results = {
+        "residual": np.abs(reconstruction).mean(axis=1),
+        "target": target,
+        "recon": reconstruction,
+    }
+    monkeypatch.setattr(anomaly_analysis, "get_model_target_dim", lambda model_path, config_path: 40)
+    monkeypatch.setattr(anomaly_analysis, "inference_ad_tesseract2_mp", Mock(return_value=inference_results))
+    mock_thresholder = Mock()
+    mock_thresholder.detect_anomalies.return_value = np.array([True] + [False] * (sample_count - 1))
+    mock_strategy = Mock()
+    mock_strategy.scs_thresholder = mock_thresholder
+    monkeypatch.setattr(anomaly_analysis, "SCSThresholdStrategy", Mock(return_value=mock_strategy))
+
+    result = anomaly_analysis.perform_anomaly_analysis_with_diffusion(
+        input_df,
+        threshold_strategy="scs",
+        model_path="model.pth",
+        config_path="config.yaml",
+        explain=True,
+    )
+
+    contributors = json.loads(result.loc[0, "TopContributors"])
+    assert contributors == feature_names[-min(3, input_feature_count) :][::-1]
 
 
 def test_report_metadata_arguments_are_ignored_without_report_path(monkeypatch, inference_results):

--- a/ad_diffusion/sdk/tests/test_explainability.py
+++ b/ad_diffusion/sdk/tests/test_explainability.py
@@ -54,6 +54,32 @@ def test_zero_error_has_zero_contribution_shares() -> None:
     assert explanations.loc[0, "ExplanationCoverage"] == 0.0
 
 
+def test_maps_input_features_without_renormalizing_padded_model_error() -> None:
+    """Mapped inputs should keep their shares of total model-space MAE."""
+    explanations = explain_reconstruction_anomalies(
+        target=np.zeros((1, 4)),
+        reconstruction=np.array([[4.0, 3.0, 2.0, 1.0]]),
+        feature_names=["temperature", "pressure"],
+        feature_indices=[0, 1],
+        top_k=2,
+    )
+
+    assert json.loads(explanations.loc[0, "TopContributors"]) == ["temperature", "pressure"]
+    assert json.loads(explanations.loc[0, "ContributionShares"]) == pytest.approx([0.4, 0.3])
+    assert explanations.loc[0, "ExplanationCoverage"] == pytest.approx(0.7)
+
+
+@pytest.mark.parametrize("feature_indices", [[], [0, 0], [0, 2]])
+def test_rejects_invalid_feature_indices(feature_indices: list[int]) -> None:
+    with pytest.raises(ValueError, match="feature_indices"):
+        explain_reconstruction_anomalies(
+            target=np.zeros((1, 2)),
+            reconstruction=np.ones((1, 2)),
+            feature_names=["a"] * len(feature_indices),
+            feature_indices=feature_indices,
+        )
+
+
 def test_rejects_mismatched_feature_names() -> None:
     with pytest.raises(ValueError, match="feature_names has 1 entries"):
         explain_reconstruction_anomalies(

--- a/ad_diffusion/sdk/tests/test_explainability.py
+++ b/ad_diffusion/sdk/tests/test_explainability.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for reconstruction-based anomaly explanations."""
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sdk.explainability import explain_reconstruction_anomalies
+
+
+def test_ranks_exact_reconstruction_error_contributions() -> None:
+    explanations = explain_reconstruction_anomalies(
+        target=np.array([[3.0, 4.0, 5.0]]),
+        reconstruction=np.array([[1.0, 3.0, 5.0]]),
+        feature_names=["pressure", "flow", "power"],
+        top_k=2,
+    )
+
+    assert json.loads(explanations.loc[0, "TopContributors"]) == ["pressure", "flow"]
+    assert json.loads(explanations.loc[0, "ContributionShares"]) == pytest.approx([2 / 3, 1 / 3], abs=1e-6)
+    assert explanations.loc[0, "ExplanationCoverage"] == pytest.approx(1.0)
+    assert explanations.loc[0, "ExplanationMethod"] == "reconstruction_error"
+
+
+def test_explains_only_rows_selected_by_anomaly_mask() -> None:
+    explanations = explain_reconstruction_anomalies(
+        target=np.array([[1.0, 2.0], [4.0, 8.0]]),
+        reconstruction=np.zeros((2, 2)),
+        anomaly_mask=np.array([False, True]),
+        top_k=1,
+    )
+
+    assert explanations.loc[0, "TopContributors"] == "[]"
+    assert explanations.loc[0, "ExplanationMethod"] == ""
+    assert json.loads(explanations.loc[1, "TopContributors"]) == ["component_1"]
+    assert explanations.loc[1, "ExplanationCoverage"] == pytest.approx(2 / 3)
+
+
+def test_zero_error_has_zero_contribution_shares() -> None:
+    explanations = explain_reconstruction_anomalies(
+        target=np.ones((1, 2)),
+        reconstruction=np.ones((1, 2)),
+        top_k=2,
+    )
+
+    assert json.loads(explanations.loc[0, "ContributionShares"]) == [0.0, 0.0]
+    assert explanations.loc[0, "ExplanationCoverage"] == 0.0
+
+
+def test_rejects_mismatched_feature_names() -> None:
+    with pytest.raises(ValueError, match="feature_names has 1 entries"):
+        explain_reconstruction_anomalies(
+            target=np.ones((2, 2)),
+            reconstruction=np.zeros((2, 2)),
+            feature_names=["only_one"],
+        )
+
+
+@pytest.mark.parametrize("top_k", [1.5, "2", True])
+def test_rejects_non_integer_top_k(top_k: object) -> None:
+    with pytest.raises(TypeError, match="top_k must be an integer"):
+        explain_reconstruction_anomalies(
+            target=np.ones((2, 2)),
+            reconstruction=np.zeros((2, 2)),
+            top_k=top_k,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    ("target", "reconstruction"),
+    [
+        (np.array([[np.nan, 1.0]]), np.zeros((1, 2))),
+        (np.ones((1, 2)), np.array([[0.0, np.inf]])),
+    ],
+)
+def test_rejects_non_finite_reconstruction_errors(target: np.ndarray, reconstruction: np.ndarray) -> None:
+    with pytest.raises(ValueError, match="only finite reconstruction errors"):
+        explain_reconstruction_anomalies(target=target, reconstruction=reconstruction)

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -12,7 +12,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from sdk.reporting import _resolve_explanation_rows, generate_anomaly_detection_report
+from sdk.reporting import (
+    _create_explanation_page,
+    _resolve_explanation_rows,
+    generate_anomaly_detection_report,
+)
 
 
 def _report_frame() -> pd.DataFrame:
@@ -131,3 +135,16 @@ def test_generate_report_without_explanations_keeps_metrics_optional() -> None:
     )
 
     assert rows is None
+
+
+def test_explanation_table_labels_anomalous_timestamp() -> None:
+    """The first explanation column should identify anomalous timestamps."""
+    figure = _create_explanation_page(
+        [("2026-01-01\n00:03:00", "temperature", "75.0%", "75.0%")],
+        page_number=3,
+        explanation_page_number=1,
+        explanation_page_count=1,
+    )
+
+    table = figure.axes[0].tables[0]
+    assert table.get_celld()[(0, 0)].get_text().get_text() == "Anomalous timestamp"

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -151,7 +151,7 @@ def test_generate_report_without_explanations_keeps_metrics_optional() -> None:
 
 
 def test_contribution_graph_visualizes_shares_and_coverage() -> None:
-    """The contribution graph should stack contributors plus uncovered error."""
+    """The graph should label feature shares and retain timestamp-only row labels."""
     figure = _create_contribution_graph_page(
         [("2026-01-01\n00:03:00", "temperature\npressure", "75.0%\n15.0%", "90.0%")],
         page_number=3,
@@ -162,5 +162,7 @@ def test_contribution_graph_visualizes_shares_and_coverage() -> None:
     axis = figure.axes[0]
     assert len(axis.patches) == 3  # Two contributor segments plus uncovered error.
     assert axis.get_title() == ""
-    assert axis.get_yticklabels()[0].get_text().startswith("2026-01-01 00:03:00")
+    assert axis.get_yticklabels()[0].get_text() == "2026-01-01 00:03:00"
+    assert any(text.get_text() == "temperature\n75%" for text in axis.texts)
+    assert any(text.get_text() == "pressure\n15%" for text in axis.texts)
     assert any(text.get_text() == "90.0% covered" for text in axis.texts)

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from sdk.reporting import (
     _create_contribution_graph_page,
+    _create_mae_note_page,
     _resolve_explanation_rows,
     _resolve_x_axis,
     generate_anomaly_detection_report,
@@ -117,6 +118,24 @@ def test_resolve_x_axis_preserves_timestamp_values() -> None:
     assert values.equals(frame["timestamp"])
     assert label == "timestamp"
     assert is_datetime is True
+
+
+def test_mae_note_page_explains_row_number_time_steps() -> None:
+    """The PDF should explain row-number time steps when timestamps are unavailable."""
+    figure = _create_mae_note_page(page_number=3, uses_row_numbers=True)
+
+    assert any(
+        text.get_text()
+        == "No usable timestamp column was provided, so time steps in this report are zero-based DataFrame row numbers."
+        for text in figure.axes[0].texts
+    )
+
+
+def test_mae_note_page_omits_row_number_note_for_timestamped_data() -> None:
+    """Timestamped reports should not show the row-number fallback note."""
+    figure = _create_mae_note_page(page_number=3, uses_row_numbers=False)
+
+    assert not any("zero-based DataFrame row numbers" in text.get_text() for text in figure.axes[0].texts)
 
 
 def test_generate_report_includes_explainability_metrics(tmp_path: Path) -> None:

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -12,7 +12,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from sdk.reporting import generate_anomaly_detection_report
+from sdk.reporting import _resolve_explanation_rows, generate_anomaly_detection_report
 
 
 def _report_frame() -> pd.DataFrame:
@@ -84,3 +84,50 @@ def test_generate_report_preserves_non_string_feature_labels(tmp_path: Path) -> 
     generate_anomaly_detection_report(frame, destination, feature_columns=[10, 20])
 
     assert destination.read_bytes().startswith(b"%PDF")
+
+
+def test_generate_report_includes_explainability_metrics(tmp_path: Path) -> None:
+    """Explainability output should add anomaly-detail metrics to the PDF."""
+    frame = _report_frame()
+    frame["TopContributors"] = ["[]"] * len(frame)
+    frame["ContributionShares"] = ["[]"] * len(frame)
+    frame["ExplanationCoverage"] = 0.0
+    frame.loc[3, ["TopContributors", "ContributionShares", "ExplanationCoverage"]] = [
+        '["temperature","pressure"]',
+        "[0.75,0.25]",
+        1.0,
+    ]
+    frame.loc[7, ["TopContributors", "ContributionShares", "ExplanationCoverage"]] = [
+        '["pressure"]',
+        "[0.6]",
+        0.6,
+    ]
+    destination = tmp_path / "explainable_report.pdf"
+
+    generate_anomaly_detection_report(frame, destination)
+
+    rows = _resolve_explanation_rows(
+        frame,
+        frame["Anomaly"].to_numpy(dtype=bool),
+        frame["timestamp"],
+        is_datetime=True,
+    )
+    assert rows == [
+        ("2026-01-01\n00:03:00", "temperature\npressure", "75.0%\n25.0%", "100.0%"),
+        ("2026-01-01\n00:07:00", "pressure", "60.0%", "60.0%"),
+    ]
+    assert destination.read_bytes().startswith(b"%PDF")
+
+
+def test_generate_report_without_explanations_keeps_metrics_optional() -> None:
+    """Reports without explanation columns should preserve the existing path."""
+    frame = _report_frame()
+
+    rows = _resolve_explanation_rows(
+        frame,
+        frame["Anomaly"].to_numpy(dtype=bool),
+        frame["timestamp"],
+        is_datetime=True,
+    )
+
+    assert rows is None

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -15,7 +15,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from sdk.reporting import (
     _create_contribution_graph_page,
     _resolve_explanation_rows,
+    _resolve_x_axis,
     generate_anomaly_detection_report,
+    infer_ground_truth_column,
 )
 
 
@@ -88,6 +90,33 @@ def test_generate_report_preserves_non_string_feature_labels(tmp_path: Path) -> 
     generate_anomaly_detection_report(frame, destination, feature_columns=[10, 20])
 
     assert destination.read_bytes().startswith(b"%PDF")
+
+
+def test_infers_lowercase_anomaly_as_ground_truth() -> None:
+    """A conventional lowercase anomaly label should be treated as report metadata."""
+    frame = pd.DataFrame({"signal": [1.0, 2.0], "anomaly": [0, 1]})
+
+    assert infer_ground_truth_column(frame) == "anomaly"
+
+
+def test_resolve_x_axis_identifies_row_numbers_without_timestamp() -> None:
+    """Reports without timestamps should identify their zero-based row-number axis."""
+    values, label, is_datetime = _resolve_x_axis(pd.DataFrame({"signal": [1.0, 2.0]}), None)
+
+    assert values.tolist() == [0, 1]
+    assert label == "Row number (no timestamp column)"
+    assert is_datetime is False
+
+
+def test_resolve_x_axis_preserves_timestamp_values() -> None:
+    """A valid timestamp column should remain the report's datetime axis."""
+    frame = _report_frame()
+
+    values, label, is_datetime = _resolve_x_axis(frame, "timestamp")
+
+    assert values.equals(frame["timestamp"])
+    assert label == "timestamp"
+    assert is_datetime is True
 
 
 def test_generate_report_includes_explainability_metrics(tmp_path: Path) -> None:

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -14,7 +14,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from sdk.reporting import (
     _create_contribution_graph_page,
-    _create_explanation_page,
     _resolve_explanation_rows,
     generate_anomaly_detection_report,
 )
@@ -122,6 +121,19 @@ def test_generate_report_includes_explainability_metrics(tmp_path: Path) -> None
         ("2026-01-01\n00:07:00", "pressure", "60.0%", "60.0%"),
     ]
     assert destination.read_bytes().startswith(b"%PDF")
+    csv_destination = tmp_path / "explainable_report_explanations.csv"
+    exported = pd.read_csv(csv_destination)
+    assert list(exported.columns) == [
+        "Anomalous timestamp",
+        "Top contributors",
+        "Contribution shares",
+        "Explanation coverage",
+    ]
+    assert len(exported) == 2
+    assert exported.loc[0, "Anomalous timestamp"] == "2026-01-01 00:03:00"
+    assert exported.loc[0, "Top contributors"] == '["temperature","pressure"]'
+    assert exported.loc[0, "Contribution shares"] == "[0.75,0.25]"
+    assert exported.loc[0, "Explanation coverage"] == 1.0
 
 
 def test_generate_report_without_explanations_keeps_metrics_optional() -> None:
@@ -136,19 +148,6 @@ def test_generate_report_without_explanations_keeps_metrics_optional() -> None:
     )
 
     assert rows is None
-
-
-def test_explanation_table_labels_anomalous_timestamp() -> None:
-    """The first explanation column should identify anomalous timestamps."""
-    figure = _create_explanation_page(
-        [("2026-01-01\n00:03:00", "temperature", "75.0%", "75.0%")],
-        page_number=3,
-        explanation_page_number=1,
-        explanation_page_count=1,
-    )
-
-    table = figure.axes[0].tables[0]
-    assert table.get_celld()[(0, 0)].get_text().get_text() == "Anomalous timestamp"
 
 
 def test_contribution_graph_visualizes_shares_and_coverage() -> None:

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -5,6 +5,7 @@
 
 import sys
 from pathlib import Path
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -12,7 +13,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from sdk import reporting
 from sdk.reporting import (
+    _aggregate_explanation_contributions,
     _create_contribution_graph_page,
     _create_mae_note_page,
     _resolve_explanation_rows,
@@ -214,3 +217,53 @@ def test_contribution_graph_visualizes_shares_and_coverage() -> None:
     assert any(text.get_text() == "temperature\n75%" for text in axis.texts)
     assert any(text.get_text() == "pressure\n15%" for text in axis.texts)
     assert any(text.get_text() == "90.0% covered" for text in axis.texts)
+
+
+def test_aggregate_explanations_weights_features_by_anomaly_score() -> None:
+    """Overall contributors should reflect their contribution to total anomaly MAE."""
+    frame = pd.DataFrame(
+        {
+            "Anomaly": [True, True],
+            "MAE": [1.0, 3.0],
+            "TopContributors": ['["temperature","pressure"]', '["pressure","temperature"]'],
+            "ContributionShares": ["[0.5,0.5]", "[0.75,0.25]"],
+            "ExplanationCoverage": [1.0, 1.0],
+        }
+    )
+
+    contributions, coverage = _aggregate_explanation_contributions(
+        frame,
+        frame["Anomaly"].to_numpy(dtype=bool),
+        score_column="MAE",
+        top_k=2,
+    )
+
+    assert [feature for feature, _ in contributions] == ["pressure", "temperature"]
+    assert [share for _, share in contributions] == pytest.approx([0.6875, 0.3125])
+    assert coverage == pytest.approx(1.0)
+
+
+def test_large_explanation_report_uses_one_consolidated_page(monkeypatch, tmp_path: Path) -> None:
+    """Large anomaly sets should switch from per-anomaly pages to one summary page."""
+    sample_count = 80
+    frame = pd.DataFrame(
+        {
+            "signal": np.linspace(0.0, 1.0, sample_count),
+            "Anomaly": [True] * sample_count,
+            "MAE": np.linspace(0.1, 1.0, sample_count),
+            "TopContributors": ['["signal"]'] * sample_count,
+            "ContributionShares": ["[1.0]"] * sample_count,
+            "ExplanationCoverage": [1.0] * sample_count,
+        }
+    )
+    consolidated = Mock(wraps=reporting._create_consolidated_contribution_page)
+    detailed = Mock(wraps=reporting._create_contribution_graph_page)
+    monkeypatch.setattr(reporting, "_create_consolidated_contribution_page", consolidated)
+    monkeypatch.setattr(reporting, "_create_contribution_graph_page", detailed)
+
+    generate_anomaly_detection_report(frame, tmp_path / "consolidated.pdf", max_report_pages=10)
+
+    consolidated.assert_called_once()
+    detailed.assert_not_called()
+    assert consolidated.call_args.kwargs["max_report_pages"] == 10
+    assert consolidated.call_args.kwargs["anomaly_count"] == sample_count

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from sdk.reporting import (
+    _create_contribution_graph_page,
     _create_explanation_page,
     _resolve_explanation_rows,
     generate_anomaly_detection_report,
@@ -148,3 +149,19 @@ def test_explanation_table_labels_anomalous_timestamp() -> None:
 
     table = figure.axes[0].tables[0]
     assert table.get_celld()[(0, 0)].get_text().get_text() == "Anomalous timestamp"
+
+
+def test_contribution_graph_visualizes_shares_and_coverage() -> None:
+    """The contribution graph should stack contributors plus uncovered error."""
+    figure = _create_contribution_graph_page(
+        [("2026-01-01\n00:03:00", "temperature\npressure", "75.0%\n15.0%", "90.0%")],
+        page_number=3,
+        graph_page_number=1,
+        graph_page_count=1,
+    )
+
+    axis = figure.axes[0]
+    assert len(axis.patches) == 3  # Two contributor segments plus uncovered error.
+    assert axis.get_title() == ""
+    assert axis.get_yticklabels()[0].get_text().startswith("2026-01-01 00:03:00")
+    assert any(text.get_text() == "90.0% covered" for text in axis.texts)


### PR DESCRIPTION
## Summary

- add opt-in, model-agnostic reconstruction-error explanations to anomaly detection output without additional inference
- report top contributors, contribution shares, explanation coverage, and explanation method for every detected anomaly
- preserve original feature names for any directly mapped input width up to the model target dimension; padded dimensions remain in the MAE denominator but are not presented as features
- visualize detected anomalies in red and ground truth in blue, with numeric-looking feature headers preserved and row-number time steps explained when timestamps are absent
- keep PDFs within 10 pages by replacing excessive per-anomaly charts with one MAE-weighted top-five consolidated view
- export complete per-anomaly explanations to a companion CSV regardless of PDF consolidation
- preserve existing SDK and report behavior unless explainability or PDF output is requested

## Validation

- `make lint`
- 41 focused OSS SDK tests passed across analysis, explainability, and reporting
- full OES `data_0.csv`: 5,805 rows; all 257 detected anomalies explained; no `component_N` labels; five-page consolidated report
- smaller OES rows 500-999: 500 rows; all 15 detected anomalies explained; seven-page detailed report with no consolidation
- all generated report pages visually inspected for labels, colors, spacing, page numbering, and notes

Sister change: internal GitLab MR !381.
