### PR TITLE
Add YAML-configured reconstruction diagnosis to anomaly reports

### DIFF
--- a/ad_diffusion/README.md
+++ b/ad_diffusion/README.md
@@ -29,14 +29,34 @@ uv sync
 uv run python your_script.py
 ```
 
-Then use the main function:
-```python
-import pandas as pd
-import sys, os
-sys.path.append('/path/to/ad_diffusion')  # Adjust to your installation path
-from sdk.anomaly_analysis import ADDiffusionConfig, perform_anomaly_analysis_with_diffusion
+Explainability and reporting use a YAML configuration. Copy the fully commented
+template at `sdk/sdk_config.yaml` and enable the required settings:
 
-# Load your data
+```yaml
+sdk:
+  explain: true
+  explanation_top_k: 3
+  diagnose_reconstruction: true
+  report_path: output/pdf/anomaly_detection_report.pdf
+  timestamp_column: timestamp
+  ground_truth_column: GT
+  report_title: Anomaly Detection Report
+  report_explanation_csv_path: output/pdf/anomaly_detection_report_explanations.csv
+  report_max_pages: 10
+  report_consolidated_top_k: 5
+```
+
+Pass the YAML file to the SDK:
+
+```python
+import os
+import sys
+
+import pandas as pd
+
+sys.path.append("/path/to/ad_diffusion")
+from sdk.anomaly_analysis import perform_anomaly_analysis_with_diffusion
+
 df = pd.read_csv("your_data.csv")
 
 # Perform anomaly detection — omit model_path/model_config_path to auto-download
@@ -47,29 +67,25 @@ results = perform_anomaly_analysis_with_diffusion(
     # model_path="path/to/your/model.pth",         # optional; defaults to final_model.pth
     # model_config_path="path/to/config.yaml",     # optional; defaults to curriculum_medium.yaml
     nsample=15,
-    preprocess_model_dir="path/to/preprocessing/models",  # optional
-    explain=True,
-    explanation_top_k=3,
+    sdk_config="path/to/sdk_config.yaml",
 )
-
-# Results contain original data plus anomaly detection results
 print(f"Detected {results['Anomaly'].sum()} anomalies")
 ```
 
-Reporting settings (`report_path`, etc.) live on `ADDiffusionConfig`, which can
-also be loaded from a YAML file — a fully commented template is available at
-`sdk/sdk_config.yaml`. `explain`/`explanation_top_k` stay direct keyword
-arguments since they're not part of the reporting config:
+`ADDiffusionConfig` remains available when configuration must be constructed
+programmatically instead of loaded from YAML:
 
 ```python
-results = perform_anomaly_analysis_with_diffusion(
-    df=df,
-    threshold_strategy="scs",
-    sdk_config="sdk_config.yaml",
+from sdk.anomaly_analysis import ADDiffusionConfig
+
+sdk_config = ADDiffusionConfig(
+    explain=True,
+    explanation_top_k=3,
+    diagnose_reconstruction=True,
 )
 ```
 
-With `explain=True`, the result also includes `TopContributors`,
+When `sdk.explain: true`, the result also includes `TopContributors`,
 `ContributionShares`, `ExplanationCoverage`, and `ExplanationMethod`. These
 columns are derived from the existing target and reconstruction, so explanation
 does not run the detector again. Inputs with any feature count up to the model's
@@ -78,30 +94,25 @@ remain part of the MAE denominator but are not presented as input features. When
 PCA or feature engineering changes the feature space, contributors use conservative
 `component_N` labels instead of claiming an incorrect mapping to original signals.
 
-Generate a PDF report with the original signals, detected anomalies, MAE, and
-ground truth when a conventional label column such as `GT` is present:
+Set `sdk.diagnose_reconstruction: true` to test why selected features may have
+been reconstructed incorrectly. The SDK applies level-shift, trend-change,
+transient-spike, and variance-burst repairs and re-scores them with the unchanged
+detector. This opt-in path performs four additional inference passes and requires
+directly mapped input features without a preprocessing model. It returns
+`LikelyReconstructionIssue`, `RepairImpact`, `DiagnosticConfidence`, and
+`ExplanationConsistency`. These metrics describe detector behavior and do not
+establish physical causality.
 
-```python
-results = perform_anomaly_analysis_with_diffusion(
-    df=df,
-    threshold_strategy="scs",
-    explain=True,
-    sdk_config=ADDiffusionConfig(
-        report_path="output/pdf/anomaly_detection_report.pdf",
-        timestamp_column="timestamp",
-        ground_truth_column="GT",
-        report_max_pages=10,
-        report_consolidated_top_k=5,
-    ),
-)
-```
+Set `sdk.report_path` in the YAML file to generate a PDF report with the
+original signals, detected anomalies, MAE, and ground truth when a conventional
+label column such as `GT` is present.
 
 Timestamp and ground-truth columns used for the report are excluded from model
 features but preserved in the returned DataFrame. Existing callers are unchanged
-because PDF generation is disabled unless `report_path` is supplied.
-When explanations are enabled, the PDF adds contributor-share graphs and writes
+because PDF generation is disabled unless `sdk.report_path` is supplied.
+When `sdk.explain: true`, the PDF adds contributor-share graphs and writes
 the complete row-level explanation data to a companion CSV. If per-anomaly
-charts would make the PDF exceed `report_max_pages` (10 by default), the PDF
+charts would make the PDF exceed `sdk.report_max_pages` (10 by default), the PDF
 uses one consolidated, MAE-weighted top-contributors page instead; the companion
 CSV still contains every detected anomaly.
 
@@ -367,6 +378,9 @@ from sdk.anomaly_analysis import perform_anomaly_analysis_with_diffusion
   or missing, `curriculum_medium.yaml` is auto-downloaded from the same repo.
 - **nsample** (int): Number of diffusion samples (default: 15)
 - **preprocess_model_dir** (str|Path): Optional preprocessing model directory
+- **sdk_config** (ADDiffusionConfig|str|Path, optional): Explainability and
+  reporting configuration object or path to an SDK YAML file. The default
+  disables explanations, reconstruction diagnosis, and PDF generation.
 
 ### Advanced Usage
 

--- a/ad_diffusion/sdk/anomaly_analysis.py
+++ b/ad_diffusion/sdk/anomaly_analysis.py
@@ -3,21 +3,30 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
 from dataclasses import dataclass, fields
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import yaml
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from sdk.explainability import explain_reconstruction_anomalies
 from sdk.inference_ad import (
+    DEFAULT_SEED,
     _resolve_model_paths,
     get_model_target_dim,
     inference_ad_tesseract2_mp,
+    set_seed,
+)
+from sdk.reconstruction_failure import (
+    FAILURE_MODES,
+    build_repair_variants,
+    summarize_repair_diagnostics,
 )
 from sdk.reporting import (
     generate_anomaly_detection_report,
@@ -32,14 +41,16 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class ADDiffusionConfig:
-    """Reporting configuration for :func:`perform_anomaly_analysis_with_diffusion`.
+    """Explainability and reporting configuration for :func:`perform_anomaly_analysis_with_diffusion`.
 
-    Scoped to report-related parameters — inference-behavior knobs like
-    ``threshold_strategy``, ``nsample``, the model/config paths, and the
-    ``explain``/``explanation_top_k`` explainability toggle stay as direct
-    function arguments.
+    Scoped to the explain toggle and explainability/report-related parameters —
+    inference-behavior knobs like ``threshold_strategy``, ``nsample``, and the
+    model/config paths stay as direct function arguments.
     """
 
+    explain: bool = False
+    explanation_top_k: int = 3
+    diagnose_reconstruction: bool = False
     report_path: str | Path | None = None
     timestamp_column: str | None = None
     ground_truth_column: str | None = None
@@ -96,8 +107,6 @@ def perform_anomaly_analysis_with_diffusion(
     model_config_path: str | Path = "",
     nsample: int = 15,
     preprocess_model_dir: str | Path | None = None,
-    explain: bool = False,
-    explanation_top_k: int = 3,
     sdk_config: ADDiffusionConfig | str | Path | None = None,
 ) -> pd.DataFrame:
     """
@@ -116,15 +125,24 @@ def perform_anomaly_analysis_with_diffusion(
         model_config_path: Path to the model architecture config file (optional if config is in checkpoint)
         nsample: Number of samples for diffusion model inference
         preprocess_model_dir: Directory containing preprocessing model (optional)
-        explain: Whether to add reconstruction-error explanations for detected anomalies.
-        explanation_top_k: Maximum number of contributors returned per anomaly.
-        sdk_config: Reporting `ADDiffusionConfig`, YAML path, or `None` for defaults.
-            See `ADDiffusionConfig` for the field reference.
+        sdk_config: Explainability/reporting `ADDiffusionConfig`, YAML path, or `None` for defaults.
+            Set ``diagnose_reconstruction=True`` to test four reconstruction-failure
+            hypotheses with structure-preserving repairs and paired re-scoring.
+            This requires ``explain=True`` and performs four additional model
+            inference passes. Raw per-hypothesis scores are not returned.
+            See `ADDiffusionConfig` for the full field reference.
 
     Returns:
         DataFrame with original data and anomaly detection results
     """
     cfg = _resolve_sdk_config(sdk_config)
+    if cfg.diagnose_reconstruction and not cfg.explain:
+        raise ValueError("diagnose_reconstruction=True requires explain=True.")
+    if cfg.diagnose_reconstruction and preprocess_model_dir is not None:
+        raise ValueError(
+            "Reconstruction diagnosis currently requires directly mapped input features; "
+            "preprocess_model_dir is not supported."
+        )
 
     # Prepare data for diffusion model
     # The diffusion model expects all numeric columns
@@ -147,8 +165,6 @@ def perform_anomaly_analysis_with_diffusion(
 
     # Validate all columns are numeric by attempting to convert the entire DataFrame
     original_columns = input_df.columns.tolist()
-
-    # Try to convert all columns to numeric at once
     numeric_df = input_df.apply(pd.to_numeric, errors="coerce")
 
     # Check which columns introduced NaNs (indicating non-numeric values)
@@ -160,7 +176,6 @@ def perform_anomaly_analysis_with_diffusion(
         if converted_na_count > original_na_count:
             non_numeric_cols.append(col)
         else:
-            # Update the original dataframe with successfully converted column
             input_df[col] = numeric_df[col]
 
     if non_numeric_cols:
@@ -169,7 +184,6 @@ def perform_anomaly_analysis_with_diffusion(
             f"All input values must be numeric for anomaly detection."
         )
 
-    # Resolve / auto-download weights once up front so downstream calls share them.
     resolved_model, resolved_config = _resolve_model_paths(
         str(model_path) if model_path else None,
         str(model_config_path) if model_config_path else "",
@@ -187,6 +201,8 @@ def perform_anomaly_analysis_with_diffusion(
         )
 
     # Run inference with diffusion model (auto-uses multi-GPU when available)
+    if cfg.diagnose_reconstruction:
+        set_seed(DEFAULT_SEED)
     results = inference_ad_tesseract2_mp(
         data=input_df,
         model_path=resolved_model,
@@ -201,15 +217,16 @@ def perform_anomaly_analysis_with_diffusion(
     # Get target data for advanced thresholding methods
     target_data = results["target"]
 
-    # Model evaluation works on fixed-size windows and may append padded rows to
-    # the final window. Align outputs before threshold calibration so synthetic
-    # padding cannot change the thresholds used for real input rows.
+    # Align padded inference outputs before adaptive-threshold calibration.
     original_length = len(df)
-    if len(residual_scores) != original_length:
-        logger.info(f"Aligning lengths: residual_scores={len(residual_scores)}, original_data={original_length}")
-        residual_scores = residual_scores[:original_length]
-    if len(target_data) != original_length:
-        target_data = target_data[:original_length]
+    if len(residual_scores) != original_length or len(target_data) != original_length:
+        logger.info(
+            "Aligning detector inputs: "
+            f"residual_scores={len(residual_scores)}, target_data={len(target_data)}, "
+            f"original_data={original_length}"
+        )
+    residual_scores = residual_scores[:original_length]
+    target_data = target_data[:original_length]
 
     # Apply thresholding strategy
     if threshold_strategy == "scs":
@@ -221,15 +238,17 @@ def perform_anomaly_analysis_with_diffusion(
     else:
         raise ValueError(f"Unknown threshold strategy: {threshold_strategy}")
 
-    # Create result dataframe. A thresholder may return a longer mask than the
-    # score array, so keep assignment aligned with the input rows as well.
+    # A custom threshold strategy may return a mask aligned to padded model
+    # outputs. Preserve the OSS SDK's one-row-per-input contract.
+    anomalies = np.asarray(anomalies, dtype=bool)[:original_length]
+
+    # Create result dataframe
     result_df = df.copy()
-    anomalies = anomalies[:original_length]
 
     result_df["Anomaly"] = anomalies
     result_df["MAE"] = residual_scores  # Using residual (MAE) as anomaly score
 
-    if explain:
+    if cfg.explain:
         reconstruction = results.get("recon")
         if reconstruction is None:
             raise ValueError("Inference results must include 'recon' when explain=True.")
@@ -237,6 +256,7 @@ def perform_anomaly_analysis_with_diffusion(
         explanation_length = min(original_length, len(target_data), len(reconstruction), len(anomalies))
         target_for_explanation = target_data[:explanation_length]
         reconstruction_for_explanation = reconstruction[:explanation_length]
+
         target_feature_count = target_for_explanation.shape[1] if target_for_explanation.ndim > 1 else 1
         input_feature_count = len(input_df.columns)
         directly_mapped = preprocess_model_dir is None and input_feature_count <= target_feature_count
@@ -248,8 +268,11 @@ def perform_anomaly_analysis_with_diffusion(
             anomaly_mask=anomalies[:explanation_length],
             feature_names=feature_names,
             feature_indices=feature_indices,
-            top_k=explanation_top_k,
+            top_k=cfg.explanation_top_k,
         )
+
+        # Model outputs can be shorter than the source frame for some windowing
+        # configurations. Reindexing preserves the SDK's one-row-per-input contract.
         explanations = explanations.reindex(range(original_length)).fillna(
             {
                 "TopContributors": "[]",
@@ -261,6 +284,46 @@ def perform_anomaly_analysis_with_diffusion(
         for column in explanations.columns:
             result_df[column] = explanations[column].to_numpy()
 
+        if cfg.diagnose_reconstruction:
+            if not directly_mapped:
+                raise ValueError(
+                    "Reconstruction diagnosis requires input features that map directly to model dimensions."
+                )
+            feature_lookup = {str(column): index for index, column in enumerate(input_df.columns)}
+            candidate_feature_indices: list[list[int]] = [[] for _ in range(original_length)]
+            for row_index in np.flatnonzero(anomalies[:original_length]):
+                contributor_names = json.loads(result_df.iloc[row_index]["TopContributors"])
+                candidate_feature_indices[row_index] = [feature_lookup[name] for name in contributor_names]
+
+            reference_window = min(21, len(input_df) if len(input_df) % 2 else max(1, len(input_df) - 1))
+            reference = input_df.rolling(window=reference_window, center=True, min_periods=1).median()
+            repair_variants = build_repair_variants(
+                input_df.to_numpy(dtype=float),
+                reference.to_numpy(dtype=float),
+                anomaly_mask=anomalies[:original_length],
+                candidate_feature_indices=candidate_feature_indices,
+                lookback=min(20, len(input_df)),
+            )
+            repaired_scores: dict[str, np.ndarray] = {}
+            for hypothesis in FAILURE_MODES:
+                set_seed(DEFAULT_SEED)
+                repaired_result = inference_ad_tesseract2_mp(
+                    data=pd.DataFrame(repair_variants[hypothesis], columns=input_df.columns),
+                    model_path=resolved_model,
+                    config_path=resolved_config,
+                    nsample=nsample,
+                    preprocess_model_dir=None,
+                    seed=DEFAULT_SEED,
+                )
+                repaired_scores[hypothesis] = np.asarray(repaired_result["residual"], dtype=float)[:original_length]
+
+            diagnoses = summarize_repair_diagnostics(
+                residual_scores[:original_length],
+                repaired_scores,
+                anomaly_mask=anomalies[:original_length],
+            )
+            for column in diagnoses.columns:
+                result_df[column] = diagnoses[column].to_numpy()
     if cfg.report_path is not None:
         generate_anomaly_detection_report(
             result_df,

--- a/ad_diffusion/sdk/reconstruction_failure.py
+++ b/ad_diffusion/sdk/reconstruction_failure.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Counterfactual operators for reconstruction-failure experiments.
+
+The functions in this module deliberately operate on input windows and a
+normal-reference window.  They do not inspect model internals, which lets the
+same experiment harness re-score the repaired windows with any anomaly
+detector that accepts the same input representation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import numpy as np
+import pandas as pd
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from numpy.typing import ArrayLike, NDArray
+
+FailureMode = Literal["level_shift", "trend_change", "transient_spike", "variance_burst"]
+FAILURE_MODES: tuple[FailureMode, ...] = (
+    "level_shift",
+    "trend_change",
+    "transient_spike",
+    "variance_burst",
+)
+FAILURE_MODE_LABELS: dict[FailureMode, str] = {
+    "level_shift": "Level shift",
+    "trend_change": "Trend change",
+    "transient_spike": "Transient spike",
+    "variance_burst": "Variance burst",
+}
+DIAGNOSIS_COLUMNS: tuple[str, ...] = (
+    "LikelyReconstructionIssue",
+    "RepairImpact",
+    "DiagnosticConfidence",
+    "ExplanationConsistency",
+)
+
+
+def _window(values: ArrayLike, *, name: str) -> NDArray[np.float64]:
+    matrix = np.asarray(values, dtype=np.float64)
+    if matrix.ndim != 2:
+        raise ValueError(f"{name} must have shape (timestamps, features), got {matrix.shape}.")
+    if not np.isfinite(matrix).all():
+        raise ValueError(f"{name} must contain only finite values.")
+    return matrix
+
+
+def _validate_inputs(
+    values: ArrayLike,
+    reference: ArrayLike,
+    feature_index: int,
+    segment: tuple[int, int],
+) -> tuple[NDArray[np.float64], NDArray[np.float64], slice]:
+    window = _window(values, name="values")
+    normal = _window(reference, name="reference")
+    if window.shape != normal.shape:
+        raise ValueError(f"values and reference must have the same shape, got {window.shape} and {normal.shape}.")
+    if not isinstance(feature_index, int) or isinstance(feature_index, bool):
+        raise TypeError("feature_index must be an integer.")
+    if not 0 <= feature_index < window.shape[1]:
+        raise ValueError(f"feature_index must be between 0 and {window.shape[1] - 1}.")
+    start, end = segment
+    if not (0 <= start < end <= window.shape[0]):
+        raise ValueError(f"segment must satisfy 0 <= start < end <= {window.shape[0]}, got {segment}.")
+    return window, normal, slice(start, end)
+
+
+def inject_failure(
+    reference: ArrayLike,
+    *,
+    feature_index: int,
+    segment: tuple[int, int],
+    mode: FailureMode,
+    magnitude: float,
+    rng: np.random.Generator,
+) -> NDArray[np.float64]:
+    """Inject one controlled failure signature into a normal-reference window."""
+    normal, _, affected = _validate_inputs(reference, reference, feature_index, segment)
+    if mode not in FAILURE_MODES:
+        raise ValueError(f"Unknown failure mode: {mode}.")
+    if not np.isfinite(magnitude) or magnitude <= 0:
+        raise ValueError("magnitude must be a positive finite number.")
+
+    result = normal.copy()
+    baseline = normal[affected, feature_index]
+    scale = max(float(np.std(baseline)), 0.05)
+    length = len(baseline)
+
+    if mode == "level_shift":
+        result[affected, feature_index] += magnitude * scale
+    elif mode == "trend_change":
+        ramp = np.linspace(-1.0, 1.0, length)
+        result[affected, feature_index] += magnitude * scale * ramp
+    elif mode == "transient_spike":
+        width = max(1, length // 10)
+        center = affected.start + length // 2
+        lo = max(affected.start, center - width)
+        hi = min(affected.stop, center + width + 1)
+        result[lo:hi, feature_index] += magnitude * scale
+    else:
+        result[affected, feature_index] += rng.normal(0.0, magnitude * scale, size=length)
+    return result
+
+
+def repair_under_hypothesis(
+    values: ArrayLike,
+    reference: ArrayLike,
+    *,
+    feature_index: int,
+    segment: tuple[int, int],
+    hypothesis: FailureMode,
+) -> NDArray[np.float64]:
+    """Apply a hypothesis-specific repair using a normal-reference window.
+
+    These operators are intentionally distinct.  A level repair removes only a
+    constant offset; a trend repair removes only a centered linear slope; a
+    transient repair replaces a compact peak; and a variance repair attenuates
+    high-frequency deviations across the segment.
+    """
+    window, normal, affected = _validate_inputs(values, reference, feature_index, segment)
+    if hypothesis not in FAILURE_MODES:
+        raise ValueError(f"Unknown failure-mode hypothesis: {hypothesis}.")
+
+    repaired = window.copy()
+    delta = window[affected, feature_index] - normal[affected, feature_index]
+    length = len(delta)
+
+    if hypothesis == "level_shift":
+        repaired[affected, feature_index] -= float(np.median(delta))
+    elif hypothesis == "trend_change":
+        axis = np.linspace(-1.0, 1.0, length)
+        slope = float(np.dot(delta, axis) / max(np.dot(axis, axis), np.finfo(float).eps))
+        repaired[affected, feature_index] -= slope * axis
+    elif hypothesis == "transient_spike":
+        width = max(1, length // 10)
+        center = int(np.argmax(np.abs(delta))) + affected.start
+        lo = max(affected.start, center - width)
+        hi = min(affected.stop, center + width + 1)
+        repaired[lo:hi, feature_index] = normal[lo:hi, feature_index]
+    else:
+        kernel_size = min(5, length if length % 2 else max(1, length - 1))
+        kernel = np.ones(kernel_size, dtype=float) / kernel_size
+        low_frequency = np.convolve(delta, kernel, mode="same")
+        high_frequency = delta - low_frequency
+        repaired[affected, feature_index] -= 0.8 * high_frequency
+    return repaired
+
+
+def normalized_score_reduction(original_score: float, repaired_score: float, *, epsilon: float = 1e-12) -> float:
+    """Return the fraction of the original score removed by a repair."""
+    if not np.isfinite(original_score) or not np.isfinite(repaired_score):
+        raise ValueError("Scores must be finite.")
+    return float((original_score - repaired_score) / max(abs(original_score), epsilon))
+
+
+def build_repair_variants(
+    values: ArrayLike,
+    reference: ArrayLike,
+    *,
+    anomaly_mask: ArrayLike,
+    candidate_feature_indices: Sequence[Sequence[int]],
+    lookback: int = 20,
+) -> dict[FailureMode, NDArray[np.float64]]:
+    """Build one structure-preserving input variant per failure hypothesis.
+
+    Consecutive anomalous rows are treated as one event.  Each repair covers
+    the event and up to ``lookback`` rows of preceding context, and is applied
+    only to features selected by the existing contribution explanation.
+    """
+    window = _window(values, name="values")
+    normal = _window(reference, name="reference")
+    if window.shape != normal.shape:
+        raise ValueError(f"values and reference must have the same shape, got {window.shape} and {normal.shape}.")
+    if not isinstance(lookback, int) or isinstance(lookback, bool):
+        raise TypeError("lookback must be an integer.")
+    if lookback < 1:
+        raise ValueError("lookback must be at least 1.")
+
+    mask = np.asarray(anomaly_mask, dtype=bool).reshape(-1)
+    if len(mask) != len(window):
+        raise ValueError(f"anomaly_mask has length {len(mask)}, expected {len(window)}.")
+    if len(candidate_feature_indices) != len(window):
+        raise ValueError(
+            f"candidate_feature_indices has length {len(candidate_feature_indices)}, expected {len(window)}."
+        )
+
+    variants = {hypothesis: window.copy() for hypothesis in FAILURE_MODES}
+    anomaly_indexes = np.flatnonzero(mask)
+    if not len(anomaly_indexes):
+        return variants
+
+    event_starts = np.r_[0, np.flatnonzero(np.diff(anomaly_indexes) > 1) + 1]
+    event_ends = np.r_[event_starts[1:], len(anomaly_indexes)]
+    for event_start, event_end in zip(event_starts, event_ends, strict=True):
+        event_indexes = anomaly_indexes[event_start:event_end]
+        segment = (max(0, int(event_indexes[0]) - lookback + 1), int(event_indexes[-1]) + 1)
+        features = sorted(
+            {
+                int(feature_index)
+                for row_index in event_indexes
+                for feature_index in candidate_feature_indices[int(row_index)]
+            }
+        )
+        invalid = [feature_index for feature_index in features if not 0 <= feature_index < window.shape[1]]
+        if invalid:
+            raise ValueError(f"Candidate feature indexes are outside the input width {window.shape[1]}: {invalid}.")
+        for hypothesis in FAILURE_MODES:
+            for feature_index in features:
+                variants[hypothesis] = repair_under_hypothesis(
+                    variants[hypothesis],
+                    normal,
+                    feature_index=feature_index,
+                    segment=segment,
+                    hypothesis=hypothesis,
+                )
+    return variants
+
+
+def summarize_repair_diagnostics(
+    original_scores: ArrayLike,
+    repaired_scores: Mapping[FailureMode, ArrayLike],
+    *,
+    anomaly_mask: ArrayLike,
+    consistency_predictions: Sequence[Sequence[FailureMode]] | None = None,
+) -> pd.DataFrame:
+    """Convert counterfactual score changes into four end-user metrics.
+
+    The returned frame intentionally excludes per-hypothesis scores.  Confidence
+    measures the margin between the best and second-best repair impacts; it is
+    not a probability.  Consistency is reported only when repeated-reference or
+    repeated-seed predictions are supplied.
+    """
+    original = np.asarray(original_scores, dtype=float).reshape(-1)
+    mask = np.asarray(anomaly_mask, dtype=bool).reshape(-1)
+    if len(mask) != len(original):
+        raise ValueError(f"anomaly_mask has length {len(mask)}, expected {len(original)}.")
+    if not np.isfinite(original).all():
+        raise ValueError("original_scores must contain only finite values.")
+
+    missing = [hypothesis for hypothesis in FAILURE_MODES if hypothesis not in repaired_scores]
+    if missing:
+        raise ValueError(f"repaired_scores is missing hypotheses: {missing}.")
+    repaired = np.column_stack(
+        [np.asarray(repaired_scores[hypothesis], dtype=float).reshape(-1) for hypothesis in FAILURE_MODES]
+    )
+    if repaired.shape != (len(original), len(FAILURE_MODES)):
+        raise ValueError(
+            "Each repaired score vector must have the same length as original_scores; "
+            f"got combined shape {repaired.shape}."
+        )
+    if not np.isfinite(repaired).all():
+        raise ValueError("repaired_scores must contain only finite values.")
+
+    denominator = np.maximum(np.abs(original), np.finfo(float).eps)
+    effects = (original[:, None] - repaired) / denominator[:, None]
+    records = [
+        {
+            "LikelyReconstructionIssue": "",
+            "RepairImpact": 0.0,
+            "DiagnosticConfidence": "",
+            "ExplanationConsistency": "",
+        }
+        for _ in original
+    ]
+    repeat_arrays = None
+    if consistency_predictions is not None:
+        repeat_arrays = [np.asarray(predictions, dtype=object).reshape(-1) for predictions in consistency_predictions]
+        if any(len(predictions) != len(original) for predictions in repeat_arrays):
+            raise ValueError("Each consistency prediction vector must have the same length as original_scores.")
+
+    for row_index in np.flatnonzero(mask):
+        order = np.argsort(-effects[row_index], kind="stable")
+        best_index, second_index = int(order[0]), int(order[1])
+        best_effect = float(effects[row_index, best_index])
+        margin = best_effect - float(effects[row_index, second_index])
+        if best_effect <= 0:
+            issue = "No supported repair"
+            impact = 0.0
+            confidence = "Inconclusive"
+        else:
+            best_mode = FAILURE_MODES[best_index]
+            issue = FAILURE_MODE_LABELS[best_mode]
+            impact = min(best_effect, 1.0)
+            if margin >= 0.20:
+                confidence = "High"
+            elif margin >= 0.10:
+                confidence = "Moderate"
+            elif margin > 0:
+                confidence = "Low"
+            else:
+                confidence = "Inconclusive"
+
+        consistency = "Not evaluated"
+        if repeat_arrays:
+            best_mode = FAILURE_MODES[best_index]
+            agreement = np.mean([predictions[row_index] == best_mode for predictions in repeat_arrays])
+            consistency = f"{agreement:.0%}"
+        records[row_index] = {
+            "LikelyReconstructionIssue": issue,
+            "RepairImpact": impact,
+            "DiagnosticConfidence": confidence,
+            "ExplanationConsistency": consistency,
+        }
+    return pd.DataFrame.from_records(records, columns=DIAGNOSIS_COLUMNS)

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -25,12 +25,26 @@ EXPLANATION_COLUMNS = {
     "ContributionShares",
     "ExplanationCoverage",
     "ExplanationMethod",
+    "LikelyReconstructionIssue",
+    "RepairImpact",
+    "DiagnosticConfidence",
+    "ExplanationConsistency",
 }
 REQUIRED_EXPLANATION_COLUMNS = ("TopContributors", "ContributionShares", "ExplanationCoverage")
+REQUIRED_DIAGNOSIS_COLUMNS = (
+    "LikelyReconstructionIssue",
+    "RepairImpact",
+    "DiagnosticConfidence",
+    "ExplanationConsistency",
+)
 MAX_EXPLANATIONS_PER_PAGE = 7
 DEFAULT_MAX_REPORT_PAGES = 10
 DEFAULT_CONSOLIDATED_TOP_K = 5
 FEATURE_COLORS = ("#175CD3", "#039855", "#F79009", "#7F56D9", "#0E9384", "#D92D20", "#444CE7", "#C11574")
+SCORE_DIRECTION_NOTE = (
+    "Lower MAE means a closer reconstruction\nand more typical behavior.\n"
+    "Higher MAE means a larger mismatch\nand more anomalous behavior."
+)
 
 
 def infer_ground_truth_column(df: pd.DataFrame) -> str | None:
@@ -187,6 +201,30 @@ def _resolve_explanation_rows(
     return rows
 
 
+def _resolve_diagnosis_rows(
+    result_df: pd.DataFrame,
+    detected: np.ndarray,
+) -> list[tuple[str, str, str, str]] | None:
+    """Validate and format the four user-facing reconstruction-diagnosis fields."""
+    present = [column for column in REQUIRED_DIAGNOSIS_COLUMNS if column in result_df.columns]
+    if not present:
+        return None
+    missing = [column for column in REQUIRED_DIAGNOSIS_COLUMNS if column not in result_df.columns]
+    if missing:
+        raise ValueError(f"Reconstruction-diagnosis report data is missing columns: {missing}.")
+
+    rows = []
+    for row_index in np.flatnonzero(detected):
+        impact = pd.to_numeric(result_df.iloc[row_index]["RepairImpact"], errors="coerce")
+        if not np.isfinite(impact) or not 0 <= impact <= 1:
+            raise ValueError("RepairImpact must contain only finite values between 0 and 1.")
+        issue = str(result_df.iloc[row_index]["LikelyReconstructionIssue"]).strip() or "Not available"
+        confidence = str(result_df.iloc[row_index]["DiagnosticConfidence"]).strip() or "Not available"
+        consistency = str(result_df.iloc[row_index]["ExplanationConsistency"]).strip() or "Not available"
+        rows.append((issue, f"{impact:.1%}", confidence, consistency))
+    return rows
+
+
 def _style_axis(axis, *, is_datetime: bool) -> None:
     axis.grid(True, color="#D8DEE9", linewidth=0.6, alpha=0.8)
     axis.spines[["top", "right"]].set_visible(False)
@@ -225,6 +263,26 @@ def _create_overview_page(
         y_position = 0.78 - row_index * 0.13
         summary_axis.text(0.0, y_position, label, fontsize=9, color="#667085", va="center")
         summary_axis.text(0.32, y_position, value, fontsize=10, color="#101828", fontweight="bold", va="center")
+
+    summary_axis.text(
+        0.56,
+        0.82,
+        "How to read the anomaly score",
+        fontsize=10,
+        fontweight="bold",
+        color="#175CD3",
+        va="top",
+    )
+    summary_axis.text(
+        0.56,
+        0.66,
+        SCORE_DIRECTION_NOTE,
+        fontsize=8.5,
+        color="#344054",
+        va="top",
+        linespacing=1.5,
+        bbox={"boxstyle": "round,pad=0.65", "facecolor": "#F5F8FF", "edgecolor": "#B2CCFF"},
+    )
 
     score_axis.plot(x_values, scores, color="#475467", linewidth=1.2, label="MAE anomaly score")
     if ground_truth is not None and ground_truth.any():
@@ -342,11 +400,12 @@ def _create_contribution_graph_page(
     graph_page_number: int,
     graph_page_count: int,
     feature_colors: dict[str, str] | None = None,
+    diagnosis_rows: Sequence[tuple[str, str, str, str]] | None = None,
 ) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
-    axis = figure.add_axes((0.28, 0.14, 0.64, 0.66))
+    axis = figure.add_axes((0.20, 0.14, 0.44 if diagnosis_rows is not None else 0.72, 0.66))
     figure.suptitle(
-        f"Feature contributions by anomaly ({graph_page_number}/{graph_page_count})",
+        f"Feature contributions and diagnosis by anomaly ({graph_page_number}/{graph_page_count})",
         x=0.07,
         y=0.955,
         ha="left",
@@ -361,6 +420,8 @@ def _create_contribution_graph_page(
         fontsize=10,
         color="#667085",
     )
+    if diagnosis_rows is not None:
+        figure.text(0.71, 0.825, "Reconstruction diagnosis", fontsize=8, fontweight="bold", color="#175CD3")
     if not rows:
         axis.axis("off")
         axis.text(
@@ -431,6 +492,25 @@ def _create_contribution_graph_page(
         axis.text(1.015, y_position, f"{coverage_text} covered", va="center", fontsize=7.5, color="#475467")
         y_labels.append(timestamp.replace("\n", " "))
 
+    if diagnosis_rows is not None:
+        for y_position, (issue, impact, confidence, consistency) in zip(y_positions, diagnosis_rows, strict=True):
+            normalized_y = 0.14 + 0.66 * ((y_position + 0.75) / MAX_EXPLANATIONS_PER_PAGE)
+            figure.text(0.71, normalized_y + 0.018, issue, fontsize=7, fontweight="bold", color="#101828")
+            figure.text(
+                0.71,
+                normalized_y - 0.002,
+                f"Impact {impact}  |  Confidence {confidence}",
+                fontsize=6.5,
+                color="#344054",
+            )
+            figure.text(
+                0.71,
+                normalized_y - 0.022,
+                f"Consistency {consistency}",
+                fontsize=6.5,
+                color="#667085",
+            )
+
     axis.set_yticks(y_positions, labels=y_labels)
     axis.set_ylim(-0.75, MAX_EXPLANATIONS_PER_PAGE - 0.25)
     axis.set_xlim(0.0, 1.15)
@@ -473,6 +553,37 @@ def _aggregate_explanation_contributions(
     return contributions, sum(share for _, share in contributions)
 
 
+def _summarize_diagnoses(
+    result_df: pd.DataFrame,
+    detected: np.ndarray,
+) -> list[tuple[str, str]] | None:
+    if not all(column in result_df.columns for column in REQUIRED_DIAGNOSIS_COLUMNS):
+        return None
+    anomalous = result_df.loc[detected]
+    if anomalous.empty:
+        return [
+            ("Most common issue", "Not available"),
+            ("Median impact", "0.0%"),
+            ("High confidence", "0.0%"),
+            ("Consistency", "Not evaluated"),
+        ]
+    issues = anomalous["LikelyReconstructionIssue"].astype(str)
+    most_common_issue = issues.value_counts().index[0]
+    median_impact = float(pd.to_numeric(anomalous["RepairImpact"], errors="coerce").median())
+    high_confidence = float(anomalous["DiagnosticConfidence"].astype(str).eq("High").mean())
+    consistency_values = anomalous["ExplanationConsistency"].astype(str)
+    numeric_consistency = pd.to_numeric(consistency_values.str.removesuffix("%"), errors="coerce")
+    consistency = (
+        f"{float(numeric_consistency.median()):.0f}%" if numeric_consistency.notna().any() else "Not evaluated"
+    )
+    return [
+        ("Most common issue", most_common_issue),
+        ("Median impact", f"{median_impact:.1%}"),
+        ("High confidence", f"{high_confidence:.1%}"),
+        ("Consistency", consistency),
+    ]
+
+
 def _create_consolidated_contribution_page(
     contributions: Sequence[tuple[str, float]],
     *,
@@ -480,6 +591,7 @@ def _create_consolidated_contribution_page(
     anomaly_count: int,
     page_number: int,
     max_report_pages: int,
+    diagnosis_summary: Sequence[tuple[str, str]] | None = None,
 ) -> Figure:
     """Create one page summarizing the strongest contributors across all anomalies."""
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
@@ -542,6 +654,12 @@ def _create_consolidated_contribution_page(
         fontsize=9,
         color="#475467",
     )
+    if diagnosis_summary:
+        figure.text(0.07, 0.075, "Reconstruction diagnosis", fontsize=9, fontweight="bold", color="#175CD3")
+        for index, (label, value) in enumerate(diagnosis_summary):
+            x_position = 0.27 + index * 0.17
+            figure.text(x_position, 0.077, label, fontsize=7, color="#667085")
+            figure.text(x_position, 0.052, value, fontsize=8, fontweight="bold", color="#101828")
     _add_footer(figure, page_number)
     return figure
 
@@ -554,73 +672,170 @@ def _write_explanation_csv(
     *,
     is_datetime: bool,
 ) -> Path:
-    columns = (
+    columns = [
         "Anomalous timestamp",
         "Top contributors",
         "Contribution shares",
         "Explanation coverage",
-    )
+    ]
+    include_diagnosis = all(column in result_df.columns for column in REQUIRED_DIAGNOSIS_COLUMNS)
+    if include_diagnosis:
+        columns.extend(
+            ["Likely reconstruction issue", "Repair impact", "Diagnostic confidence", "Explanation consistency"]
+        )
     records = []
     x_array = np.asarray(x_values)
     for row_index in np.flatnonzero(detected):
         contributors = _parse_explanation_list(result_df.iloc[row_index]["TopContributors"], name="TopContributors")
         shares = _parse_explanation_list(result_df.iloc[row_index]["ContributionShares"], name="ContributionShares")
         coverage = float(result_df.iloc[row_index]["ExplanationCoverage"])
-        records.append(
-            {
-                "Anomalous timestamp": _format_explanation_sample(x_array[row_index], is_datetime=is_datetime).replace(
-                    "\n", " "
-                ),
-                "Top contributors": json.dumps([str(value) for value in contributors], separators=(",", ":")),
-                "Contribution shares": json.dumps([float(value) for value in shares], separators=(",", ":")),
-                "Explanation coverage": coverage,
-            }
-        )
+        record = {
+            "Anomalous timestamp": _format_explanation_sample(x_array[row_index], is_datetime=is_datetime).replace(
+                "\n", " "
+            ),
+            "Top contributors": json.dumps([str(value) for value in contributors], separators=(",", ":")),
+            "Contribution shares": json.dumps([float(value) for value in shares], separators=(",", ":")),
+            "Explanation coverage": coverage,
+        }
+        if include_diagnosis:
+            record.update(
+                {
+                    "Likely reconstruction issue": result_df.iloc[row_index]["LikelyReconstructionIssue"],
+                    "Repair impact": float(result_df.iloc[row_index]["RepairImpact"]),
+                    "Diagnostic confidence": result_df.iloc[row_index]["DiagnosticConfidence"],
+                    "Explanation consistency": result_df.iloc[row_index]["ExplanationConsistency"],
+                }
+            )
+        records.append(record)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame.from_records(records, columns=columns).to_csv(output_path, index=False)
     return output_path
 
 
-def _create_mae_note_page(*, page_number: int, uses_row_numbers: bool = False) -> Figure:
+def _create_mae_note_page(
+    *,
+    page_number: int,
+    uses_row_numbers: bool = False,
+    include_diagnosis: bool = False,
+) -> Figure:
     figure = Figure(figsize=(11.0, 8.5), facecolor="white")
-    axis = figure.add_axes((0.09, 0.12, 0.82, 0.76))
+    axis = figure.add_axes((0.07, 0.10, 0.86, 0.80))
     axis.axis("off")
+    axis.set_xlim(0.0, 1.0)
+    axis.set_ylim(0.0, 1.0)
+    axis.set_autoscale_on(False)
 
-    axis.text(0.0, 0.96, "About the MAE anomaly score", fontsize=18, fontweight="bold", color="#17365D", va="top")
+    title = "How to interpret this report" if include_diagnosis else "About the MAE anomaly score"
+    axis.text(0.0, 0.98, title, fontsize=18, fontweight="bold", color="#17365D", va="top")
     axis.text(
         0.0,
-        0.83,
-        "MAE means mean absolute error. In this report, it measures the average absolute difference "
-        "between the observed values and NV-Tesseract's reconstructed values at each sample.",
-        fontsize=11,
+        0.86,
+        "MAE means mean absolute error. It is the average absolute\n"
+        "difference between observed and reconstructed values at each sample.",
+        fontsize=9.5,
         color="#344054",
         va="top",
         wrap=True,
     )
     axis.text(
         0.0,
-        0.65,
+        0.70,
         r"$\mathrm{MAE}(t)=\frac{1}{F}\sum_{f=1}^{F}|x_{t,f}-\hat{x}_{t,f}|$",
-        fontsize=16,
+        fontsize=14,
         color="#101828",
         va="top",
     )
     notes = [
-        "A larger MAE means the detector reconstructed that sample less accurately.",
-        "The anomaly flag is produced by applying the selected threshold strategy to the MAE sequence.",
-        "MAE scale depends on preprocessing and feature scaling, so values should be interpreted in the context of the same model and data pipeline.",
-        "A high MAE identifies unusual reconstruction behavior; by itself, it does not establish physical causality or root cause.",
+        "Lower MAE means a closer reconstruction and more typical\n"
+        "behavior. Higher MAE means a larger mismatch and more\n"
+        "anomalous behavior.",
+        "The anomaly flag is produced by applying the selected\nthreshold strategy to the MAE sequence.",
+        "MAE scale depends on preprocessing and feature scaling.\nCompare values within the same model and data pipeline.",
+        "High MAE identifies unusual reconstruction behavior. It does\nnot establish physical causality or root cause.",
     ]
     if uses_row_numbers:
         notes.append(
             "No usable timestamp column was provided, so time steps in this report are zero-based DataFrame row numbers."
         )
-    axis.text(0.0, 0.48, "Interpretation notes", fontsize=12, fontweight="bold", color="#175CD3", va="top")
-    for note_index, note in enumerate(notes):
-        y_position = 0.39 - note_index * 0.08
-        axis.text(0.0, y_position, "-", fontsize=12, color="#175CD3", va="top")
-        axis.text(0.035, y_position, note, fontsize=10, color="#344054", va="top", wrap=True)
+    axis.text(0.0, 0.57, "MAE interpretation", fontsize=11, fontweight="bold", color="#175CD3", va="top")
+    note_positions = [0.49, 0.34, 0.23, 0.12, 0.02]
+    for y_position, note in zip(note_positions[: len(notes)], notes, strict=True):
+        axis.text(0.0, y_position, "-", fontsize=10, color="#175CD3", va="top")
+        axis.text(0.025, y_position, note, fontsize=8.5, color="#344054", va="top", wrap=True)
+
+    if include_diagnosis:
+        x_position = 0.53
+        axis.plot([0.49, 0.49], [0.05, 0.89], color="#D8DEE9", linewidth=0.8, transform=axis.transAxes)
+        axis.text(
+            x_position,
+            0.86,
+            "Reconstruction diagnosis",
+            fontsize=11,
+            fontweight="bold",
+            color="#175CD3",
+            va="top",
+        )
+        axis.text(
+            x_position,
+            0.79,
+            "These metrics describe how the detector responded to four\n"
+            "tested repairs. They do not prove physical causality or root cause.",
+            fontsize=8.5,
+            color="#344054",
+            va="top",
+            wrap=True,
+        )
+        axis.text(x_position, 0.69, "Likely issue", fontsize=9, fontweight="bold", color="#101828", va="top")
+        axis.text(
+            x_position,
+            0.645,
+            "The pattern whose repair reduced the anomaly score the most.\nPossible values:",
+            fontsize=8,
+            color="#475467",
+            va="top",
+        )
+        issue_values = [
+            "Level shift - sustained upward or downward change.",
+            "Trend change - unexpected change in direction or slope.",
+            "Transient spike - brief, isolated jump or drop.",
+            "Variance burst - temporary increase in fluctuation or noise.",
+            "No supported repair - none of the tested repairs reduced the score.",
+        ]
+        for index, value in enumerate(issue_values):
+            y_position = 0.56 - index * 0.045
+            axis.text(x_position, y_position, "-", fontsize=8, color="#175CD3", va="top")
+            axis.text(x_position + 0.018, y_position, value, fontsize=7.6, color="#344054", va="top")
+
+        axis.text(x_position, 0.31, "Repair impact", fontsize=9, fontweight="bold", color="#101828", va="top")
+        axis.text(
+            x_position,
+            0.265,
+            "Percentage decrease in anomaly score after the best repair.\n"
+            "Larger values mean a stronger effect on the detector.",
+            fontsize=8,
+            color="#475467",
+            va="top",
+        )
+        axis.text(x_position, 0.18, "Diagnostic confidence", fontsize=9, fontweight="bold", color="#101828", va="top")
+        axis.text(
+            x_position,
+            0.135,
+            "Best-versus-next-best margin: High >=20 points; Moderate\n"
+            "10-20; Low <10; Inconclusive means no clear improvement.",
+            fontsize=8,
+            color="#475467",
+            va="top",
+        )
+        axis.text(x_position, 0.07, "Explanation consistency", fontsize=9, fontweight="bold", color="#101828", va="top")
+        axis.text(
+            x_position,
+            0.025,
+            "Agreement across repeated evaluations; Not evaluated means one evaluation was used.",
+            fontsize=7.4,
+            color="#475467",
+            va="top",
+        )
 
     _add_footer(figure, page_number)
     return figure
@@ -702,6 +917,9 @@ def generate_anomaly_detection_report(
         x_values,
         is_datetime=is_datetime,
     )
+    diagnosis_rows = _resolve_diagnosis_rows(result_df, detected)
+    if diagnosis_rows is not None and explanation_rows is None:
+        raise ValueError("Reconstruction-diagnosis report data requires feature-contribution explanation columns.")
 
     destination = Path(output_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -735,6 +953,14 @@ def generate_anomaly_detection_report(
         ]
         if explanation_rows
         else ([[]] if explanation_rows is not None else [])
+    )
+    diagnosis_groups = (
+        [
+            diagnosis_rows[index : index + MAX_EXPLANATIONS_PER_PAGE]
+            for index in range(0, len(diagnosis_rows), MAX_EXPLANATIONS_PER_PAGE)
+        ]
+        if diagnosis_rows
+        else ([[]] if diagnosis_rows is not None else [])
     )
     explanation_features = list(
         dict.fromkeys(
@@ -798,6 +1024,7 @@ def generate_anomaly_detection_report(
                     anomaly_count=int(detected.sum()),
                     page_number=2 + len(feature_groups),
                     max_report_pages=max_report_pages,
+                    diagnosis_summary=_summarize_diagnoses(result_df, detected),
                 )
             )
         for graph_page_number, group in enumerate(
@@ -805,6 +1032,7 @@ def generate_anomaly_detection_report(
             start=1,
         ):
             page_number = 1 + len(feature_groups) + graph_page_number
+            diagnosis_group = diagnosis_groups[graph_page_number - 1] if diagnosis_groups else None
             pdf.savefig(
                 _create_contribution_graph_page(
                     group,
@@ -812,12 +1040,14 @@ def generate_anomaly_detection_report(
                     graph_page_number=graph_page_number,
                     graph_page_count=len(explanation_groups),
                     feature_colors=explanation_feature_colors,
+                    diagnosis_rows=diagnosis_group,
                 )
             )
         pdf.savefig(
             _create_mae_note_page(
                 page_number=page_count,
                 uses_row_numbers=x_label.startswith("Row number"),
+                include_diagnosis=diagnosis_rows is not None,
             )
         )
     return destination

--- a/ad_diffusion/sdk/reporting.py
+++ b/ad_diffusion/sdk/reporting.py
@@ -747,9 +747,11 @@ def _create_mae_note_page(
         va="top",
     )
     notes = [
-        "Lower MAE means a closer reconstruction and more typical\n"
-        "behavior. Higher MAE means a larger mismatch and more\n"
-        "anomalous behavior.",
+        (
+            "Lower MAE means a closer reconstruction and more typical\n"
+            "behavior. Higher MAE means a larger mismatch and more\n"
+            "anomalous behavior."
+        ),
         "The anomaly flag is produced by applying the selected\nthreshold strategy to the MAE sequence.",
         "MAE scale depends on preprocessing and feature scaling.\nCompare values within the same model and data pipeline.",
         "High MAE identifies unusual reconstruction behavior. It does\nnot establish physical causality or root cause.",

--- a/ad_diffusion/sdk/sdk_config.yaml
+++ b/ad_diffusion/sdk/sdk_config.yaml
@@ -1,13 +1,23 @@
-# SDK (reporting) settings for
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# SDK (explainability/reporting) settings for
 # sdk.anomaly_analysis.perform_anomaly_analysis_with_diffusion.
 # Copy this file and pass it with sdk_config="path/to/your_config.yaml".
 #
-# This covers only report-related parameters. Inference-behavior settings
-# (threshold_strategy, nsample, preprocess_model_dir), model paths
-# (model_path, model_config_path), and the explain/explanation_top_k
-# explainability toggle stay as direct keyword arguments on
-# perform_anomaly_analysis_with_diffusion.
+# This covers only the explain toggle and explainability/report-related
+# parameters. Inference-behavior settings (threshold_strategy, nsample,
+# preprocess_model_dir) and model paths (model_path, model_config_path) stay
+# as direct keyword arguments on perform_anomaly_analysis_with_diffusion.
 sdk:
+  # If true, add exact reconstruction-error explanations for anomalous rows.
+  # This does not trigger additional model inference.
+  explain: false
+  # Maximum number of target-space contributors to return per anomalous row.
+  explanation_top_k: 3
+  # If true, test four reconstruction-failure repair hypotheses. Requires
+  # explain: true and performs four additional inference passes.
+  diagnose_reconstruction: false
   # Optional PDF destination. No report is generated when null.
   report_path: null
   # Optional timestamp column used only for report plotting; conventional

--- a/ad_diffusion/sdk/tests/test_anomaly_analysis.py
+++ b/ad_diffusion/sdk/tests/test_anomaly_analysis.py
@@ -87,9 +87,9 @@ def test_perform_anomaly_analysis_with_scs_strategy(monkeypatch, numeric_df, inf
     assert kwargs["model_path"] == "model.pth"
     assert kwargs["config_path"] == "config.yaml"
     assert kwargs["nsample"] == 7
-    mock_thresholder.detect_anomalies.assert_called_once_with(
-        inference_results["residual"], inference_results["target"]
-    )
+    detector_scores, detector_target = mock_thresholder.detect_anomalies.call_args.args
+    np.testing.assert_array_equal(detector_scores, inference_results["residual"])
+    np.testing.assert_array_equal(detector_target, inference_results["target"])
 
 
 def test_perform_anomaly_analysis_rejects_non_numeric_columns(numeric_df):
@@ -228,9 +228,11 @@ def test_explain_toggle_preserves_numeric_feature_names(monkeypatch, tmp_path):
         threshold_strategy="scs",
         model_path="model.pth",
         model_config_path="config.yaml",
-        explain=True,
-        explanation_top_k=3,
-        sdk_config=anomaly_analysis.ADDiffusionConfig(report_path=tmp_path / "report.pdf"),
+        sdk_config=anomaly_analysis.ADDiffusionConfig(
+            explain=True,
+            explanation_top_k=3,
+            report_path=tmp_path / "report.pdf",
+        ),
     )
 
     inference_df = mock_inference.call_args.kwargs["data"]
@@ -270,7 +272,7 @@ def test_explain_toggle_maps_any_supported_input_width(monkeypatch, input_featur
         threshold_strategy="scs",
         model_path="model.pth",
         model_config_path="config.yaml",
-        explain=True,
+        sdk_config=anomaly_analysis.ADDiffusionConfig(explain=True),
     )
 
     contributors = json.loads(result.loc[0, "TopContributors"])
@@ -318,6 +320,9 @@ def test_load_sdk_config_accepts_nested_sdk_section(tmp_path):
 model:
   target_dim: 40
 sdk:
+  explain: true
+  explanation_top_k: 4
+  diagnose_reconstruction: true
   report_title: Custom Report
   report_consolidated_top_k: 8
 """,
@@ -327,6 +332,9 @@ sdk:
     config = anomaly_analysis.load_sdk_config(config_path)
 
     assert isinstance(config, anomaly_analysis.ADDiffusionConfig)
+    assert config.explain is True
+    assert config.explanation_top_k == 4
+    assert config.diagnose_reconstruction is True
     assert config.report_title == "Custom Report"
     assert config.report_consolidated_top_k == 8
     assert config.report_max_pages == 10
@@ -412,3 +420,49 @@ sdk:
     assert list(inference_df.columns) == ["feature_1", "feature_2"]
     assert {"timestamp", "GT", "Anomaly", "MAE"}.issubset(result.columns)
     assert destination.read_bytes().startswith(b"%PDF")
+
+
+def test_reconstruction_diagnosis_is_opt_in_and_hides_raw_scores(monkeypatch, numeric_df):
+    """Diagnosis should return only simplified metrics after four repair passes."""
+    original = {
+        "residual": np.array([0.1, 0.5, 0.2, 0.3, 0.1]),
+        "target": np.zeros((5, 3)),
+        "recon": np.array([[0.0, 0.0, 0.0], [3.0, 1.0, 0.5], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+    }
+
+    def repaired(score_at_anomaly):
+        return {"residual": np.array([0.1, score_at_anomaly, 0.2, 0.3, 0.1])}
+
+    mock_inference = Mock(side_effect=[original, repaired(0.1), repaired(0.3), repaired(0.4), repaired(0.45)])
+    monkeypatch.setattr(anomaly_analysis, "inference_ad_tesseract2_mp", mock_inference)
+    mock_thresholder = Mock()
+    mock_thresholder.detect_anomalies.return_value = np.array([False, True, False, False, False])
+    mock_strategy = Mock()
+    mock_strategy.scs_thresholder = mock_thresholder
+    monkeypatch.setattr(anomaly_analysis, "SCSThresholdStrategy", Mock(return_value=mock_strategy))
+
+    result = anomaly_analysis.perform_anomaly_analysis_with_diffusion(
+        numeric_df,
+        threshold_strategy="scs",
+        model_path="model.pth",
+        model_config_path="config.yaml",
+        sdk_config=anomaly_analysis.ADDiffusionConfig(explain=True, diagnose_reconstruction=True),
+    )
+
+    assert mock_inference.call_count == 5
+    assert result.loc[1, "LikelyReconstructionIssue"] == "Level shift"
+    assert result.loc[1, "RepairImpact"] == pytest.approx(0.8)
+    assert result.loc[1, "DiagnosticConfidence"] == "High"
+    assert result.loc[1, "ExplanationConsistency"] == "Not evaluated"
+    assert not any(column.startswith(("effect_", "score_after_")) for column in result.columns)
+
+
+def test_reconstruction_diagnosis_requires_feature_explanations(numeric_df):
+    with pytest.raises(ValueError, match="requires explain=True"):
+        anomaly_analysis.perform_anomaly_analysis_with_diffusion(
+            numeric_df,
+            threshold_strategy="scs",
+            model_path="model.pth",
+            model_config_path="config.yaml",
+            sdk_config=anomaly_analysis.ADDiffusionConfig(diagnose_reconstruction=True),
+        )

--- a/ad_diffusion/sdk/tests/test_reconstruction_failure.py
+++ b/ad_diffusion/sdk/tests/test_reconstruction_failure.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for counterfactual reconstruction-failure operators."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sdk.reconstruction_failure import (
+    FAILURE_MODES,
+    build_repair_variants,
+    inject_failure,
+    normalized_score_reduction,
+    repair_under_hypothesis,
+    summarize_repair_diagnostics,
+)
+
+
+@pytest.mark.parametrize("mode", FAILURE_MODES)
+def test_matching_repair_is_best_for_controlled_failure(mode: str) -> None:
+    rng = np.random.default_rng(7)
+    time = np.linspace(0, 4 * np.pi, 60)
+    reference = np.column_stack((np.sin(time), np.cos(time)))
+    anomalous = inject_failure(
+        reference,
+        feature_index=0,
+        segment=(15, 45),
+        mode=mode,
+        magnitude=4.0,
+        rng=rng,
+    )
+
+    def score(candidate: np.ndarray) -> float:
+        return float(np.mean(np.abs(candidate - reference)))
+
+    scores = {
+        hypothesis: score(
+            repair_under_hypothesis(
+                anomalous,
+                reference,
+                feature_index=0,
+                segment=(15, 45),
+                hypothesis=hypothesis,
+            )
+        )
+        for hypothesis in FAILURE_MODES
+    }
+    assert min(scores, key=scores.get) == mode
+    assert scores[mode] < score(anomalous)
+
+
+def test_repair_changes_only_selected_feature_and_segment() -> None:
+    reference = np.zeros((20, 3))
+    anomalous = reference.copy()
+    anomalous[5:15, 1] = 3.0
+    repaired = repair_under_hypothesis(
+        anomalous,
+        reference,
+        feature_index=1,
+        segment=(5, 15),
+        hypothesis="level_shift",
+    )
+    np.testing.assert_array_equal(repaired[:5], anomalous[:5])
+    np.testing.assert_array_equal(repaired[15:], anomalous[15:])
+    np.testing.assert_array_equal(repaired[:, 0], anomalous[:, 0])
+    np.testing.assert_array_equal(repaired[:, 2], anomalous[:, 2])
+
+
+def test_normalized_score_reduction() -> None:
+    assert normalized_score_reduction(0.8, 0.2) == pytest.approx(0.75)
+
+
+def test_build_repair_variants_changes_only_selected_event_feature() -> None:
+    values = np.zeros((12, 3))
+    values[5:7, 1] = 4.0
+    candidates = [[] for _ in range(len(values))]
+    candidates[5] = [1]
+    candidates[6] = [1]
+
+    variants = build_repair_variants(
+        values,
+        np.zeros_like(values),
+        anomaly_mask=[False, False, False, False, False, True, True, False, False, False, False, False],
+        candidate_feature_indices=candidates,
+        lookback=1,
+    )
+
+    assert set(variants) == set(FAILURE_MODES)
+    for repaired in variants.values():
+        np.testing.assert_array_equal(repaired[:, 0], values[:, 0])
+        np.testing.assert_array_equal(repaired[:, 2], values[:, 2])
+        np.testing.assert_array_equal(repaired[:5], values[:5])
+        np.testing.assert_array_equal(repaired[7:], values[7:])
+
+
+def test_summarize_repair_diagnostics_returns_only_user_facing_metrics() -> None:
+    diagnosis = summarize_repair_diagnostics(
+        [0.2, 1.0, 0.5],
+        {
+            "level_shift": [0.2, 0.35, 0.6],
+            "trend_change": [0.2, 0.75, 0.6],
+            "transient_spike": [0.2, 0.85, 0.6],
+            "variance_burst": [0.2, 0.95, 0.6],
+        },
+        anomaly_mask=[False, True, True],
+    )
+
+    assert list(diagnosis.columns) == [
+        "LikelyReconstructionIssue",
+        "RepairImpact",
+        "DiagnosticConfidence",
+        "ExplanationConsistency",
+    ]
+    assert diagnosis.loc[1].to_dict() == {
+        "LikelyReconstructionIssue": "Level shift",
+        "RepairImpact": pytest.approx(0.65),
+        "DiagnosticConfidence": "High",
+        "ExplanationConsistency": "Not evaluated",
+    }
+    assert diagnosis.loc[2].to_dict() == {
+        "LikelyReconstructionIssue": "No supported repair",
+        "RepairImpact": 0.0,
+        "DiagnosticConfidence": "Inconclusive",
+        "ExplanationConsistency": "Not evaluated",
+    }

--- a/ad_diffusion/sdk/tests/test_reporting.py
+++ b/ad_diffusion/sdk/tests/test_reporting.py
@@ -18,6 +18,7 @@ from sdk.reporting import (
     _aggregate_explanation_contributions,
     _create_contribution_graph_page,
     _create_mae_note_page,
+    _resolve_diagnosis_rows,
     _resolve_explanation_rows,
     _resolve_x_axis,
     generate_anomaly_detection_report,
@@ -141,6 +142,36 @@ def test_mae_note_page_omits_row_number_note_for_timestamped_data() -> None:
     assert not any("zero-based DataFrame row numbers" in text.get_text() for text in figure.axes[0].texts)
 
 
+def test_overview_page_explains_anomaly_score_direction() -> None:
+    """The first report page should state what lower and higher MAE mean."""
+    figure = reporting._create_overview_page(
+        np.arange(3),
+        np.array([0.1, 0.2, 0.3]),
+        np.array([False, False, True]),
+        None,
+        title="Anomaly report",
+        x_label="Row number",
+        is_datetime=False,
+    )
+
+    page_text = [text.get_text() for axis in figure.axes for text in axis.texts]
+    assert "How to read the anomaly score" in page_text
+    assert reporting.SCORE_DIRECTION_NOTE in page_text
+
+
+def test_diagnosis_note_page_explains_metrics_and_likely_issue_values() -> None:
+    """Question 2 reports should explain every end-user metric and issue label."""
+    figure = _create_mae_note_page(page_number=3, include_diagnosis=True)
+
+    page_text = "\n".join(text.get_text() for text in figure.axes[0].texts)
+    assert "Likely issue" in page_text
+    assert "Repair impact" in page_text
+    assert "Diagnostic confidence" in page_text
+    assert "Explanation consistency" in page_text
+    for issue in ["Level shift", "Trend change", "Transient spike", "Variance burst", "No supported repair"]:
+        assert issue in page_text
+
+
 def test_generate_report_includes_explainability_metrics(tmp_path: Path) -> None:
     """Explainability output should add anomaly-detail metrics to the PDF."""
     frame = _report_frame()
@@ -185,6 +216,56 @@ def test_generate_report_includes_explainability_metrics(tmp_path: Path) -> None
     assert exported.loc[0, "Top contributors"] == '["temperature","pressure"]'
     assert exported.loc[0, "Contribution shares"] == "[0.75,0.25]"
     assert exported.loc[0, "Explanation coverage"] == 1.0
+
+
+def test_report_adds_simplified_reconstruction_diagnosis_without_raw_scores(tmp_path: Path) -> None:
+    frame = _report_frame()
+    frame["TopContributors"] = ["[]"] * len(frame)
+    frame["ContributionShares"] = ["[]"] * len(frame)
+    frame["ExplanationCoverage"] = 0.0
+    frame["LikelyReconstructionIssue"] = ""
+    frame["RepairImpact"] = 0.0
+    frame["DiagnosticConfidence"] = ""
+    frame["ExplanationConsistency"] = ""
+    frame.loc[3, ["TopContributors", "ContributionShares", "ExplanationCoverage"]] = [
+        '["temperature","pressure"]',
+        "[0.75,0.25]",
+        1.0,
+    ]
+    frame.loc[7, ["TopContributors", "ContributionShares", "ExplanationCoverage"]] = [
+        '["pressure"]',
+        "[0.6]",
+        0.6,
+    ]
+    frame.loc[3, ["LikelyReconstructionIssue", "RepairImpact", "DiagnosticConfidence", "ExplanationConsistency"]] = [
+        "Level shift",
+        0.63,
+        "High",
+        "Not evaluated",
+    ]
+    frame.loc[7, ["LikelyReconstructionIssue", "RepairImpact", "DiagnosticConfidence", "ExplanationConsistency"]] = [
+        "Transient spike",
+        0.31,
+        "Moderate",
+        "75%",
+    ]
+
+    destination = tmp_path / "diagnosis_report.pdf"
+    generate_anomaly_detection_report(frame, destination)
+
+    assert _resolve_diagnosis_rows(frame, frame["Anomaly"].to_numpy(dtype=bool)) == [
+        ("Level shift", "63.0%", "High", "Not evaluated"),
+        ("Transient spike", "31.0%", "Moderate", "75%"),
+    ]
+    exported = pd.read_csv(tmp_path / "diagnosis_report_explanations.csv")
+    assert list(exported.columns[-4:]) == [
+        "Likely reconstruction issue",
+        "Repair impact",
+        "Diagnostic confidence",
+        "Explanation consistency",
+    ]
+    assert not any(column.startswith(("effect_", "score_after_")) for column in exported.columns)
+    assert destination.read_bytes().startswith(b"%PDF")
 
 
 def test_generate_report_without_explanations_keeps_metrics_optional() -> None:


### PR DESCRIPTION
## Summary

- add YAML-based SDK configuration for anomaly explainability and reporting
- add model-agnostic reconstruction-failure diagnosis using structure-preserving repair hypotheses
- add Likely Issue, Repair Impact, Diagnostic Confidence, and Explanation Consistency to PDF reports
- explain anomaly-score direction and all possible Likely Issue values for end users
- document the new configuration and diagnosis workflow

## Validation

- 43 focused SDK/reporting tests passed
- changed Python files pass Ruff lint and format checks
- SPDX header check passed
- diff whitespace check passed

This is the GitHub sister change for the corresponding GitLab reconstruction-diagnosis MR.