### PR TITLE
Add ForecastingConfig/YAML-based inference config to perform_forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use the same interpreter/venv when you run the examples below.
 
 #### Forecasting
 ```python
-from sdk.forecasting import perform_forecasting
+from sdk.forecasting import ForecastingConfig, perform_forecasting
 import pandas as pd
 import numpy as np
 
@@ -43,25 +43,41 @@ df = pd.DataFrame({
     "feature_a": np.random.randn(600),
 })
 
-forecasts = perform_forecasting(
-    df=df,
+config = ForecastingConfig(
     seq_len=512,
     forecast_horizon=72,
 )
+forecasts = perform_forecasting(df=df, config=config)
 # Returns a DataFrame with `target_forecast` column containing 72 predictions
+```
+
+Forecasting options can also be moved into a YAML file and passed as the typed
+configuration source — a fully commented template is packaged at
+`forecasting/sdk/forecasting_inference_config.yaml`:
+
+```python
+from sdk.forecasting import perform_forecasting
+
+results = perform_forecasting(
+    df=df,
+    config="forecasting/sdk/forecasting_inference_config.yaml",
+)
 ```
 
 #### DARR (Context-Enhanced) Forecasting
 
 ```python
-darr_result = perform_forecasting(
-    df=df,
-    context_df=historical_df,  # Historical data for kNN retrieval
+darr_config = ForecastingConfig(
     seq_len=512,
     forecast_horizon=72,
     alpha=0.2,   # 20% direct, 80% kNN
     k=64,
     temperature=0.05,
+)
+darr_result = perform_forecasting(
+    df=df,
+    config=darr_config,
+    context_df=historical_df,  # Historical data for kNN retrieval
 )
 ```
 
@@ -70,14 +86,14 @@ darr_result = perform_forecasting(
 Forecasting includes a model-agnostic **interpretability** framework that explains *why* a forecast looks the way it does — without modifying the underlying model. Pass `interpretability=True` to write an explanation bundle alongside the forecast: lag and feature attributions per horizon, semantic-flow diagnostics, trajectory stability, and optional embedding Integrated Gradients (JSON, CSVs, and PDF report):
 
 ```python
-results = perform_forecasting(
-    df=df,
+interp_config = ForecastingConfig(
     seq_len=512,
     forecast_horizon=72,
     interpretability=True,
     interpretability_output=None,  # "json", "pdf", or None for both
     interpretability_out_dir="interpretability_output",
 )
+results = perform_forecasting(df=df, config=interp_config)
 # Bundle written under interpretability_output/run_<UTC-timestamp>/
 ```
 

--- a/forecasting/README.md
+++ b/forecasting/README.md
@@ -28,7 +28,7 @@ The model weights are published on Hugging Face (`nvidia/nv-tesseract-forecastin
 
 ```python
 import pandas as pd
-from sdk.forecasting import perform_forecasting, DEVICE
+from sdk.forecasting import ForecastingConfig, perform_forecasting, DEVICE
 
 # Check device being used
 print(f"Using device: {DEVICE}")
@@ -37,15 +37,27 @@ print(f"Using device: {DEVICE}")
 df = pd.read_csv("your_data.csv")  # Must have 'timestamp' and 'target' columns
 
 # Perform forecasting - weights auto-downloaded if needed
-results = perform_forecasting(
-    df=df,
+config = ForecastingConfig(
     timestamp_column="timestamp",
     target_column="target",
     forecast_horizon=72,  # Forecast 72 steps ahead
 )
+results = perform_forecasting(df=df, config=config)
 
 print(results)
 ```
+
+Forecasting options can also be moved into a YAML file and passed as the typed
+configuration source — a fully commented template is packaged at
+`sdk/forecasting_inference_config.yaml`:
+
+```python
+results = perform_forecasting(df=df, config="sdk/forecasting_inference_config.yaml")
+```
+
+The YAML may be flat or use a top-level `inference:` section. Unknown keys
+raise `ValueError`, so misspelled config values do not silently fall back to
+defaults.
 
 Or run the example:
 
@@ -95,8 +107,7 @@ The output directory contains:
 Use the fine-tuned artifacts with the SDK:
 
 ```python
-results = perform_forecasting(
-    df=df,
+config = ForecastingConfig(
     timestamp_column="timestamp",
     target_column="target",
     seq_len=512,
@@ -106,6 +117,7 @@ results = perform_forecasting(
     ckpt="artifacts/finetune_my_data/best_model.pt",
     # use_cross_channel is inferred automatically from the checkpoint contents
 )
+results = perform_forecasting(df=df, config=config)
 ```
 
 ## UV Commands Reference
@@ -217,13 +229,13 @@ The estimator batches channel probes and transitions on the selected device. See
 
 ### What the SDK gives you
 
-When you call `perform_forecasting(..., interpretability=True)` the SDK runs the same loaded model on the trailing window and writes a self-contained explanation bundle: the K×H matrix as wide and long CSVs, a heatmap PNG, a per-transition `semantic_flow.csv` with a `history`/`forecast` segment label, a full `explanation.json` (baseline forecast, lag×horizon scores and attributions, latent trajectory, semantic-flow magnitudes, diagnostic ratios that flag whether the forecast segment is volatile relative to history, and trajectory-stability metrics), and a multi-page PDF report. Multivariate inputs also receive channel-by-horizon feature attribution. Optional embedding Integrated Gradients can be enabled with `integrated_gradients=True`. See the **Interpretability (Lag x Horizon Explanations)** example below for the call shape and `sdk/README.md` for the full parameter reference and on-disk artifact catalogue.
+When you call `perform_forecasting(df, config=ForecastingConfig(interpretability=True))` the SDK runs the same loaded model on the trailing window and writes a self-contained explanation bundle: the K×H matrix as wide and long CSVs, a heatmap PNG, a per-transition `semantic_flow.csv` with a `history`/`forecast` segment label, a full `explanation.json` (baseline forecast, lag×horizon scores and attributions, latent trajectory, semantic-flow magnitudes, diagnostic ratios that flag whether the forecast segment is volatile relative to history, and trajectory-stability metrics), and a multi-page PDF report. Multivariate inputs also receive channel-by-horizon feature attribution. Optional embedding Integrated Gradients can be enabled with `integrated_gradients=True`. See the **Interpretability (Lag x Horizon Explanations)** example below for the call shape and `sdk/README.md` for the full parameter reference and on-disk artifact catalogue.
 
 ## Usage Examples
 
 ### Basic Forecasting
 ```python
-from sdk.forecasting import perform_forecasting, DEVICE
+from sdk.forecasting import ForecastingConfig, perform_forecasting, DEVICE
 import pandas as pd
 import numpy as np
 
@@ -234,42 +246,44 @@ df = pd.DataFrame({
 })
 
 # Perform forecasting - model weights auto-downloaded on first run
-results = perform_forecasting(
-    df=df, 
+config = ForecastingConfig(
     forecast_horizon=24,
     timestamp_column="timestamp",
-    target_column="target"
+    target_column="target",
 )
+results = perform_forecasting(df=df, config=config)
 ```
 
 ### Context-Enhanced Forecasting (DARR Mode)
 ```python
-from sdk.forecasting import perform_forecasting
+from sdk.forecasting import ForecastingConfig, perform_forecasting
 
 # With additional context data for improved accuracy
 context_df = pd.read_csv("historical_data.csv")
 
-results = perform_forecasting(
-    df=df,
-    context_df=context_df,  # Additional context for better predictions
+darr_config = ForecastingConfig(
     forecast_horizon=72,
     alpha=0.01,  # Blending parameter for DARR mode
     timestamp_column="timestamp",
-    target_column="target"
+    target_column="target",
+)
+results = perform_forecasting(
+    df=df,
+    config=darr_config,
+    context_df=context_df,  # Additional context for better predictions
 )
 ```
 
 ### Interpretability (Lag x Horizon Explanations)
 ```python
-from sdk.forecasting import perform_forecasting
+from sdk.forecasting import ForecastingConfig, perform_forecasting
 
 # Set interpretability=True to also produce an explanation bundle on disk.
 # `interpretability_output` selects what to materialize:
 #   - "json" -> forecast.csv + explanation.json
 #   - "pdf"  -> forecast.csv + lag_horizon_*.csv/png + explanation_report.pdf
 #   - None   -> both bundles
-results = perform_forecasting(
-    df=df,
+interp_config = ForecastingConfig(
     forecast_horizon=72,
     timestamp_column="timestamp",
     target_column="target",
@@ -280,20 +294,21 @@ results = perform_forecasting(
     n_lags=128,
     softmax_tau=1.0,
 )
+results = perform_forecasting(df=df, config=interp_config)
 # Bundle is written under <interpretability_out_dir>/run_<UTC-timestamp>/
 ```
 
 ### Manual Weight Paths (Optional)
 ```python
-from sdk.forecasting import perform_forecasting
+from sdk.forecasting import ForecastingConfig, perform_forecasting
 
 # If you want to specify custom paths for model weights
-results = perform_forecasting(
-    df=df,
+config = ForecastingConfig(
     forecast_horizon=72,
     standardizer_pkl="custom/path/standardizer.pkl",  # Default: "standardizer.pkl"
-    ckpt="custom/path/model_checkpoint.pt"            # Default: packaged forecast checkpoint path
+    ckpt="custom/path/model_checkpoint.pt",            # Default: packaged forecast checkpoint path
 )
+results = perform_forecasting(df=df, config=config)
 ```
 
 ## Development

--- a/forecasting/pyproject.toml
+++ b/forecasting/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "tqdm>=4.65.0",
     "huggingface_hub>=0.22.0",
     "transformers>=4.36.0",
+    "pyyaml>=6.0,<7",
 ]
 
 [tool.uv]

--- a/forecasting/sdk/README.md
+++ b/forecasting/sdk/README.md
@@ -27,7 +27,7 @@ uv sync
 ### Standard inference
 
 ```python
-from sdk.forecasting import perform_forecasting
+from sdk.forecasting import ForecastingConfig, perform_forecasting
 import pandas as pd
 import numpy as np
 
@@ -38,14 +38,40 @@ df = pd.DataFrame({
     "feature_b": np.random.randn(600),
 })
 
-forecasts = perform_forecasting(
-    df=df,
+config = ForecastingConfig(
     seq_len=512,
     forecast_horizon=72,
 )
+forecasts = perform_forecasting(df=df, config=config)
 
 # Result contains a `target_forecast` column with `forecast_horizon` rows
 ```
+
+### YAML-backed inference config
+
+When repeated calls need the same inference knobs, put them in YAML and pass the
+file path instead of expanding a long argument list. A fully commented template
+is available at `sdk/forecasting_inference_config.yaml`.
+
+```yaml
+inference:
+  # Number of historical rows consumed for the input context window.
+  seq_len: 512
+  # Number of future rows to predict.
+  forecast_horizon: 72
+  # Native horizon used when training the checkpoint.
+  model_horizon: 72
+  # Enable cross-channel attention for multivariate forecasting.
+  use_cross_channel: true
+```
+
+```python
+forecasts = perform_forecasting(df=df, config="forecasting_inference_config.yaml")
+```
+
+The YAML may be either a flat mapping of `ForecastingConfig` fields or an
+`inference:` section inside a larger spec. Unknown config keys raise
+`ValueError` so misspellings do not silently fall back to defaults.
 
 ### DARR (context-enhanced) inference
 
@@ -56,15 +82,14 @@ context = pd.DataFrame({
     "feature_a": historical_feature_a,
 })
 
-darr_result = perform_forecasting(
-    df=df,
-    context_df=context,
+darr_config = ForecastingConfig(
     seq_len=512,
     forecast_horizon=72,
     alpha=0.2,  # 20% direct, 80% kNN
     k=64,
     temperature=0.05,
 )
+darr_result = perform_forecasting(df=df, config=darr_config, context_df=context)
 
 # DARR output includes hybrid, direct, and kNN forecast columns
 ```
@@ -113,8 +138,7 @@ Setting `interpretability=True` runs the loaded model on the trailing `seq_len` 
 ```python
 from pathlib import Path
 
-interp_result = perform_forecasting(
-    df=df,
+interp_config = ForecastingConfig(
     seq_len=512,
     forecast_horizon=100,
     interpretability=True,
@@ -125,6 +149,7 @@ interp_result = perform_forecasting(
     softmax_tau=1.0,
     integrated_gradients=True,
 )
+interp_result = perform_forecasting(df=df, config=interp_config)
 ```
 
 `interpretability_output` selects which artifacts are written:
@@ -143,57 +168,10 @@ If the input DataFrame has more than one numeric column, the feature-axis decomp
 
 ```python
 perform_forecasting(
-    # Input data
     df: pd.DataFrame,
-    timestamp_column: str = "timestamp",
-    target_column: str = "target",
-    context_df: Optional[pd.DataFrame] = None,
-    
-    # Model configuration
-    standardizer_pkl: str = "standardizer.pkl",
-    ckpt: str = "run8_best_model_cr.pt",
-    seq_len: int = 512,
-    forecast_horizon: int = 72,
-    model_horizon: int = 72,
-    
-    # Output configuration
-    save_preds: Optional[str] = None,
-    
-    # DARR mode configuration
-    alpha: float = 0.01,
-    k: int = 64,
-    temperature: float = 0.05,
-    
-    # Additional parameters
-    model_name: str = "configured pretrained backbone identifier",
-    batch_size: int = 8,
-    num_workers: int = 2,
-    stride: Optional[int] = None,
-    context_stride: Optional[int] = None,
-    seed: int = 13,
-    device: Optional[str] = None,
-    local_files_only: bool = False,
-
-    # Interpretability
-    interpretability: bool = False,
-    interpretability_output: Optional[str] = None,            # "json" | "pdf" | None
-    interpretability_out_dir: Union[str, Path] = "interpretability_output",
-    interpretability_run_name: Optional[str] = None,
-    interpretability_top_k: int = 5,
-    interpretability_dataset_name: Optional[str] = None,
-    n_lags: int = 128,
-    softmax_tau: float = 1.0,
-    channel_output_aware: bool = False,
-    integrated_gradients: bool = False,
-    integrated_gradients_baseline: Any = "noise",
-    integrated_gradients_steps: int = 64,
-    integrated_gradients_n_baselines: int = 1,
-    integrated_gradients_internal_batch_size: Optional[int] = None,
-    integrated_gradients_reduce: str = "l2",
-    integrated_gradients_grad_through_norm: bool = True,
-
-    # Multichannel output
-    return_all_channels: bool = False,
+    *,
+    config: ForecastingConfig | str | Path | None = None,
+    context_df: pd.DataFrame | None = None,
 ) -> pd.DataFrame
 ```
 
@@ -202,18 +180,14 @@ perform_forecasting(
 | Parameter | Description |
 |-----------|-------------|
 | `df` | Input DataFrame containing time series data |
-| `timestamp_column` / `target_column` | Alias your columns when they differ from the defaults |
-| `standardizer_pkl`, `ckpt` | Paths to the training artifacts |
-| `seq_len` | Number of rows consumed for a single inference window (must exist in the provided `df`) |
-| `forecast_horizon` | How many future steps to return (max: 512). If this exceeds `model_horizon`, the SDK repeats predictions autoregressively |
-| `model_horizon` | Native horizon the model was trained on (default: 72). Override if using different weights |
+| `config` | `ForecastingConfig`, YAML path, or `None` for defaults. The YAML can be flat or use a top-level `inference` section |
 | `context_df` | Enables DARR mode when supplied |
-| `alpha` | Blending factor for DARR hybrid output (`alpha * direct + (1 - alpha) * kNN`) |
-| `k` / `temperature` | Configure kNN retrieval (number of neighbors and softmax temperature) |
-| `stride` / `context_stride` | Stride for windowing; defaults to `model_horizon` |
-| `save_preds` | Optional CSV export location |
-| `device` | Override device selection (defaults to auto-detected CUDA/MPS/CPU) |
-| `local_files_only` | Load model from local cache without network access |
+
+All model, data-column, DARR, output, and interpretability settings are fields
+on `ForecastingConfig` and are documented in the commented YAML template.
+
+| Parameter | Description |
+|-----------|-------------|
 | `interpretability` | Master switch. When `True`, the SDK skips the standard / DARR inference path and runs the interpretability explanation pipeline against the loaded model |
 | `interpretability_output` | `"json"` for explanation JSON only, `"pdf"` for the heatmap + PDF bundle, `None` for both. Invalid values raise `ValueError` |
 | `interpretability_out_dir` | Parent directory for the run subfolder; created if missing |
@@ -314,7 +288,7 @@ Warning: Column mismatch detected between input and context datasets
 | `ValueError: DataFrame has X rows but seq_len requires at least Y rows` | Insufficient data points | Provide more data or reduce `seq_len` |
 | `ValueError: Context DataFrame has X rows but requires at least Y rows` | Context dataset too small | Context needs `seq_len + max(model_horizon, forecast_horizon)` rows minimum |
 | `ValueError: forecast_horizon must be <= 512` | Forecast horizon too large | Reduce `forecast_horizon` or make multiple calls |
-| `ValueError: Target column 'X' not found in DataFrame` | Missing target column | Verify column name or use `target_column` parameter |
+| `ValueError: Target column 'X' not found in DataFrame` | Missing target column | Verify column name or set `target_column` on `ForecastingConfig` |
 | `ValueError: interpretability_output must be one of None, 'json', 'pdf'` | Bad value for the artifact selector | Use `None`, `"json"`, or `"pdf"` |
 | `Interpretability PDF report skipped: matplotlib is not installed.` | PDF/heatmap path attempted without matplotlib | `uv add matplotlib`, or set `interpretability_output="json"` |
 

--- a/forecasting/sdk/__init__.py
+++ b/forecasting/sdk/__init__.py
@@ -8,8 +8,10 @@ from .forecasting import (
     CHECKPOINT_CROSS_CHANNEL,
     DEFAULT_BACKBONE_NAME,
     DEVICE,
+    ForecastingConfig,
     NVTesseractForecasting,
     download_model_weights,
+    load_forecasting_config,
     perform_forecasting,
 )
 
@@ -18,7 +20,9 @@ __all__ = [
     "CHECKPOINT_CROSS_CHANNEL",
     "DEFAULT_BACKBONE_NAME",
     "DEVICE",
+    "ForecastingConfig",
     "NVTesseractForecasting",
     "download_model_weights",
+    "load_forecasting_config",
     "perform_forecasting",
 ]

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -139,7 +139,9 @@ def load_forecasting_config(config_path: str | Path) -> ForecastingConfig:
     if config is None:
         return ForecastingConfig()
     if not isinstance(config, dict):
-        raise ValueError(f"Forecasting inference config 'inference' section must be a mapping, got {type(config).__name__}.")
+        raise ValueError(
+            f"Forecasting inference config 'inference' section must be a mapping, got {type(config).__name__}."
+        )
 
     unknown_keys = sorted(set(config) - _FORECASTING_CONFIG_FIELDS)
     if unknown_keys:

--- a/forecasting/sdk/forecasting.py
+++ b/forecasting/sdk/forecasting.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import types
 from contextlib import contextmanager
+from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ import joblib
 import numpy as np
 import pandas as pd
 import torch
+import yaml
 from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
 
@@ -71,6 +73,115 @@ CHECKPOINT_BASE = "moment_head_512_6hr.pt"  # non-cross-channel
 _KNOWN_CHECKPOINTS = {CHECKPOINT_CROSS_CHANNEL, CHECKPOINT_BASE}
 DEFAULT_BACKBONE_NAME = "AutonLab/MOMENT-1-large"
 _MODEL_CACHE: dict[str, torch.nn.Module] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class ForecastingConfig:
+    """Typed configuration for :func:`perform_forecasting`."""
+
+    timestamp_column: str = "timestamp"
+    target_column: str = "target"
+    standardizer_pkl: str = "standardizer.pkl"
+    ckpt: str = CHECKPOINT_CROSS_CHANNEL
+    seq_len: int = 512
+    forecast_horizon: int = 72
+    model_horizon: int | None = 72
+    save_preds: str | None = None
+    alpha: float = 0.01
+    model_name: str = DEFAULT_BACKBONE_NAME
+    batch_size: int = 8
+    num_workers: int = 2
+    stride: int | None = None
+    context_stride: int | None = None
+    seed: int = 13
+    k: int = 64
+    temperature: float = 0.05
+    device: str | None = None
+    local_files_only: bool = False
+    use_cross_channel: bool = True
+    cross_channel_heads: int = 8
+    cross_channel_dropout: float = 0.1
+    return_all_channels: bool = False
+    interpretability: bool = False
+    interpretability_output: str | None = None
+    interpretability_out_dir: str | Path = "interpretability_output"
+    interpretability_run_name: str | None = None
+    interpretability_top_k: int = 5
+    interpretability_dataset_name: str | None = None
+    n_lags: int = 128
+    softmax_tau: float = 1.0
+    channel_output_aware: bool = False
+    integrated_gradients: bool = False
+    integrated_gradients_baseline: Any = "noise"
+    integrated_gradients_steps: int = 64
+    integrated_gradients_n_baselines: int = 1
+    integrated_gradients_internal_batch_size: int | None = None
+    integrated_gradients_reduce: str = "l2"
+    integrated_gradients_grad_through_norm: bool = True
+
+
+_FORECASTING_CONFIG_FIELDS = frozenset(field.name for field in fields(ForecastingConfig))
+
+
+def load_forecasting_config(config_path: str | Path) -> ForecastingConfig:
+    """Load and validate a :class:`ForecastingConfig` from YAML.
+
+    The YAML may be a flat mapping or contain a top-level ``inference`` mapping,
+    which allows the TAO specification to carry dataset and training sections.
+    """
+    with open(config_path) as f:
+        raw_config = yaml.safe_load(f) or {}
+
+    if not isinstance(raw_config, dict):
+        raise ValueError(f"Forecasting inference config must be a mapping, got {type(raw_config).__name__}.")
+
+    config = raw_config.get("inference", raw_config)
+    if config is None:
+        return ForecastingConfig()
+    if not isinstance(config, dict):
+        raise ValueError(f"Forecasting inference config 'inference' section must be a mapping, got {type(config).__name__}.")
+
+    unknown_keys = sorted(set(config) - _FORECASTING_CONFIG_FIELDS)
+    if unknown_keys:
+        allowed = ", ".join(sorted(_FORECASTING_CONFIG_FIELDS))
+        raise ValueError(f"Unknown forecasting inference config keys: {unknown_keys}. Allowed keys: {allowed}")
+
+    values = dict(config)
+    for artifact_field in ("standardizer_pkl", "ckpt"):
+        if artifact_field in values and not values[artifact_field]:
+            logger.warning(
+                "Forecasting config has an empty '%s'; falling back to default %r.",
+                artifact_field,
+                getattr(ForecastingConfig(), artifact_field),
+            )
+            values.pop(artifact_field, None)
+    return ForecastingConfig(**values)
+
+
+def _resolve_forecasting_config(
+    config: ForecastingConfig | str | Path | None,
+) -> ForecastingConfig:
+    if config is None:
+        resolved = ForecastingConfig()
+    elif isinstance(config, ForecastingConfig):
+        resolved = config
+    elif isinstance(config, (str, Path)):
+        resolved = load_forecasting_config(config)
+    else:
+        raise TypeError("config must be a ForecastingConfig, YAML path, or None")
+
+    artifact_defaults = ForecastingConfig()
+    artifact_updates = {}
+    for name in ("standardizer_pkl", "ckpt"):
+        if not getattr(resolved, name):
+            default_value = getattr(artifact_defaults, name)
+            logger.warning(
+                "Forecasting config has an empty '%s'; falling back to default %r.",
+                name,
+                default_value,
+            )
+            artifact_updates[name] = default_value
+    return replace(resolved, **artifact_updates) if artifact_updates else resolved
 
 
 def _checkpoint_uses_cross_channel(state: dict) -> bool:
@@ -2417,54 +2528,10 @@ def _run_interpretability(
 
 
 def perform_forecasting(
-    # Input data
     df: pd.DataFrame,
-    timestamp_column: str = "timestamp",
-    target_column: str = "target",
+    *,
+    config: ForecastingConfig | str | Path | None = None,
     context_df: pd.DataFrame | None = None,  # Optional context DataFrame for DARR mode
-    # Model configuration - Replace with your own paths for the weights and standardizer
-    standardizer_pkl: str = "standardizer.pkl",
-    ckpt: str = CHECKPOINT_CROSS_CHANNEL,
-    seq_len: int = 512,
-    forecast_horizon: int = 72,
-    model_horizon: int = 72,  # Override with other weights' values if needed
-    # Output configuration
-    save_preds: str | None = None,
-    # DARR mode configuration
-    alpha: float = 0.01,
-    # Additional parameters (with sensible defaults)
-    model_name: str = DEFAULT_BACKBONE_NAME,
-    batch_size: int = 8,
-    num_workers: int = 2,
-    stride: int | None = None,
-    context_stride: int | None = None,
-    seed: int = 13,
-    k: int = 64,
-    temperature: float = 0.05,
-    device: str | None = None,
-    local_files_only: bool = False,
-    use_cross_channel: bool = True,
-    cross_channel_heads: int = 8,
-    cross_channel_dropout: float = 0.1,
-    # Interpretability configuration
-    interpretability: bool = False,
-    interpretability_output: str | None = None,  # "json", "pdf", or None (both)
-    interpretability_out_dir: str | Path = "interpretability_output",
-    interpretability_run_name: str | None = None,
-    interpretability_top_k: int = 5,
-    interpretability_dataset_name: str | None = None,
-    n_lags: int = 128,
-    softmax_tau: float = 1.0,
-    channel_output_aware: bool = False,
-    integrated_gradients: bool = False,
-    integrated_gradients_baseline: Any = "noise",
-    integrated_gradients_steps: int = 64,
-    integrated_gradients_n_baselines: int = 1,
-    integrated_gradients_internal_batch_size: int | None = None,
-    integrated_gradients_reduce: str = "l2",
-    integrated_gradients_grad_through_norm: bool = True,
-    # Output configuration
-    return_all_channels: bool = False,  # When True, emit one {col}_forecast per feature column
 ) -> pd.DataFrame:
     """
     Perform time series forecasting using NV-Tesseract with optional context-enhanced mode (DARR).
@@ -2477,80 +2544,86 @@ def perform_forecasting(
     then the remaining numeric feature columns) instead of only
     ``{target_column}_forecast``. This also applies to interpretability mode.
     """
-    # Set model_horizon to forecast_horizon if not specified
-    if model_horizon is None:
-        model_horizon = forecast_horizon
+    cfg = _resolve_forecasting_config(config)
+
+    # Keep locals only for values resolved or transformed during this run.
+    standardizer_pkl = cfg.standardizer_pkl
+    ckpt = cfg.ckpt
+    model_horizon = cfg.model_horizon if cfg.model_horizon is not None else cfg.forecast_horizon
+    stride = cfg.stride if cfg.stride is not None else model_horizon
+    context_stride = cfg.context_stride if cfg.context_stride is not None else model_horizon
+    device = DEVICE if cfg.device is None else torch.device(cfg.device)
 
     # Validate that model_horizon is reasonable
     if model_horizon <= 0:
         raise ValueError(f"model_horizon must be positive, got {model_horizon}")
 
-    if forecast_horizon <= 0:
-        raise ValueError(f"forecast_horizon must be positive, got {forecast_horizon}")
+    if cfg.forecast_horizon <= 0:
+        raise ValueError(f"forecast_horizon must be positive, got {cfg.forecast_horizon}")
 
     # Maximum forecast horizon limit
     MAX_FORECAST_HORIZON = 512
-    if forecast_horizon > MAX_FORECAST_HORIZON:
-        raise ValueError(f"forecast_horizon must be <= {MAX_FORECAST_HORIZON}, got {forecast_horizon}")
+    if cfg.forecast_horizon > MAX_FORECAST_HORIZON:
+        raise ValueError(f"forecast_horizon must be <= {MAX_FORECAST_HORIZON}, got {cfg.forecast_horizon}")
 
     # The model's native horizon limits direct predictions, but DARR retrieves
     # observed continuations from context data. Keep the existing native-sized
     # context windows for shorter requests while retaining the full retrieval
     # trajectory whenever callers ask for a longer forecast.
-    darr_context_horizon = max(model_horizon, forecast_horizon)
+    darr_context_horizon = max(model_horizon, cfg.forecast_horizon)
 
     # Input validation
     if df is None or df.empty:
         raise ValueError("Input DataFrame is required and cannot be empty")
 
     # Validate minimum rows
-    if len(df) < seq_len:
-        raise ValueError(f"DataFrame has {len(df)} rows but seq_len requires at least {seq_len} rows")
+    if len(df) < cfg.seq_len:
+        raise ValueError(f"DataFrame has {len(df)} rows but seq_len requires at least {cfg.seq_len} rows")
 
     # Validate timestamp column
-    if timestamp_column not in df.columns:
-        raise ValueError(f"Timestamp column '{timestamp_column}' not found in DataFrame")
+    if cfg.timestamp_column not in df.columns:
+        raise ValueError(f"Timestamp column '{cfg.timestamp_column}' not found in DataFrame")
 
-    if df[timestamp_column].isnull().any():
-        raise ValueError(f"Timestamp column '{timestamp_column}' contains NULL values")
+    if df[cfg.timestamp_column].isnull().any():
+        raise ValueError(f"Timestamp column '{cfg.timestamp_column}' contains NULL values")
 
     # Try to convert timestamp column to datetime if it's not already
     working_df = df.copy()
     try:
-        if not pd.api.types.is_datetime64_any_dtype(working_df[timestamp_column]):
-            working_df[timestamp_column] = pd.to_datetime(working_df[timestamp_column])
+        if not pd.api.types.is_datetime64_any_dtype(working_df[cfg.timestamp_column]):
+            working_df[cfg.timestamp_column] = pd.to_datetime(working_df[cfg.timestamp_column])
     except Exception as e:
-        raise ValueError(f"Cannot parse timestamp column '{timestamp_column}' as datetime: {e}")
+        raise ValueError(f"Cannot parse timestamp column '{cfg.timestamp_column}' as datetime: {e}")
 
     # Validate target column
-    if target_column not in df.columns:
-        raise ValueError(f"Target column '{target_column}' not found in DataFrame")
+    if cfg.target_column not in df.columns:
+        raise ValueError(f"Target column '{cfg.target_column}' not found in DataFrame")
 
     # Check if target column is numeric
-    if not pd.api.types.is_numeric_dtype(working_df[target_column]):
-        raise ValueError(f"Target column '{target_column}' must contain numeric values")
+    if not pd.api.types.is_numeric_dtype(working_df[cfg.target_column]):
+        raise ValueError(f"Target column '{cfg.target_column}' must contain numeric values")
 
     # Handle NULL values in target column - fill with zeros
-    if working_df[target_column].isnull().any():
-        logger.warning("Found NULL values in '%s', filling with zeros", target_column)
-        working_df[target_column] = working_df[target_column].fillna(0)
+    if working_df[cfg.target_column].isnull().any():
+        logger.warning("Found NULL values in '%s', filling with zeros", cfg.target_column)
+        working_df[cfg.target_column] = working_df[cfg.target_column].fillna(0)
 
     # Automatically detect all numeric columns to use as features
     numeric_columns = working_df.select_dtypes(include=[np.number]).columns.tolist()
 
     # Make sure target column is first in the list
-    if target_column in numeric_columns:
-        numeric_columns.remove(target_column)
-    columns_to_process = [target_column] + numeric_columns
+    if cfg.target_column in numeric_columns:
+        numeric_columns.remove(cfg.target_column)
+    columns_to_process = [cfg.target_column] + numeric_columns
 
     # return_all_channels emits one {column}_forecast per channel; reject a
     # timestamp column name that would collide with one of them, since the
     # collision would silently overwrite the timestamp column in the output.
-    if return_all_channels:
-        colliding = [c for c in columns_to_process if f"{c}_forecast" == timestamp_column]
+    if cfg.return_all_channels:
+        colliding = [c for c in columns_to_process if f"{c}_forecast" == cfg.timestamp_column]
         if colliding:
             raise ValueError(
-                f"timestamp_column {timestamp_column!r} collides with the forecast column "
+                f"timestamp_column {cfg.timestamp_column!r} collides with the forecast column "
                 f"emitted for input column {colliding[0]!r}; rename one of them"
             )
 
@@ -2560,26 +2633,13 @@ def perform_forecasting(
             logger.warning("Found NULL values in '%s', filling with zeros", col)
             working_df[col] = working_df[col].fillna(0)
 
-    # Set default values
-    # Use model_horizon for strides to ensure consistent context memory regardless of forecast_horizon
-    if stride is None:
-        stride = model_horizon
-    if context_stride is None:
-        context_stride = model_horizon
-
-    # Set device
-    if device is None:
-        device = DEVICE
-    else:
-        device = torch.device(device)
-
     # Set random seed
-    control_randomness(seed=seed)
+    control_randomness(seed=cfg.seed)
 
     # For the two published checkpoints, resolve the right one from use_cross_channel.
     # Custom paths are left untouched — state dict inspection in _load_cached_model handles them.
     if ckpt in _KNOWN_CHECKPOINTS:
-        ckpt = CHECKPOINT_CROSS_CHANNEL if use_cross_channel else CHECKPOINT_BASE
+        ckpt = CHECKPOINT_CROSS_CHANNEL if cfg.use_cross_channel else CHECKPOINT_BASE
 
     # Auto-download model weights if they don't exist
     try:
@@ -2591,7 +2651,7 @@ def perform_forecasting(
     # Determine mode
     if context_df is not None:
         mode = "darr"
-        logger.info("Using DARR mode (Context-Enhanced Forecasting) with alpha=%s", alpha)
+        logger.info("Using DARR mode (Context-Enhanced Forecasting) with alpha=%s", cfg.alpha)
     else:
         mode = "standard"
         logger.info("Using standard forecasting mode (inference only)")
@@ -2606,8 +2666,8 @@ def perform_forecasting(
         temp_test_csv = _create_temp_csv_path("nv_tesseract_test_")
 
         # Save only the necessary columns (timestamp + value columns)
-        csv_df = working_df[[timestamp_column] + columns_to_process].copy()
-        csv_df.rename(columns={timestamp_column: "timestamp"}, inplace=True)
+        csv_df = working_df[[cfg.timestamp_column] + columns_to_process].copy()
+        csv_df.rename(columns={cfg.timestamp_column: "timestamp"}, inplace=True)
         csv_df.to_csv(temp_test_csv, index=False)
         test_csv_path = temp_test_csv
 
@@ -2616,19 +2676,19 @@ def perform_forecasting(
             temp_context_csv = _create_temp_csv_path("nv_tesseract_context_")
 
             # Validate context DataFrame columns
-            if timestamp_column not in context_df.columns:
-                raise ValueError(f"Context DataFrame missing timestamp column '{timestamp_column}'")
+            if cfg.timestamp_column not in context_df.columns:
+                raise ValueError(f"Context DataFrame missing timestamp column '{cfg.timestamp_column}'")
 
-            if target_column not in context_df.columns:
-                raise ValueError(f"Context DataFrame missing target column '{target_column}'")
+            if cfg.target_column not in context_df.columns:
+                raise ValueError(f"Context DataFrame missing target column '{cfg.target_column}'")
 
             # Validate context DataFrame has enough rows for at least one window
-            min_context_rows = seq_len + darr_context_horizon
+            min_context_rows = cfg.seq_len + darr_context_horizon
             if len(context_df) < min_context_rows:
                 raise ValueError(
                     f"Context DataFrame has {len(context_df)} rows but requires at least "
                     f"{min_context_rows} rows "
-                    f"(seq_len={seq_len} + context_horizon={darr_context_horizon})"
+                    f"(seq_len={cfg.seq_len} + context_horizon={darr_context_horizon})"
                 )
 
             # Process context DataFrame similarly to main DataFrame
@@ -2636,17 +2696,17 @@ def perform_forecasting(
 
             # Convert timestamp if needed
             try:
-                if not pd.api.types.is_datetime64_any_dtype(context_working[timestamp_column]):
-                    context_working[timestamp_column] = pd.to_datetime(context_working[timestamp_column])
+                if not pd.api.types.is_datetime64_any_dtype(context_working[cfg.timestamp_column]):
+                    context_working[cfg.timestamp_column] = pd.to_datetime(context_working[cfg.timestamp_column])
             except Exception as e:
-                raise ValueError(f"Cannot parse context timestamp column '{timestamp_column}' as datetime: {e}")
+                raise ValueError(f"Cannot parse context timestamp column '{cfg.timestamp_column}' as datetime: {e}")
 
             # Get numeric columns from context DataFrame
             context_numeric = context_working.select_dtypes(include=[np.number]).columns.tolist()
 
             # Ensure target column is included
-            if target_column in context_numeric:
-                context_numeric.remove(target_column)
+            if cfg.target_column in context_numeric:
+                context_numeric.remove(cfg.target_column)
 
             # COLUMN COMPATIBILITY CHECK AND ALIGNMENT
             # Common feature columns in input-DataFrame order (target excluded;
@@ -2657,7 +2717,7 @@ def perform_forecasting(
             # match, common_columns == context_numeric).
             context_numeric_set = set(context_numeric)
             common_columns = [col for col in numeric_columns if col in context_numeric_set]
-            context_columns_to_use = [timestamp_column, target_column] + common_columns
+            context_columns_to_use = [cfg.timestamp_column, cfg.target_column] + common_columns
 
             # Realign whenever the context column list differs from the input
             # list. A set comparison is not enough: the same columns in a
@@ -2691,14 +2751,14 @@ def perform_forecasting(
 
                     # The channel set narrowed: rewrite the main CSV in the same
                     # canonical order as the context CSV.
-                    columns_to_process = [target_column] + common_columns
-                    csv_df = working_df[[timestamp_column] + columns_to_process].copy()
-                    csv_df.rename(columns={timestamp_column: "timestamp"}, inplace=True)
+                    columns_to_process = [cfg.target_column] + common_columns
+                    csv_df = working_df[[cfg.timestamp_column] + columns_to_process].copy()
+                    csv_df.rename(columns={cfg.timestamp_column: "timestamp"}, inplace=True)
                     csv_df.to_csv(temp_test_csv, index=False)
 
             # Create CSV with selected columns
             context_csv_df = context_working[context_columns_to_use].copy()
-            context_csv_df.rename(columns={timestamp_column: "timestamp"}, inplace=True)
+            context_csv_df.rename(columns={cfg.timestamp_column: "timestamp"}, inplace=True)
 
             # Fill NULLs in context data
             for col in context_csv_df.columns:
@@ -2713,7 +2773,7 @@ def perform_forecasting(
         standardizer = _load_standardizer_artifact(standardizer_pkl)
 
         # ALWAYS use InferenceOnlyDataset for the main test data
-        test_dataset = InferenceOnlyDataset(csv_path=test_csv_path, seq_len=seq_len, standardizer=standardizer)
+        test_dataset = InferenceOnlyDataset(csv_path=test_csv_path, seq_len=cfg.seq_len, standardizer=standardizer)
 
         test_loader = DataLoader(
             test_dataset,
@@ -2724,15 +2784,15 @@ def perform_forecasting(
         )
 
         model = _load_cached_model(
-            model_name=model_name,
+            model_name=cfg.model_name,
             ckpt=ckpt,
-            seq_len=seq_len,
+            seq_len=cfg.seq_len,
             model_horizon=model_horizon,
             device=device,
-            local_files_only=local_files_only,
-            use_cross_channel=use_cross_channel,
-            cross_channel_heads=cross_channel_heads,
-            cross_channel_dropout=cross_channel_dropout,
+            local_files_only=cfg.local_files_only,
+            use_cross_channel=cfg.use_cross_channel,
+            cross_channel_heads=cfg.cross_channel_heads,
+            cross_channel_dropout=cfg.cross_channel_dropout,
         )
 
         # Interpretability path: produce explanation artifacts (heatmap, top-k
@@ -2740,40 +2800,40 @@ def perform_forecasting(
         # comes from the explanation's baseline (single forward pass, no AR
         # rollout) so that the persisted forecast.csv aligns 1:1 with the
         # attribution matrix.
-        if interpretability:
+        if cfg.interpretability:
             result_df, run_dir = _run_interpretability(
                 model=model,
                 standardizer=standardizer,
                 working_df=working_df,
                 columns_to_process=columns_to_process,
-                timestamp_column=timestamp_column,
-                target_column=target_column,
-                seq_len=seq_len,
-                forecast_horizon=forecast_horizon,
+                timestamp_column=cfg.timestamp_column,
+                target_column=cfg.target_column,
+                seq_len=cfg.seq_len,
+                forecast_horizon=cfg.forecast_horizon,
                 model_horizon=model_horizon,
                 device=device,
-                n_lags=n_lags,
-                softmax_tau=softmax_tau,
-                interpretability_output=interpretability_output,
-                interpretability_out_dir=interpretability_out_dir,
-                interpretability_run_name=interpretability_run_name,
-                interpretability_top_k=interpretability_top_k,
-                dataset_name=interpretability_dataset_name,
-                channel_output_aware=channel_output_aware,
-                return_all_channels=return_all_channels,
-                integrated_gradients=integrated_gradients,
-                integrated_gradients_baseline=integrated_gradients_baseline,
-                integrated_gradients_steps=integrated_gradients_steps,
-                integrated_gradients_n_baselines=integrated_gradients_n_baselines,
-                integrated_gradients_internal_batch_size=integrated_gradients_internal_batch_size,
-                integrated_gradients_reduce=integrated_gradients_reduce,
-                integrated_gradients_seed=seed,
-                integrated_gradients_grad_through_norm=integrated_gradients_grad_through_norm,
+                n_lags=cfg.n_lags,
+                softmax_tau=cfg.softmax_tau,
+                interpretability_output=cfg.interpretability_output,
+                interpretability_out_dir=cfg.interpretability_out_dir,
+                interpretability_run_name=cfg.interpretability_run_name,
+                interpretability_top_k=cfg.interpretability_top_k,
+                dataset_name=cfg.interpretability_dataset_name,
+                channel_output_aware=cfg.channel_output_aware,
+                return_all_channels=cfg.return_all_channels,
+                integrated_gradients=cfg.integrated_gradients,
+                integrated_gradients_baseline=cfg.integrated_gradients_baseline,
+                integrated_gradients_steps=cfg.integrated_gradients_steps,
+                integrated_gradients_n_baselines=cfg.integrated_gradients_n_baselines,
+                integrated_gradients_internal_batch_size=cfg.integrated_gradients_internal_batch_size,
+                integrated_gradients_reduce=cfg.integrated_gradients_reduce,
+                integrated_gradients_seed=cfg.seed,
+                integrated_gradients_grad_through_norm=cfg.integrated_gradients_grad_through_norm,
             )
             logger.info("Interpretability bundle written to: %s", run_dir)
-            if save_preds:
-                result_df.to_csv(save_preds, index=False)
-                logger.info("Saved predictions to %s", save_preds)
+            if cfg.save_preds:
+                result_df.to_csv(cfg.save_preds, index=False)
+                logger.info("Saved predictions to %s", cfg.save_preds)
             return result_df
 
         # Perform inference based on mode
@@ -2786,7 +2846,7 @@ def perform_forecasting(
             context_dataset = CSVLongHorizonSimpleDataset(
                 csv_path=context_csv_path,
                 data_split="train",
-                seq_len=seq_len,
+                seq_len=cfg.seq_len,
                 forecast_horizon=darr_context_horizon,
                 standardizer=None,
                 standardize=False,
@@ -2796,7 +2856,7 @@ def perform_forecasting(
             context_dataset.series = context_dataset.standardizer.transform(context_dataset.values)
 
             context_loader = DataLoader(
-                context_dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True
+                context_dataset, batch_size=cfg.batch_size, shuffle=False, num_workers=cfg.num_workers, pin_memory=True
             )
 
             # Build context memory with observed continuations long enough for
@@ -2824,7 +2884,7 @@ def perform_forecasting(
 
                 # Direct prediction with autoregressive extension if needed
                 batch_preds = autoregressive_forecast(
-                    model, timeseries, input_mask, model_horizon, forecast_horizon, standardizer, device
+                    model, timeseries, input_mask, model_horizon, cfg.forecast_horizon, standardizer, device
                 )
                 preds_direct.append(batch_preds)
 
@@ -2835,8 +2895,8 @@ def perform_forecasting(
             preds_direct = np.concatenate(preds_direct, axis=0)
 
             # kNN retrieval forecast
-            preds_knn = knn_forecast(DB_E, DB_Y, Q_E, k=k, temperature=temperature)
-            preds_knn = preds_knn[:, :, :forecast_horizon]
+            preds_knn = knn_forecast(DB_E, DB_Y, Q_E, k=cfg.k, temperature=cfg.temperature)
+            preds_knn = preds_knn[:, :, : cfg.forecast_horizon]
 
             # Validate shapes before combining predictions
             if preds_direct.shape != preds_knn.shape:
@@ -2849,7 +2909,7 @@ def perform_forecasting(
                 )
 
             # Hybrid predictions
-            preds_hybrid = alpha * preds_direct + (1 - alpha) * preds_knn
+            preds_hybrid = cfg.alpha * preds_direct + (1 - cfg.alpha) * preds_knn
 
             # Use hybrid as main predictions
             preds = preds_hybrid
@@ -2864,7 +2924,7 @@ def perform_forecasting(
 
                 # Autoregressive forecast
                 batch_preds = autoregressive_forecast(
-                    model, timeseries, input_mask, model_horizon, forecast_horizon, standardizer, device
+                    model, timeseries, input_mask, model_horizon, cfg.forecast_horizon, standardizer, device
                 )
                 preds.append(batch_preds)
 
@@ -2880,15 +2940,15 @@ def perform_forecasting(
         P_orig_reshaped = P_orig.reshape(B * H, C).reshape(B, H, C).transpose(0, 2, 1)
 
         # Infer frequency from timestamp column
-        time_diffs = working_df[timestamp_column].diff().dropna()
+        time_diffs = working_df[cfg.timestamp_column].diff().dropna()
         if len(time_diffs) > 0:
             inferred_freq = time_diffs.mode()[0] if len(time_diffs.mode()) > 0 else time_diffs.median()
         else:
             inferred_freq = pd.Timedelta(hours=1)
 
-        last_input_time = working_df[timestamp_column].iloc[-1]
+        last_input_time = working_df[cfg.timestamp_column].iloc[-1]
         forecast_timestamps = pd.date_range(
-            start=last_input_time + inferred_freq, periods=forecast_horizon, freq=inferred_freq
+            start=last_input_time + inferred_freq, periods=cfg.forecast_horizon, freq=inferred_freq
         )
 
         # Emit the target channel only (default), or one {column}_forecast per
@@ -2898,16 +2958,16 @@ def perform_forecasting(
         # numeric features in input-column order). The backbone predicts every
         # channel anyway, so emitting them all avoids re-running the SDK once
         # per column (V calls -> 1) for multivariate use cases.
-        output_channels = columns_to_process if return_all_channels else [target_column]
-        cols = {timestamp_column: forecast_timestamps}
+        output_channels = columns_to_process if cfg.return_all_channels else [cfg.target_column]
+        cols = {cfg.timestamp_column: forecast_timestamps}
         for ch_idx, channel_name in enumerate(output_channels):
-            cols[f"{channel_name}_forecast"] = P_orig_reshaped[0, ch_idx, :forecast_horizon].tolist()
+            cols[f"{channel_name}_forecast"] = P_orig_reshaped[0, ch_idx, : cfg.forecast_horizon].tolist()
         result_df = pd.DataFrame(cols)
 
         # Save predictions if requested
-        if save_preds:
-            result_df.to_csv(save_preds, index=False)
-            logger.info("Saved predictions to %s", save_preds)
+        if cfg.save_preds:
+            result_df.to_csv(cfg.save_preds, index=False)
+            logger.info("Saved predictions to %s", cfg.save_preds)
 
         if mode == "darr":
             logger.info("%s", "\n" + "=" * 60)
@@ -2991,6 +3051,17 @@ class NVTesseractForecasting(
         shutil.copy2(self.standardizer_pkl, save_directory / Path(self.standardizer_pkl).name)
         shutil.copy2(self.ckpt, save_directory / Path(self.ckpt).name)
 
-    def forecast(self, df: "pd.DataFrame", **kwargs) -> "pd.DataFrame":
-        """Run forecasting. All keyword args are forwarded to ``perform_forecasting``."""
-        return perform_forecasting(df, standardizer_pkl=self.standardizer_pkl, ckpt=self.ckpt, **kwargs)
+    def forecast(
+        self,
+        df: "pd.DataFrame",
+        *,
+        config: "ForecastingConfig | str | Path | None" = None,
+        context_df: "pd.DataFrame | None" = None,
+    ) -> "pd.DataFrame":
+        """Forecast a DataFrame using this instance's artifacts."""
+        resolved = replace(
+            _resolve_forecasting_config(config),
+            standardizer_pkl=self.standardizer_pkl,
+            ckpt=self.ckpt,
+        )
+        return perform_forecasting(df, config=resolved, context_df=context_df)

--- a/forecasting/sdk/forecasting_inference_config.yaml
+++ b/forecasting/sdk/forecasting_inference_config.yaml
@@ -1,0 +1,81 @@
+# Forecasting inference settings for sdk.forecasting.perform_forecasting.
+# Copy this file and pass it with config="path/to/your_config.yaml".
+inference:
+  # Name of the datetime column in the input and optional context DataFrames.
+  timestamp_column: timestamp
+  # Name of the primary numeric column to forecast.
+  target_column: target
+  # Path to the standardizer pickle; auto-downloaded when the default file is missing.
+  standardizer_pkl: standardizer.pkl
+  # Path to the forecasting checkpoint; defaults to cross-channel weights when use_cross_channel is true.
+  ckpt: run8_best_model_cr.pt
+  # Number of historical rows consumed for the input context window.
+  seq_len: 512
+  # Number of future rows to predict; values above model_horizon use autoregressive rollout.
+  forecast_horizon: 72
+  # Native forecast horizon used when training the checkpoint; set null to reuse forecast_horizon.
+  model_horizon: 72
+  # Optional CSV path for writing forecast outputs; set null to skip writing predictions.
+  save_preds: null
+  # DARR blend weight: alpha * direct forecast + (1 - alpha) * kNN forecast.
+  alpha: 0.01
+  # Hugging Face backbone identifier used to build the forecasting model.
+  model_name: AutonLab/MOMENT-1-large
+  # Number of windows processed per inference batch.
+  batch_size: 8
+  # DataLoader worker count for local CSV inference.
+  num_workers: 2
+  # Sliding-window stride for the input data; null defaults to model_horizon.
+  stride: null
+  # Sliding-window stride for DARR context memory; null defaults to model_horizon.
+  context_stride: null
+  # Random seed used for reproducible model setup and interpretability sampling.
+  seed: 13
+  # Number of nearest neighbors retrieved in DARR mode.
+  k: 64
+  # Softmax temperature applied to DARR neighbor distances.
+  temperature: 0.05
+  # Device override such as "cuda", "mps", or "cpu"; null uses auto-detection.
+  device: null
+  # When true, only load model assets already present in the local Hugging Face cache.
+  local_files_only: false
+  # Enable cross-channel attention for multivariate forecasting.
+  use_cross_channel: true
+  # Attention head count for the cross-channel layer.
+  cross_channel_heads: 8
+  # Dropout probability for the cross-channel layer.
+  cross_channel_dropout: 0.1
+  # Emit one forecast column per numeric channel instead of only the target forecast.
+  return_all_channels: false
+  # Run the interpretability pipeline instead of the standard/DARR inference path.
+  interpretability: false
+  # Interpretability artifact mode: "json", "pdf", or null for both.
+  interpretability_output: null
+  # Parent directory where interpretability run artifacts are written.
+  interpretability_out_dir: interpretability_output
+  # Optional interpretability run folder name; null creates a UTC-stamped folder.
+  interpretability_run_name: null
+  # Number of top lag contributors to show in the interpretability PDF table.
+  interpretability_top_k: 5
+  # Optional dataset label stored in interpretability JSON/PDF metadata.
+  interpretability_dataset_name: null
+  # Number of historical lag steps resolved by lag-horizon attribution.
+  n_lags: 128
+  # Temperature used when converting interpretability scores into attribution weights.
+  softmax_tau: 1.0
+  # Attribute feature-axis effects on the target forecast instead of latent embeddings.
+  channel_output_aware: false
+  # Add embedding integrated-gradients artifacts to interpretability output.
+  integrated_gradients: false
+  # Integrated-gradients baseline; "noise" enables noise baseline sampling.
+  integrated_gradients_baseline: noise
+  # Number of midpoint integration steps for integrated gradients.
+  integrated_gradients_steps: 64
+  # Number of independent baselines averaged when using the "noise" baseline.
+  integrated_gradients_n_baselines: 1
+  # Optional chunk size for integrated-gradients interpolation points; null processes all.
+  integrated_gradients_internal_batch_size: null
+  # Embedding objective reduction for integrated gradients: "l2", "sum", or "mean".
+  integrated_gradients_reduce: l2
+  # Let integrated-gradient attribution flow through model normalization statistics.
+  integrated_gradients_grad_through_norm: true

--- a/forecasting/sdk/quick_example.py
+++ b/forecasting/sdk/quick_example.py
@@ -16,11 +16,12 @@ Model weights download automatically from the public Hugging Face repo on first 
 
 import logging
 import os
+from dataclasses import replace
 from pathlib import Path
 
 import pandas as pd
 
-from sdk.forecasting import perform_forecasting
+from sdk.forecasting import ForecastingConfig, perform_forecasting
 
 logger = logging.getLogger(__name__)
 
@@ -49,15 +50,18 @@ if __name__ == "__main__":
     seq_len = 512
     forecast_horizon = 100
 
-    # Standard forecasting (no external memory)
-    # Model weights will be auto-downloaded if not present
-    forecast_df = perform_forecasting(
-        df=df,
+    base_config = ForecastingConfig(
         seq_len=seq_len,
         forecast_horizon=forecast_horizon,
         timestamp_column=timestamp_col,
         target_column=target_col,
-        save_preds="forecast_ETTh_seq_len_100.csv",
+    )
+
+    # Standard forecasting (no external memory)
+    # Model weights will be auto-downloaded if not present
+    forecast_df = perform_forecasting(
+        df=df,
+        config=replace(base_config, save_preds="forecast_ETTh_seq_len_100.csv"),
     )
     logger.info(
         "\nStandard forecast (only predicted rows with '%s_forecast' column):\n%s", target_col, forecast_df.to_csv()
@@ -73,12 +77,8 @@ if __name__ == "__main__":
     context_df = pd.read_csv(context_csv_path)
     darr_df = perform_forecasting(
         df=df,
-        seq_len=seq_len,
-        forecast_horizon=forecast_horizon,
+        config=replace(base_config, save_preds="forecast_ETTh_darr_100.csv"),
         context_df=context_df,  # This enables DARR mode
-        timestamp_column=timestamp_col,
-        target_column=target_col,
-        save_preds="forecast_ETTh_darr_100.csv",
         # Model weights auto-downloaded if needed
     )
     logger.info("\nDARR forecast (hybrid prediction in '%s_forecast' column):\n%s", target_col, darr_df.to_csv())
@@ -98,12 +98,8 @@ if __name__ == "__main__":
     df_interp[f"{target_col}_diff"] = df_interp[target_col].diff().fillna(0.0)
     df_interp[f"{target_col}_roll12"] = df_interp[target_col].rolling(window=12, min_periods=1).mean()
 
-    interp_df = perform_forecasting(
-        df=df_interp,
-        seq_len=seq_len,
-        forecast_horizon=forecast_horizon,
-        timestamp_column=timestamp_col,
-        target_column=target_col,
+    interp_config = replace(
+        base_config,
         # Interpretability controls
         interpretability=True,
         interpretability_output=None,  # write both JSON and PDF
@@ -113,6 +109,10 @@ if __name__ == "__main__":
         softmax_tau=1.0,
         integrated_gradients=True,
         save_preds="forecast_ETTh_with_explanations.csv",
+    )
+    interp_df = perform_forecasting(
+        df=df_interp,
+        config=interp_config,
     )
     logger.info(
         "\nInterpretability forecast (single-window baseline in '%s_forecast' column):\n%s",

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -14,9 +14,8 @@ from types import SimpleNamespace
 import numpy as np
 import pandas as pd
 import pytest
-import torch
-
 import sdk
+import torch
 from sdk import forecasting
 
 

--- a/forecasting/sdk/tests/test_forecasting.py
+++ b/forecasting/sdk/tests/test_forecasting.py
@@ -7,13 +7,30 @@ import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from dataclasses import asdict
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
 import pytest
 import torch
+
+import sdk
 from sdk import forecasting
+
+
+def perform_forecasting(
+    df: pd.DataFrame,
+    *,
+    config=None,
+    context_df: pd.DataFrame | None = None,
+    **options,
+) -> pd.DataFrame:
+    """Exercise the config-first API while keeping individual tests concise."""
+    assert config is None or not options
+    resolved = forecasting.ForecastingConfig(**options) if config is None else config
+    return forecasting.perform_forecasting(df, config=resolved, context_df=context_df)
 
 
 class DummyModel:
@@ -139,7 +156,7 @@ def make_timeseries_with_columns(num_rows: int = 10, columns: list[str] | None =
 
 def test_perform_forecasting_generates_forecast_when_horizon_exceeds_model_horizon():
     df = make_timeseries(num_rows=10)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -173,7 +190,7 @@ def test_perform_forecasting_uses_distinct_temp_csvs_for_concurrent_calls(monkey
 
     def invoke(_):
         with pytest.raises(StopAfterTempCsvError):
-            forecasting.perform_forecasting(
+            perform_forecasting(
                 make_timeseries(num_rows=10),
                 seq_len=5,
                 forecast_horizon=2,
@@ -209,7 +226,7 @@ def test_perform_forecasting_uses_and_cleans_owned_temp_csvs(monkeypatch, tmp_pa
 
     monkeypatch.setattr(forecasting, "_create_temp_csv_path", create_temp_csv_path)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         make_timeseries(num_rows=10),
         context_df=make_timeseries(num_rows=10) if with_context else None,
         seq_len=5,
@@ -233,7 +250,7 @@ def test_perform_forecasting_uses_cross_channel_model_when_checkpoint_contains_w
     )
 
     df = make_timeseries(num_rows=10)
-    forecasting.perform_forecasting(
+    perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -252,7 +269,7 @@ def test_perform_forecasting_uses_cross_channel_model_when_checkpoint_contains_w
 def test_perform_forecasting_disables_cross_channel_when_checkpoint_has_no_weights(caplog, patch_external_dependencies):
     df = make_timeseries(num_rows=10)
     with caplog.at_level(logging.WARNING):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=3,
@@ -275,7 +292,7 @@ def test_perform_forecasting_enables_cross_channel_when_checkpoint_has_weights(
 
     df = make_timeseries(num_rows=10)
     with caplog.at_level(logging.WARNING):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=3,
@@ -351,7 +368,7 @@ def test_load_cached_model_rejects_missing_keys(monkeypatch):
 
 def test_perform_forecasting_allows_cross_channel_configuration_override(patch_external_dependencies):
     df = make_timeseries(num_rows=10)
-    forecasting.perform_forecasting(
+    perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -378,7 +395,7 @@ def test_perform_forecasting_return_all_channels_emits_per_channel_forecasts(mon
     forecasting.clear_model_cache()
 
     df = make_timeseries(num_rows=10)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -401,7 +418,7 @@ def test_perform_forecasting_return_all_channels_emits_per_channel_forecasts(mon
 
 def test_perform_forecasting_return_all_channels_with_autoregressive_horizon():
     df = make_timeseries(num_rows=10)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=6,
@@ -421,7 +438,7 @@ def test_perform_forecasting_return_all_channels_with_autoregressive_horizon():
 def test_perform_forecasting_return_all_channels_darr_mode():
     df = make_timeseries(num_rows=12)
     context_df = make_timeseries(num_rows=12)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -452,7 +469,7 @@ def test_perform_forecasting_return_all_channels_supports_interpretability(monke
 
     monkeypatch.setattr(forecasting, "_run_interpretability", run_interpretability)
     df = make_timeseries(num_rows=10)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -469,18 +486,18 @@ def test_perform_forecasting_return_all_channels_supports_interpretability(monke
 def test_interpretability_sdk_defaults_match_algorithms():
     from integrated_gradients import integrated_gradients_embedding
 
-    sdk_params = inspect.signature(forecasting.perform_forecasting).parameters
+    config = forecasting.ForecastingConfig()
     explain_params = inspect.signature(forecasting.explain_forecast).parameters
     ig_params = inspect.signature(integrated_gradients_embedding).parameters
 
-    assert sdk_params["n_lags"].default == explain_params["n_lags"].default
-    assert sdk_params["softmax_tau"].default == explain_params["softmax_tau"].default
-    assert sdk_params["channel_output_aware"].default == explain_params["channel_output_aware"].default
-    assert sdk_params["integrated_gradients_baseline"].default == ig_params["baseline"].default
-    assert sdk_params["integrated_gradients_steps"].default == ig_params["n_steps"].default
-    assert sdk_params["integrated_gradients_n_baselines"].default == ig_params["n_baselines"].default
-    assert sdk_params["integrated_gradients_internal_batch_size"].default == ig_params["internal_batch_size"].default
-    assert sdk_params["integrated_gradients_reduce"].default == ig_params["reduce"].default
+    assert config.n_lags == explain_params["n_lags"].default
+    assert config.softmax_tau == explain_params["softmax_tau"].default
+    assert config.channel_output_aware == explain_params["channel_output_aware"].default
+    assert config.integrated_gradients_baseline == ig_params["baseline"].default
+    assert config.integrated_gradients_steps == ig_params["n_steps"].default
+    assert config.integrated_gradients_n_baselines == ig_params["n_baselines"].default
+    assert config.integrated_gradients_internal_batch_size == ig_params["internal_batch_size"].default
+    assert config.integrated_gradients_reduce == ig_params["reduce"].default
 
 
 def test_feature_axis_embedding_stability_csv_contains_complete_report(tmp_path):
@@ -572,7 +589,7 @@ def test_perform_forecasting_forwards_output_aware_mode(monkeypatch, tmp_path):
             "feature": np.linspace(0.0, 1.0, 10, dtype=np.float32),
         }
     )
-    forecasting.perform_forecasting(
+    perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -770,7 +787,7 @@ def test_normalization_statistics_gradient_is_scoped():
 def test_perform_forecasting_return_all_channels_rejects_timestamp_collision():
     df = make_timeseries(num_rows=10).rename(columns={"timestamp": "feature_forecast"})
     with pytest.raises(ValueError, match="collides"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             timestamp_column="feature_forecast",
             seq_len=5,
@@ -785,7 +802,7 @@ def test_perform_forecasting_return_all_channels_rejects_timestamp_collision():
 def test_perform_forecasting_requires_timestamp_column():
     df = make_timeseries(num_rows=6).drop(columns=["timestamp"])
     with pytest.raises(ValueError, match="Timestamp column 'timestamp' not found"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -799,7 +816,7 @@ def test_perform_forecasting_requires_numeric_target():
     df = make_timeseries(num_rows=6)
     df["target"] = df["target"].astype(str)
     with pytest.raises(ValueError, match="Target column 'target' must contain numeric values"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -812,7 +829,7 @@ def test_perform_forecasting_requires_numeric_target():
 def test_perform_forecasting_validates_forecast_horizon():
     df = make_timeseries(num_rows=6)
     with pytest.raises(ValueError, match="forecast_horizon must be positive"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=0,
@@ -826,7 +843,7 @@ def test_perform_forecasting_rejects_forecast_horizon_above_max():
     """forecast_horizon above 512 should raise ValueError."""
     df = make_timeseries(num_rows=520)
     with pytest.raises(ValueError, match="forecast_horizon must be <= 512"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=513,
@@ -839,7 +856,7 @@ def test_perform_forecasting_rejects_forecast_horizon_above_max():
 def test_perform_forecasting_accepts_max_forecast_horizon():
     """forecast_horizon of exactly 512 should be accepted."""
     df = make_timeseries(num_rows=520)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=512,
@@ -857,7 +874,7 @@ def test_perform_forecasting_darr_mode_rejects_forecast_horizon_above_max():
     df = make_timeseries(num_rows=520)
     context_df = make_timeseries(num_rows=520)
     with pytest.raises(ValueError, match="forecast_horizon must be <= 512"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=600,
@@ -871,7 +888,7 @@ def test_perform_forecasting_darr_mode_rejects_forecast_horizon_above_max():
 def test_perform_forecasting_validates_model_horizon():
     df = make_timeseries(num_rows=6)
     with pytest.raises(ValueError, match="model_horizon must be positive"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=0,
@@ -884,7 +901,7 @@ def test_perform_forecasting_validates_model_horizon():
 def test_perform_forecasting_requires_minimum_rows():
     df = make_timeseries(num_rows=4)
     with pytest.raises(ValueError, match="DataFrame has 4 rows but seq_len requires at least 5 rows"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -898,7 +915,7 @@ def test_perform_forecasting_context_df_missing_timestamp():
     df = make_timeseries(num_rows=7)
     context_df = make_timeseries(num_rows=7).drop(columns=["timestamp"])
     with pytest.raises(ValueError, match="Context DataFrame missing timestamp column 'timestamp'"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -913,7 +930,7 @@ def test_perform_forecasting_darr_mode_returns_hybrid_forecast():
     """DARR mode returns hybrid forecast combining direct and kNN predictions."""
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=10)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -936,7 +953,7 @@ def test_perform_forecasting_darr_mode_with_custom_alpha():
     context_df = make_timeseries(num_rows=10)
 
     # Test with alpha=0.5 (50% direct, 50% kNN)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -957,7 +974,7 @@ def test_perform_forecasting_darr_mode_with_alpha_zero():
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=10)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -978,7 +995,7 @@ def test_perform_forecasting_darr_mode_with_alpha_one():
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=10)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -999,7 +1016,7 @@ def test_perform_forecasting_darr_mode_forecast_horizon_smaller_than_model_horiz
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=10)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,  # Smaller than model_horizon
@@ -1019,7 +1036,7 @@ def test_perform_forecasting_darr_mode_forecast_horizon_equals_model_horizon():
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=10)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -1039,7 +1056,7 @@ def test_perform_forecasting_darr_mode_forecast_horizon_larger_than_model_horizo
     df = make_timeseries(num_rows=12)
     context_df = make_timeseries(num_rows=12)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=6,  # Larger than model_horizon
@@ -1059,7 +1076,7 @@ def test_perform_forecasting_darr_mode_retrieves_full_requested_horizon():
     df = make_timeseries(num_rows=12)
     context_df = make_timeseries(num_rows=12)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=6,
@@ -1081,7 +1098,7 @@ def test_perform_forecasting_darr_mode_blends_full_retrieval_horizon():
     df = make_timeseries(num_rows=12)
     context_df = make_timeseries(num_rows=12)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=6,
@@ -1103,7 +1120,7 @@ def test_perform_forecasting_darr_mode_forecast_horizon_much_larger_than_model_h
     df = make_timeseries(num_rows=15)
     context_df = make_timeseries(num_rows=15)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=10,  # 5x model_horizon, requires 5 iterations
@@ -1123,7 +1140,7 @@ def test_perform_forecasting_darr_mode_forecast_horizon_not_multiple_of_model_ho
     df = make_timeseries(num_rows=12)
     context_df = make_timeseries(num_rows=12)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=7,  # Not a multiple of model_horizon (3)
@@ -1141,7 +1158,7 @@ def test_perform_forecasting_darr_mode_forecast_horizon_not_multiple_of_model_ho
 def test_perform_forecasting_requires_target_column():
     df = make_timeseries(num_rows=6).drop(columns=["target"])
     with pytest.raises(ValueError, match="Target column 'target' not found"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -1155,7 +1172,7 @@ def test_perform_forecasting_null_timestamps_rejected():
     df = make_timeseries(num_rows=6)
     df.loc[0, "timestamp"] = pd.NaT
     with pytest.raises(ValueError, match="Timestamp column 'timestamp' contains NULL values"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -1167,7 +1184,7 @@ def test_perform_forecasting_null_timestamps_rejected():
 
 def test_perform_forecasting_allows_custom_timestamp_column():
     df = make_timeseries(num_rows=10).rename(columns={"timestamp": "ts"})
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         timestamp_column="ts",
         seq_len=5,
@@ -1184,7 +1201,7 @@ def test_perform_forecasting_allows_custom_timestamp_column():
 def test_perform_forecasting_fills_null_targets():
     df = make_timeseries(num_rows=7)
     df.loc[0, "target"] = np.nan
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1201,7 +1218,7 @@ def test_perform_forecasting_context_df_missing_target():
     df = make_timeseries(num_rows=7)
     context_df = make_timeseries(num_rows=7).drop(columns=["target"])
     with pytest.raises(ValueError, match="Context DataFrame missing target column 'target'"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -1217,7 +1234,7 @@ def test_perform_forecasting_darr_mode_with_custom_k():
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=10)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1238,7 +1255,7 @@ def test_perform_forecasting_darr_mode_with_custom_temperature():
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=10)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1259,7 +1276,7 @@ def test_perform_forecasting_darr_mode_with_larger_context():
     df = make_timeseries(num_rows=10)
     context_df = make_timeseries(num_rows=50)
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1279,7 +1296,7 @@ def test_perform_forecasting_darr_mode_custom_timestamp_column():
     df = make_timeseries(num_rows=10).rename(columns={"timestamp": "ts"})
     context_df = make_timeseries(num_rows=10).rename(columns={"timestamp": "ts"})
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         timestamp_column="ts",
         seq_len=5,
@@ -1301,7 +1318,7 @@ def test_perform_forecasting_darr_mode_custom_target_column():
     df = make_timeseries(num_rows=10).rename(columns={"target": "value"})
     context_df = make_timeseries(num_rows=10).rename(columns={"target": "value"})
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         target_column="value",
         seq_len=5,
@@ -1324,7 +1341,7 @@ def test_perform_forecasting_darr_mode_context_df_insufficient_rows():
     context_df = make_timeseries(num_rows=6)
 
     with pytest.raises(ValueError, match="Context DataFrame has .* rows but requires at least .* rows"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -1342,7 +1359,7 @@ def test_perform_forecasting_darr_mode_requires_full_retrieval_horizon():
     context_df = make_timeseries(num_rows=10)
 
     with pytest.raises(ValueError, match=r"seq_len=5 \+ context_horizon=6"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=6,
@@ -1362,7 +1379,7 @@ def test_perform_forecasting_darr_mode_column_mismatch_input_more_columns():
     context_df = make_timeseries_with_columns(num_rows=10, columns=["feat1", "feat2"])
 
     # Should succeed by using only common columns
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1385,7 +1402,7 @@ def test_perform_forecasting_darr_mode_column_mismatch_context_more_columns():
     context_df = make_timeseries_with_columns(num_rows=10, columns=["feat1", "feat2", "feat3", "feat4"])
 
     # Should succeed by using only common columns
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1408,7 +1425,7 @@ def test_perform_forecasting_darr_mode_column_mismatch_partial_overlap():
     context_df = make_timeseries_with_columns(num_rows=10, columns=["feat2", "feat3", "feat4"])
 
     # Should succeed by using only common columns (feat2, feat3)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1432,7 +1449,7 @@ def test_perform_forecasting_darr_mode_column_mismatch_no_common_columns():
 
     # Should raise error due to no common columns
     with pytest.raises(ValueError, match="No common numeric columns found between input and context datasets"):
-        forecasting.perform_forecasting(
+        perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=2,
@@ -1452,7 +1469,7 @@ def test_perform_forecasting_darr_mode_column_mismatch_many_vs_few():
     context_df = make_timeseries_with_columns(num_rows=10, columns=["HUFL", "HULL", "MUFL"])
 
     # Should succeed by using only common columns
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=2,
@@ -1475,7 +1492,7 @@ def test_perform_forecasting_darr_mode_column_alignment_with_autoregression():
     context_df = make_timeseries_with_columns(num_rows=12, columns=["feat1", "feat2"])
 
     # Test with autoregressive forecasting (forecast_horizon > model_horizon)
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=6,  # Larger than model_horizon
@@ -1501,7 +1518,7 @@ def test_perform_forecasting_darr_mode_same_columns_different_order(caplog):
     context_df = make_constant_feature_df(12, {"f2": 20.0, "f1": 10.0})
 
     with caplog.at_level(logging.WARNING):
-        result = forecasting.perform_forecasting(
+        result = perform_forecasting(
             df,
             seq_len=5,
             forecast_horizon=3,
@@ -1526,7 +1543,7 @@ def test_perform_forecasting_darr_mode_different_order_return_all_channels_align
     df = make_constant_feature_df(12, {"f1": 10.0, "f2": 20.0})
     context_df = make_constant_feature_df(12, {"f2": 20.0, "f1": 10.0})
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -1553,7 +1570,7 @@ def test_perform_forecasting_darr_mode_column_mismatch_uses_input_order_common_s
     df = make_constant_feature_df(12, {"zz": 30.0, "beta": 20.0, "alpha": 10.0})
     context_df = make_constant_feature_df(12, {"alpha": 10.0, "beta": 20.0})
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -1586,7 +1603,7 @@ def test_perform_forecasting_darr_mode_column_mismatch_direct_predictions_aligne
     df = make_constant_feature_df(12, {"zz": 30.0, "beta": 20.0, "alpha": 10.0})
     context_df = make_constant_feature_df(12, {"alpha": 10.0, "beta": 20.0})
 
-    result = forecasting.perform_forecasting(
+    result = perform_forecasting(
         df,
         seq_len=5,
         forecast_horizon=3,
@@ -1604,3 +1621,147 @@ def test_perform_forecasting_darr_mode_column_mismatch_direct_predictions_aligne
     # each column would carry the other channel's constant.
     assert result["beta_forecast"].tolist() == pytest.approx([20.0, 20.0, 20.0])
     assert result["alpha_forecast"].tolist() == pytest.approx([10.0, 10.0, 10.0])
+
+
+def test_sdk_package_exports_public_api():
+    assert sdk.DEFAULT_BACKBONE_NAME == forecasting.DEFAULT_BACKBONE_NAME
+    assert sdk.CHECKPOINT_CROSS_CHANNEL == forecasting.CHECKPOINT_CROSS_CHANNEL
+    assert sdk.CHECKPOINT_BASE == forecasting.CHECKPOINT_BASE
+    assert sdk.DEVICE == forecasting.DEVICE
+    assert sdk.ForecastingConfig is forecasting.ForecastingConfig
+    assert sdk.download_model_weights is forecasting.download_model_weights
+    assert sdk.load_forecasting_config is forecasting.load_forecasting_config
+    assert sdk.perform_forecasting is forecasting.perform_forecasting
+
+
+def test_perform_forecasting_has_compact_public_signature():
+    assert list(inspect.signature(forecasting.perform_forecasting).parameters) == [
+        "df",
+        "config",
+        "context_df",
+    ]
+
+
+def test_load_forecasting_config_accepts_nested_inference_section(tmp_path):
+    config_path = tmp_path / "forecasting.yaml"
+    config_path.write_text(
+        """
+dataset:
+  csv: ignored_by_sdk_loader.csv
+inference:
+  seq_len: 5
+  forecast_horizon: 3
+  model_horizon: 2
+  use_cross_channel: false
+train:
+  output_dir: ignored_by_sdk_loader
+""",
+        encoding="utf-8",
+    )
+
+    config = forecasting.load_forecasting_config(config_path)
+
+    assert isinstance(config, forecasting.ForecastingConfig)
+    assert config.seq_len == 5
+    assert config.forecast_horizon == 3
+    assert config.model_horizon == 2
+    assert config.use_cross_channel is False
+    assert config.batch_size == 8
+
+
+def test_load_forecasting_config_rejects_unknown_keys(tmp_path):
+    config_path = tmp_path / "forecasting.yaml"
+    config_path.write_text(
+        """
+inference:
+  seq_len: 5
+  typo_horizon: 3
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="typo_horizon"):
+        forecasting.load_forecasting_config(config_path)
+
+
+def test_commented_yaml_template_matches_config_defaults():
+    template_path = Path(forecasting.__file__).with_name("forecasting_inference_config.yaml")
+
+    assert asdict(forecasting.load_forecasting_config(template_path)) == asdict(forecasting.ForecastingConfig())
+
+    previous_content = ""
+    for line in template_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if line.startswith("  ") and not line.startswith("    ") and stripped and not stripped.startswith("#"):
+            assert previous_content.startswith("#"), f"Missing comment for config value: {stripped}"
+        if stripped:
+            previous_content = stripped
+
+
+def test_perform_forecasting_uses_yaml_config_values(monkeypatch, tmp_path, patch_external_dependencies):
+    config_path = tmp_path / "forecasting.yaml"
+    config_path.write_text(
+        """
+inference:
+  standardizer_pkl: fake_std_from_yaml.pkl
+  ckpt: fake_ckpt_from_yaml.pt
+  seq_len: 5
+  forecast_horizon: 3
+  model_horizon: 2
+  seed: 99
+  use_cross_channel: false
+  cross_channel_heads: 4
+  cross_channel_dropout: 0.2
+""",
+        encoding="utf-8",
+    )
+    download_calls = []
+
+    def download_model_weights(*, standardizer_pkl, ckpt, **kwargs):
+        download_calls.append((standardizer_pkl, ckpt))
+        return standardizer_pkl, ckpt
+
+    monkeypatch.setattr(forecasting, "download_model_weights", download_model_weights)
+
+    result = perform_forecasting(
+        make_timeseries(num_rows=10),
+        config=config_path,
+    )
+
+    assert len(result) == 3
+    assert download_calls == [("fake_std_from_yaml.pkl", "fake_ckpt_from_yaml.pt")]
+    assert patch_external_dependencies[0]["forecast_horizon"] == 2
+    assert patch_external_dependencies[0]["use_cross_channel"] is False
+    assert patch_external_dependencies[0]["cross_channel_heads"] == 4
+    assert patch_external_dependencies[0]["cross_channel_dropout"] == 0.2
+
+
+def test_perform_forecasting_treats_empty_yaml_artifact_paths_as_defaults(monkeypatch, tmp_path):
+    config_path = tmp_path / "forecasting.yaml"
+    config_path.write_text(
+        """
+inference:
+  standardizer_pkl: ""
+  ckpt: ""
+  seq_len: 5
+  forecast_horizon: 2
+  model_horizon: 2
+  use_cross_channel: true
+""",
+        encoding="utf-8",
+    )
+    download_calls = []
+
+    def download_model_weights(*, standardizer_pkl, ckpt, **kwargs):
+        download_calls.append((standardizer_pkl, ckpt))
+        return standardizer_pkl, ckpt
+
+    monkeypatch.setattr(forecasting, "download_model_weights", download_model_weights)
+
+    result = perform_forecasting(
+        make_timeseries(num_rows=10),
+        config=config_path,
+    )
+
+    assert len(result) == 2
+    assert download_calls == [("standardizer.pkl", forecasting.CHECKPOINT_CROSS_CHANNEL)]


### PR DESCRIPTION
## Summary
- `perform_forecasting()` now takes a single `config: ForecastingConfig | str | Path | None` instead of ~25 flat kwargs.
- Adds `ForecastingConfig` dataclass and `load_forecasting_config()`, which reads a flat or `inference:`-nested YAML, validates unknown keys, and warns (instead of silently swapping) when `standardizer_pkl`/`ckpt` are explicitly empty.
- Fixes `NVTesseractForecasting.forecast()`, which also called the old flat API.
- Updates `sdk/__init__.py` exports, `sdk/quick_example.py`, tests, and both READMEs (root + `forecasting/`) accordingly.
- Adds a new commented template at `forecasting/sdk/forecasting_inference_config.yaml`.

## Test plan
- [x] `uv run pytest sdk/tests/test_forecasting.py -q` — 70 passed
- [x] `uv run python sdk/quick_example.py` — standard, DARR, and interpretability (JSON + PDF) modes all ran end to end successfully
