### PR TITLE
Add ADDiffusionConfig/YAML explainability config to perform_anomaly_analysis_with_diffusion

### DIFF
--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -48,16 +48,18 @@ results = perform_anomaly_analysis_with_diffusion(
     # model_config_path="path/to/config.yaml",     # optional; defaults to curriculum_medium.yaml
     nsample=15,
     preprocess_model_dir="path/to/preprocessing/models",  # optional
-    sdk_config=ADDiffusionConfig(explain=True, explanation_top_k=3),
+    explain=True,
+    explanation_top_k=3,
 )
 
 # Results contain original data plus anomaly detection results
 print(f"Detected {results['Anomaly'].sum()} anomalies")
 ```
 
-Explainability and reporting settings (`explain`, `report_path`, etc.) live on
-`ADDiffusionConfig`, which can also be loaded from a YAML file — a fully
-commented template is available at `sdk/sdk_config.yaml`:
+Reporting settings (`report_path`, etc.) live on `ADDiffusionConfig`, which can
+also be loaded from a YAML file — a fully commented template is available at
+`sdk/sdk_config.yaml`. `explain`/`explanation_top_k` stay direct keyword
+arguments since they're not part of the reporting config:
 
 ```python
 results = perform_anomaly_analysis_with_diffusion(
@@ -83,11 +85,11 @@ ground truth when a conventional label column such as `GT` is present:
 results = perform_anomaly_analysis_with_diffusion(
     df=df,
     threshold_strategy="scs",
+    explain=True,
     sdk_config=ADDiffusionConfig(
         report_path="output/pdf/anomaly_detection_report.pdf",
         timestamp_column="timestamp",
         ground_truth_column="GT",
-        explain=True,
         report_max_pages=10,
         report_consolidated_top_k=5,
     ),

--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -34,26 +34,37 @@ Then use the main function:
 import pandas as pd
 import sys, os
 sys.path.append('/path/to/ad_diffusion')  # Adjust to your installation path
-from sdk.anomaly_analysis import perform_anomaly_analysis_with_diffusion
+from sdk.anomaly_analysis import ADDiffusionConfig, perform_anomaly_analysis_with_diffusion
 
 # Load your data
 df = pd.read_csv("your_data.csv")
 
-# Perform anomaly detection — omit model_path/config_path to auto-download
+# Perform anomaly detection — omit model_path/model_config_path to auto-download
 # the pretrained weights from Hugging Face (nvidia/nv-tesseract-ad-diffusion).
 results = perform_anomaly_analysis_with_diffusion(
     df=df,
     threshold_strategy="scs",  # or "macs"
-    # model_path="path/to/your/model.pth",    # optional; defaults to final_model.pth
-    # config_path="path/to/config.yaml",      # optional; defaults to curriculum_medium.yaml
+    # model_path="path/to/your/model.pth",         # optional; defaults to final_model.pth
+    # model_config_path="path/to/config.yaml",     # optional; defaults to curriculum_medium.yaml
     nsample=15,
     preprocess_model_dir="path/to/preprocessing/models",  # optional
-    explain=True,
-    explanation_top_k=3,
+    sdk_config=ADDiffusionConfig(explain=True, explanation_top_k=3),
 )
 
 # Results contain original data plus anomaly detection results
 print(f"Detected {results['Anomaly'].sum()} anomalies")
+```
+
+Explainability and reporting settings (`explain`, `report_path`, etc.) live on
+`ADDiffusionConfig`, which can also be loaded from a YAML file — a fully
+commented template is available at `sdk/sdk_config.yaml`:
+
+```python
+results = perform_anomaly_analysis_with_diffusion(
+    df=df,
+    threshold_strategy="scs",
+    sdk_config="sdk_config.yaml",
+)
 ```
 
 With `explain=True`, the result also includes `TopContributors`,
@@ -72,12 +83,14 @@ ground truth when a conventional label column such as `GT` is present:
 results = perform_anomaly_analysis_with_diffusion(
     df=df,
     threshold_strategy="scs",
-    report_path="output/pdf/anomaly_detection_report.pdf",
-    timestamp_column="timestamp",
-    ground_truth_column="GT",
-    explain=True,
-    report_max_pages=10,
-    report_consolidated_top_k=5,
+    sdk_config=ADDiffusionConfig(
+        report_path="output/pdf/anomaly_detection_report.pdf",
+        timestamp_column="timestamp",
+        ground_truth_column="GT",
+        explain=True,
+        report_max_pages=10,
+        report_consolidated_top_k=5,
+    ),
 )
 ```
 
@@ -298,7 +311,7 @@ results = perform_anomaly_analysis_with_diffusion(
     df=analysis_df,
     threshold_strategy="scs",
     model_path="artifacts/finetune_my_data/best_finetuned_model.pth",
-    config_path="artifacts/finetune_my_data/finetune_config.yaml",
+    model_config_path="artifacts/finetune_my_data/finetune_config.yaml",
     nsample=15,
 )
 ```

--- a/ad_diffusion/examples/quick_example.py
+++ b/ad_diffusion/examples/quick_example.py
@@ -253,7 +253,7 @@ def run_anomaly_detection_example(
                     df=analysis_df,
                     threshold_strategy="scs",  # Try "macs" as alternative
                     model_path=resolved_model_path,
-                    config_path=resolved_config_path if Path(resolved_config_path).exists() else "",
+                    model_config_path=resolved_config_path if Path(resolved_config_path).exists() else "",
                     nsample=15,
                     # preprocess_model_dir="/path/to/preprocessing/models"  # Optional
                 )

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -32,15 +32,14 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class ADDiffusionConfig:
-    """Explainability and reporting configuration for :func:`perform_anomaly_analysis_with_diffusion`.
+    """Reporting configuration for :func:`perform_anomaly_analysis_with_diffusion`.
 
-    Scoped to the explain toggle and explainability/report-related parameters —
-    inference-behavior knobs like ``threshold_strategy``, ``nsample``, and the
-    model/config paths stay as direct function arguments.
+    Scoped to report-related parameters — inference-behavior knobs like
+    ``threshold_strategy``, ``nsample``, the model/config paths, and the
+    ``explain``/``explanation_top_k`` explainability toggle stay as direct
+    function arguments.
     """
 
-    explain: bool = False
-    explanation_top_k: int = 3
     report_path: str | Path | None = None
     timestamp_column: str | None = None
     ground_truth_column: str | None = None
@@ -97,6 +96,8 @@ def perform_anomaly_analysis_with_diffusion(
     model_config_path: str | Path = "",
     nsample: int = 15,
     preprocess_model_dir: str | Path | None = None,
+    explain: bool = False,
+    explanation_top_k: int = 3,
     sdk_config: ADDiffusionConfig | str | Path | None = None,
 ) -> pd.DataFrame:
     """
@@ -115,7 +116,9 @@ def perform_anomaly_analysis_with_diffusion(
         model_config_path: Path to the model architecture config file (optional if config is in checkpoint)
         nsample: Number of samples for diffusion model inference
         preprocess_model_dir: Directory containing preprocessing model (optional)
-        sdk_config: Explainability/reporting `ADDiffusionConfig`, YAML path, or `None` for defaults.
+        explain: Whether to add reconstruction-error explanations for detected anomalies.
+        explanation_top_k: Maximum number of contributors returned per anomaly.
+        sdk_config: Reporting `ADDiffusionConfig`, YAML path, or `None` for defaults.
             See `ADDiffusionConfig` for the field reference.
 
     Returns:
@@ -226,7 +229,7 @@ def perform_anomaly_analysis_with_diffusion(
     result_df["Anomaly"] = anomalies
     result_df["MAE"] = residual_scores  # Using residual (MAE) as anomaly score
 
-    if cfg.explain:
+    if explain:
         reconstruction = results.get("recon")
         if reconstruction is None:
             raise ValueError("Inference results must include 'recon' when explain=True.")
@@ -245,7 +248,7 @@ def perform_anomaly_analysis_with_diffusion(
             anomaly_mask=anomalies[:explanation_length],
             feature_names=feature_names,
             feature_indices=feature_indices,
-            top_k=cfg.explanation_top_k,
+            top_k=explanation_top_k,
         )
         explanations = explanations.reindex(range(original_length)).fillna(
             {

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from pathlib import Path  # noqa: TC003
+from dataclasses import dataclass, fields
+from pathlib import Path
 
 import pandas as pd
+import yaml
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sdk.explainability import explain_reconstruction_anomalies
@@ -28,28 +30,79 @@ from sdk.thresholds import MACSThresholdStrategy, SCSThresholdStrategy
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class ADDiffusionConfig:
+    """Explainability and reporting configuration for :func:`perform_anomaly_analysis_with_diffusion`.
+
+    Scoped to the explain toggle and explainability/report-related parameters —
+    inference-behavior knobs like ``threshold_strategy``, ``nsample``, and the
+    model/config paths stay as direct function arguments.
+    """
+
+    explain: bool = False
+    explanation_top_k: int = 3
+    report_path: str | Path | None = None
+    timestamp_column: str | None = None
+    ground_truth_column: str | None = None
+    report_title: str = "Anomaly Detection Report"
+    report_explanation_csv_path: str | Path | None = None
+    report_max_pages: int = 10
+    report_consolidated_top_k: int = 5
+
+
+_SDK_CONFIG_FIELDS = frozenset(field.name for field in fields(ADDiffusionConfig))
+
+
+def load_sdk_config(config_path: str | Path) -> ADDiffusionConfig:
+    """Load and validate an :class:`ADDiffusionConfig` from YAML.
+
+    The YAML may be a flat mapping or contain a top-level ``sdk`` mapping,
+    which allows the file to carry other sections (e.g. model config) alongside it.
+    """
+    with open(config_path) as f:
+        raw_config = yaml.safe_load(f) or {}
+
+    if not isinstance(raw_config, dict):
+        raise TypeError(f"SDK config must be a mapping, got {type(raw_config).__name__}.")
+
+    config = raw_config.get("sdk", raw_config)
+    if config is None:
+        return ADDiffusionConfig()
+    if not isinstance(config, dict):
+        raise TypeError(f"SDK config 'sdk' section must be a mapping, got {type(config).__name__}.")
+
+    unknown_keys = sorted(set(config) - _SDK_CONFIG_FIELDS)
+    if unknown_keys:
+        allowed = ", ".join(sorted(_SDK_CONFIG_FIELDS))
+        raise ValueError(f"Unknown SDK config keys: {unknown_keys}. Allowed keys: {allowed}")
+
+    return ADDiffusionConfig(**config)
+
+
+def _resolve_sdk_config(config: ADDiffusionConfig | str | Path | None) -> ADDiffusionConfig:
+    if config is None:
+        return ADDiffusionConfig()
+    if isinstance(config, ADDiffusionConfig):
+        return config
+    if isinstance(config, str | Path):
+        return load_sdk_config(config)
+    raise TypeError("sdk_config must be an ADDiffusionConfig, YAML path, or None")
+
+
 def perform_anomaly_analysis_with_diffusion(
     df: pd.DataFrame,
     *,
     threshold_strategy: str,
     model_path: str | Path | None = None,
-    config_path: str | Path = "",
+    model_config_path: str | Path = "",
     nsample: int = 15,
     preprocess_model_dir: str | Path | None = None,
-    report_path: str | Path | None = None,
-    timestamp_column: str | None = None,
-    ground_truth_column: str | None = None,
-    report_title: str = "Anomaly Detection Report",
-    report_explanation_csv_path: str | Path | None = None,
-    report_max_pages: int = 10,
-    report_consolidated_top_k: int = 5,
-    explain: bool = False,
-    explanation_top_k: int = 3,
+    sdk_config: ADDiffusionConfig | str | Path | None = None,
 ) -> pd.DataFrame:
     """
     Perform anomaly analysis using Tesseract AD Diffusion Model.
 
-    If ``model_path``/``config_path`` do not exist locally, the default weights
+    If ``model_path``/``model_config_path`` do not exist locally, the default weights
     (``final_model.pth`` + ``curriculum_medium.yaml``) are automatically
     downloaded from the Hugging Face repository
     ``nvidia/nv-tesseract-ad-diffusion``.
@@ -59,33 +112,25 @@ def perform_anomaly_analysis_with_diffusion(
         threshold_strategy: Strategy to use for threshold calculation ('scs' or 'macs')
         model_path: Path to the diffusion model checkpoint. If ``None`` or missing
             locally, the default checkpoint is downloaded from Hugging Face.
-        config_path: Path to the model config file (optional if config is in checkpoint)
+        model_config_path: Path to the model architecture config file (optional if config is in checkpoint)
         nsample: Number of samples for diffusion model inference
         preprocess_model_dir: Directory containing preprocessing model (optional)
-        report_path: Optional PDF destination. No report is generated when omitted.
-        timestamp_column: Optional timestamp column used only for report plotting.
-            When report_path is set, conventional timestamp names are auto-detected.
-        ground_truth_column: Optional binary-label column used only for report
-            plotting. When report_path is set, conventional label names are auto-detected.
-        report_title: Title shown on the generated PDF report.
-        report_explanation_csv_path: Optional destination for the full
-            explainability CSV. When omitted, it is written beside the PDF.
-        report_max_pages: Maximum PDF page count. Excess anomaly details are consolidated.
-        report_consolidated_top_k: Number of overall contributors shown when details are consolidated.
-        explain: Whether to add reconstruction-error explanations for detected anomalies.
-        explanation_top_k: Maximum number of contributors returned per anomaly.
+        sdk_config: Explainability/reporting `ADDiffusionConfig`, YAML path, or `None` for defaults.
+            See `ADDiffusionConfig` for the field reference.
 
     Returns:
         DataFrame with original data and anomaly detection results
     """
+    cfg = _resolve_sdk_config(sdk_config)
+
     # Prepare data for diffusion model
     # The diffusion model expects all numeric columns
     resolved_timestamp_column = None
     resolved_ground_truth_column = None
     metadata_columns = []
-    if report_path is not None:
-        resolved_timestamp_column = timestamp_column or infer_timestamp_column(df)
-        resolved_ground_truth_column = ground_truth_column or infer_ground_truth_column(df)
+    if cfg.report_path is not None:
+        resolved_timestamp_column = cfg.timestamp_column or infer_timestamp_column(df)
+        resolved_ground_truth_column = cfg.ground_truth_column or infer_ground_truth_column(df)
         metadata_columns = [
             column for column in (resolved_timestamp_column, resolved_ground_truth_column) if column is not None
         ]
@@ -124,7 +169,7 @@ def perform_anomaly_analysis_with_diffusion(
     # Resolve / auto-download weights once up front so downstream calls share them.
     resolved_model, resolved_config = _resolve_model_paths(
         str(model_path) if model_path else None,
-        str(config_path) if config_path else "",
+        str(model_config_path) if model_config_path else "",
     )
 
     # Get target_dim from model and validate data size BEFORE running inference
@@ -181,7 +226,7 @@ def perform_anomaly_analysis_with_diffusion(
     result_df["Anomaly"] = anomalies
     result_df["MAE"] = residual_scores  # Using residual (MAE) as anomaly score
 
-    if explain:
+    if cfg.explain:
         reconstruction = results.get("recon")
         if reconstruction is None:
             raise ValueError("Inference results must include 'recon' when explain=True.")
@@ -200,7 +245,7 @@ def perform_anomaly_analysis_with_diffusion(
             anomaly_mask=anomalies[:explanation_length],
             feature_names=feature_names,
             feature_indices=feature_indices,
-            top_k=explanation_top_k,
+            top_k=cfg.explanation_top_k,
         )
         explanations = explanations.reindex(range(original_length)).fillna(
             {
@@ -213,17 +258,17 @@ def perform_anomaly_analysis_with_diffusion(
         for column in explanations.columns:
             result_df[column] = explanations[column].to_numpy()
 
-    if report_path is not None:
+    if cfg.report_path is not None:
         generate_anomaly_detection_report(
             result_df,
-            report_path,
+            cfg.report_path,
             feature_columns=list(input_df.columns),
             timestamp_column=resolved_timestamp_column,
             ground_truth_column=resolved_ground_truth_column,
-            title=report_title,
-            explanation_csv_path=report_explanation_csv_path,
-            max_report_pages=report_max_pages,
-            consolidated_top_k=report_consolidated_top_k,
+            title=cfg.report_title,
+            explanation_csv_path=cfg.report_explanation_csv_path,
+            max_report_pages=cfg.report_max_pages,
+            consolidated_top_k=cfg.report_consolidated_top_k,
         )
 
     return result_df

--- a/ad_diffusion/sdk/sdk_config.yaml
+++ b/ad_diffusion/sdk/sdk_config.yaml
@@ -1,17 +1,13 @@
-# SDK (explainability/reporting) settings for
+# SDK (reporting) settings for
 # sdk.anomaly_analysis.perform_anomaly_analysis_with_diffusion.
 # Copy this file and pass it with sdk_config="path/to/your_config.yaml".
 #
-# This covers only the explain toggle and explainability/report-related
-# parameters. Inference-behavior settings (threshold_strategy, nsample,
-# preprocess_model_dir) and model paths (model_path, model_config_path) stay
-# as direct keyword arguments on perform_anomaly_analysis_with_diffusion.
+# This covers only report-related parameters. Inference-behavior settings
+# (threshold_strategy, nsample, preprocess_model_dir), model paths
+# (model_path, model_config_path), and the explain/explanation_top_k
+# explainability toggle stay as direct keyword arguments on
+# perform_anomaly_analysis_with_diffusion.
 sdk:
-  # If true, add exact reconstruction-error explanations for anomalous rows.
-  # This does not trigger additional model inference.
-  explain: false
-  # Maximum number of target-space contributors to return per anomalous row.
-  explanation_top_k: 3
   # Optional PDF destination. No report is generated when null.
   report_path: null
   # Optional timestamp column used only for report plotting; conventional

--- a/ad_diffusion/sdk/sdk_config.yaml
+++ b/ad_diffusion/sdk/sdk_config.yaml
@@ -1,0 +1,31 @@
+# SDK (explainability/reporting) settings for
+# sdk.anomaly_analysis.perform_anomaly_analysis_with_diffusion.
+# Copy this file and pass it with sdk_config="path/to/your_config.yaml".
+#
+# This covers only the explain toggle and explainability/report-related
+# parameters. Inference-behavior settings (threshold_strategy, nsample,
+# preprocess_model_dir) and model paths (model_path, model_config_path) stay
+# as direct keyword arguments on perform_anomaly_analysis_with_diffusion.
+sdk:
+  # If true, add exact reconstruction-error explanations for anomalous rows.
+  # This does not trigger additional model inference.
+  explain: false
+  # Maximum number of target-space contributors to return per anomalous row.
+  explanation_top_k: 3
+  # Optional PDF destination. No report is generated when null.
+  report_path: null
+  # Optional timestamp column used only for report plotting; conventional
+  # names are auto-detected when report_path is set and this is null.
+  timestamp_column: null
+  # Optional binary-label column used only for report plotting; conventional
+  # names are auto-detected when report_path is set and this is null.
+  ground_truth_column: null
+  # Title shown on the generated PDF report.
+  report_title: Anomaly Detection Report
+  # Optional destination for the full explainability CSV; written beside the
+  # PDF when null.
+  report_explanation_csv_path: null
+  # Maximum PDF page count. Excess anomaly details are consolidated.
+  report_max_pages: 10
+  # Number of overall contributors shown when details are consolidated.
+  report_consolidated_top_k: 5

--- a/ad_diffusion/sdk/tests/test_anomaly_analysis.py
+++ b/ad_diffusion/sdk/tests/test_anomaly_analysis.py
@@ -3,6 +3,7 @@
 
 import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -75,7 +76,7 @@ def test_perform_anomaly_analysis_with_scs_strategy(monkeypatch, numeric_df, inf
         numeric_df,
         threshold_strategy="scs",
         model_path="model.pth",
-        config_path="config.yaml",
+        model_config_path="config.yaml",
         nsample=7,
     )
 
@@ -100,7 +101,7 @@ def test_perform_anomaly_analysis_rejects_non_numeric_columns(numeric_df):
             mixed_df,
             threshold_strategy="scs",
             model_path="model.pth",
-            config_path="config.yaml",
+            model_config_path="config.yaml",
         )
 
 
@@ -113,7 +114,7 @@ def test_perform_anomaly_analysis_rejects_insufficient_rows(monkeypatch):
             short_df,
             threshold_strategy="scs",
             model_path="model.pth",
-            config_path="config.yaml",
+            model_config_path="config.yaml",
         )
 
 
@@ -125,7 +126,7 @@ def test_perform_anomaly_analysis_rejects_unknown_threshold(monkeypatch, numeric
             numeric_df,
             threshold_strategy="not-a-strategy",
             model_path="model.pth",
-            config_path="config.yaml",
+            model_config_path="config.yaml",
         )
 
 
@@ -145,7 +146,7 @@ def test_perform_anomaly_analysis_truncates_long_model_outputs(monkeypatch, nume
         numeric_df,
         threshold_strategy="macs",
         model_path="model.pth",
-        config_path="config.yaml",
+        model_config_path="config.yaml",
     )
 
     assert len(result) == len(numeric_df)
@@ -179,8 +180,8 @@ def test_optional_pdf_report_excludes_metadata_from_inference(monkeypatch, infer
         input_df,
         threshold_strategy="scs",
         model_path="model.pth",
-        config_path="config.yaml",
-        report_path=destination,
+        model_config_path="config.yaml",
+        sdk_config=anomaly_analysis.ADDiffusionConfig(report_path=destination),
     )
 
     inference_df = mock_inference.call_args.kwargs["data"]
@@ -226,10 +227,12 @@ def test_explain_toggle_preserves_numeric_feature_names(monkeypatch, tmp_path):
         input_df,
         threshold_strategy="scs",
         model_path="model.pth",
-        config_path="config.yaml",
-        report_path=tmp_path / "report.pdf",
-        explain=True,
-        explanation_top_k=3,
+        model_config_path="config.yaml",
+        sdk_config=anomaly_analysis.ADDiffusionConfig(
+            report_path=tmp_path / "report.pdf",
+            explain=True,
+            explanation_top_k=3,
+        ),
     )
 
     inference_df = mock_inference.call_args.kwargs["data"]
@@ -268,8 +271,8 @@ def test_explain_toggle_maps_any_supported_input_width(monkeypatch, input_featur
         input_df,
         threshold_strategy="scs",
         model_path="model.pth",
-        config_path="config.yaml",
-        explain=True,
+        model_config_path="config.yaml",
+        sdk_config=anomaly_analysis.ADDiffusionConfig(explain=True),
     )
 
     contributors = json.loads(result.loc[0, "TopContributors"])
@@ -299,10 +302,104 @@ def test_report_metadata_arguments_are_ignored_without_report_path(monkeypatch, 
         input_df,
         threshold_strategy="scs",
         model_path="model.pth",
-        config_path="config.yaml",
-        timestamp_column="sample_time",
-        ground_truth_column="expected_anomaly",
+        model_config_path="config.yaml",
+        sdk_config=anomaly_analysis.ADDiffusionConfig(
+            timestamp_column="sample_time",
+            ground_truth_column="expected_anomaly",
+        ),
     )
 
     inference_df = mock_inference.call_args.kwargs["data"]
     assert list(inference_df.columns) == list(input_df.columns)
+
+
+def test_load_sdk_config_accepts_nested_sdk_section(tmp_path):
+    config_path = tmp_path / "sdk_config.yaml"
+    config_path.write_text(
+        """
+model:
+  target_dim: 40
+sdk:
+  explain: true
+  explanation_top_k: 5
+  report_title: Custom Report
+""",
+        encoding="utf-8",
+    )
+
+    config = anomaly_analysis.load_sdk_config(config_path)
+
+    assert isinstance(config, anomaly_analysis.ADDiffusionConfig)
+    assert config.explain is True
+    assert config.explanation_top_k == 5
+    assert config.report_title == "Custom Report"
+    assert config.report_max_pages == 10
+
+
+def test_load_sdk_config_accepts_flat_mapping(tmp_path):
+    config_path = tmp_path / "sdk_config.yaml"
+    config_path.write_text("explain: true\nexplanation_top_k: 2\n", encoding="utf-8")
+
+    config = anomaly_analysis.load_sdk_config(config_path)
+
+    assert config.explain is True
+    assert config.explanation_top_k == 2
+
+
+def test_load_sdk_config_rejects_unknown_keys(tmp_path):
+    config_path = tmp_path / "sdk_config.yaml"
+    config_path.write_text(
+        """
+sdk:
+  explain: true
+  typo_top_k: 5
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="typo_top_k"):
+        anomaly_analysis.load_sdk_config(config_path)
+
+
+def test_commented_yaml_template_matches_config_defaults():
+    template_path = Path(anomaly_analysis.__file__).with_name("sdk_config.yaml")
+
+    assert asdict(anomaly_analysis.load_sdk_config(template_path)) == asdict(anomaly_analysis.ADDiffusionConfig())
+
+    previous_content = ""
+    for line in template_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if line.startswith("  ") and not line.startswith("    ") and stripped and not stripped.startswith("#"):
+            assert previous_content.startswith("#"), f"Missing comment for config value: {stripped}"
+        if stripped:
+            previous_content = stripped
+
+
+def test_perform_anomaly_analysis_uses_yaml_sdk_config(monkeypatch, numeric_df, inference_results, tmp_path):
+    config_path = tmp_path / "sdk_config.yaml"
+    config_path.write_text(
+        """
+sdk:
+  explain: true
+  explanation_top_k: 2
+""",
+        encoding="utf-8",
+    )
+    mock_inference = Mock(return_value=inference_results)
+    monkeypatch.setattr(anomaly_analysis, "inference_ad_tesseract2_mp", mock_inference)
+
+    mock_thresholder = Mock()
+    mock_thresholder.detect_anomalies.return_value = np.array([False, True, False, True, False])
+    mock_strategy = Mock()
+    mock_strategy.scs_thresholder = mock_thresholder
+    monkeypatch.setattr(anomaly_analysis, "SCSThresholdStrategy", Mock(return_value=mock_strategy))
+
+    result = anomaly_analysis.perform_anomaly_analysis_with_diffusion(
+        numeric_df,
+        threshold_strategy="scs",
+        model_path="model.pth",
+        model_config_path="config.yaml",
+        sdk_config=config_path,
+    )
+
+    assert "TopContributors" in result.columns

--- a/ad_diffusion/sdk/tests/test_anomaly_analysis.py
+++ b/ad_diffusion/sdk/tests/test_anomaly_analysis.py
@@ -228,11 +228,9 @@ def test_explain_toggle_preserves_numeric_feature_names(monkeypatch, tmp_path):
         threshold_strategy="scs",
         model_path="model.pth",
         model_config_path="config.yaml",
-        sdk_config=anomaly_analysis.ADDiffusionConfig(
-            report_path=tmp_path / "report.pdf",
-            explain=True,
-            explanation_top_k=3,
-        ),
+        explain=True,
+        explanation_top_k=3,
+        sdk_config=anomaly_analysis.ADDiffusionConfig(report_path=tmp_path / "report.pdf"),
     )
 
     inference_df = mock_inference.call_args.kwargs["data"]
@@ -272,7 +270,7 @@ def test_explain_toggle_maps_any_supported_input_width(monkeypatch, input_featur
         threshold_strategy="scs",
         model_path="model.pth",
         model_config_path="config.yaml",
-        sdk_config=anomaly_analysis.ADDiffusionConfig(explain=True),
+        explain=True,
     )
 
     contributors = json.loads(result.loc[0, "TopContributors"])
@@ -320,9 +318,8 @@ def test_load_sdk_config_accepts_nested_sdk_section(tmp_path):
 model:
   target_dim: 40
 sdk:
-  explain: true
-  explanation_top_k: 5
   report_title: Custom Report
+  report_consolidated_top_k: 8
 """,
         encoding="utf-8",
     )
@@ -330,20 +327,19 @@ sdk:
     config = anomaly_analysis.load_sdk_config(config_path)
 
     assert isinstance(config, anomaly_analysis.ADDiffusionConfig)
-    assert config.explain is True
-    assert config.explanation_top_k == 5
     assert config.report_title == "Custom Report"
+    assert config.report_consolidated_top_k == 8
     assert config.report_max_pages == 10
 
 
 def test_load_sdk_config_accepts_flat_mapping(tmp_path):
     config_path = tmp_path / "sdk_config.yaml"
-    config_path.write_text("explain: true\nexplanation_top_k: 2\n", encoding="utf-8")
+    config_path.write_text("report_title: Custom Report\nreport_max_pages: 2\n", encoding="utf-8")
 
     config = anomaly_analysis.load_sdk_config(config_path)
 
-    assert config.explain is True
-    assert config.explanation_top_k == 2
+    assert config.report_title == "Custom Report"
+    assert config.report_max_pages == 2
 
 
 def test_load_sdk_config_rejects_unknown_keys(tmp_path):
@@ -351,7 +347,7 @@ def test_load_sdk_config_rejects_unknown_keys(tmp_path):
     config_path.write_text(
         """
 sdk:
-  explain: true
+  report_title: Custom Report
   typo_top_k: 5
 """,
         encoding="utf-8",
@@ -375,15 +371,25 @@ def test_commented_yaml_template_matches_config_defaults():
             previous_content = stripped
 
 
-def test_perform_anomaly_analysis_uses_yaml_sdk_config(monkeypatch, numeric_df, inference_results, tmp_path):
+def test_perform_anomaly_analysis_uses_yaml_sdk_config(monkeypatch, inference_results, tmp_path):
+    destination = tmp_path / "anomaly_report.pdf"
     config_path = tmp_path / "sdk_config.yaml"
     config_path.write_text(
-        """
+        f"""
 sdk:
-  explain: true
-  explanation_top_k: 2
+  timestamp_column: timestamp
+  ground_truth_column: GT
+  report_path: {destination}
 """,
         encoding="utf-8",
+    )
+    input_df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2026-01-01", periods=5, freq="min"),
+            "feature_1": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "feature_2": [2.0, 2.5, 3.0, 3.5, 4.0],
+            "GT": [0, 1, 0, 0, 1],
+        }
     )
     mock_inference = Mock(return_value=inference_results)
     monkeypatch.setattr(anomaly_analysis, "inference_ad_tesseract2_mp", mock_inference)
@@ -395,11 +401,14 @@ sdk:
     monkeypatch.setattr(anomaly_analysis, "SCSThresholdStrategy", Mock(return_value=mock_strategy))
 
     result = anomaly_analysis.perform_anomaly_analysis_with_diffusion(
-        numeric_df,
+        input_df,
         threshold_strategy="scs",
         model_path="model.pth",
         model_config_path="config.yaml",
         sdk_config=config_path,
     )
 
-    assert "TopContributors" in result.columns
+    inference_df = mock_inference.call_args.kwargs["data"]
+    assert list(inference_df.columns) == ["feature_1", "feature_2"]
+    assert {"timestamp", "GT", "Anomaly", "MAE"}.issubset(result.columns)
+    assert destination.read_bytes().startswith(b"%PDF")


### PR DESCRIPTION
## Summary
- Splits the model architecture config from SDK-level reporting settings on `perform_anomaly_analysis_with_diffusion()`.
- Renames `config_path` to `model_config_path` (the model architecture config file).
- Adds `sdk_config: ADDiffusionConfig | str | Path | None`, replacing `report_path`, `timestamp_column`, `ground_truth_column`, `report_title`, `report_explanation_csv_path`, `report_max_pages`, and `report_consolidated_top_k` with a single typed config, loadable from `sdk_config.yaml` (flat or `sdk:`-nested).
- `explain`/`explanation_top_k` stay direct keyword arguments (like `threshold_strategy`/`nsample`) rather than living in `ADDiffusionConfig`. These predate this PR (`44bad73`) and are expected to be excluded from the next `main` release, while the reporting + `model_config_path` rename are not — keeping `explain` out of the config lets that split be cherry-picked cleanly without dragging in the explainability import/toggle.
- Updates `quick_example.py` and README examples accordingly.

## Test plan
- [x] `uv run pytest sdk/tests/test_anomaly_analysis.py -q` — 17 passed (9 existing + 8 new YAML-config tests)
- [x] `uv run pytest sdk/tests/ -q` — full sdk suite, 61 passed
- [x] `ruff check` / `ruff format --check` clean against the exact ruff version pinned in `uv.lock` (0.15.11)