### PR TITLE
Fix GPU-count-dependent diffusion RNG

### DIFF
--- a/ad_diffusion/models/main_model.py
+++ b/ad_diffusion/models/main_model.py
@@ -439,7 +439,33 @@ class TSDiffuser_base(nn.Module):
 
         return total_input
 
-    def impute(self, observed_data, cond_mask, side_info, n_samples, strategy_type):
+    @staticmethod
+    def _randn_like_per_window(reference, generators=None):
+        """Generate noise from RNG streams bound to individual windows.
+
+        A regular ``torch.randn_like`` consumes one device-wide RNG stream for the
+        complete batch. That makes a window's noise depend on which other windows
+        share its batch. ``generators`` keeps one stream per batch row so changing
+        the worker or batch partition does not change that window's noise.
+        """
+        if generators is None:
+            return torch.randn_like(reference)
+        if len(generators) != reference.shape[0]:
+            raise ValueError(f"Expected one RNG generator per window ({reference.shape[0]}), got {len(generators)}.")
+        return torch.stack(
+            [
+                torch.randn(
+                    sample.shape,
+                    dtype=sample.dtype,
+                    device=sample.device,
+                    generator=generator,
+                )
+                for sample, generator in zip(reference, generators, strict=True)
+            ],
+            dim=0,
+        )
+
+    def impute(self, observed_data, cond_mask, side_info, n_samples, strategy_type, generators=None):
         B, K, L = observed_data.shape
 
         imputed_samples = torch.zeros(B, n_samples, K, L).to(self.device)
@@ -450,11 +476,11 @@ class TSDiffuser_base(nn.Module):
                 noisy_obs = observed_data
                 noisy_cond_history = []
                 for t in range(self.num_steps):
-                    noise = torch.randn_like(noisy_obs)
+                    noise = self._randn_like_per_window(noisy_obs, generators)
                     noisy_obs = (self.alpha_hat[t] ** 0.5) * noisy_obs + self.beta[t] ** 0.5 * noise
                     noisy_cond_history.append(noisy_obs * cond_mask)
 
-            current_sample = torch.randn_like(observed_data)
+            current_sample = self._randn_like_per_window(observed_data, generators)
 
             for t in range(self.num_steps - 1, -1, -1):
                 if self.is_unconditional:
@@ -476,7 +502,7 @@ class TSDiffuser_base(nn.Module):
                 current_sample = coeff1 * (current_sample - coeff2 * predicted)
 
                 if t > 0:
-                    noise = torch.randn_like(current_sample)
+                    noise = self._randn_like_per_window(current_sample, generators)
                     sigma = ((1.0 - self.alpha[t - 1]) / (1.0 - self.alpha[t]) * self.beta[t]) ** 0.5
                     current_sample += sigma * noise
 
@@ -530,7 +556,16 @@ class TSDiffuser_base(nn.Module):
             imputed_samples[:, i] = current_sample.detach()
         return imputed_samples
 
-    def dpm_solver_impute(self, observed_data, cond_mask, side_info, n_samples, strategy_type, num_steps=20):
+    def dpm_solver_impute(
+        self,
+        observed_data,
+        cond_mask,
+        side_info,
+        n_samples,
+        strategy_type,
+        num_steps=20,
+        generators=None,
+    ):
         """
         Fast inference using DPM-Solver++ (10-20 steps instead of 1000).
         No retraining needed - works with existing trained model.
@@ -576,14 +611,14 @@ class TSDiffuser_base(nn.Module):
                 # Precompute noisy conditions for timesteps we'll actually use
                 for t in timesteps_to_use:
                     t_idx = t.item()
-                    noise = torch.randn_like(observed_data)
+                    noise = self._randn_like_per_window(observed_data, generators)
                     alpha_t = self.alpha_hat[t_idx]
                     beta_t = self.beta[t_idx]
                     noisy_obs_t = (alpha_t**0.5) * observed_data + (beta_t**0.5) * noise
                     noisy_cond_history[t_idx] = noisy_obs_t * cond_mask
 
             # Initialize from noise
-            current_sample = torch.randn_like(observed_data)
+            current_sample = self._randn_like_per_window(observed_data, generators)
 
             # Define model wrapper for DPM-Solver
             def model_fn(x, t_continuous):
@@ -615,7 +650,7 @@ class TSDiffuser_base(nn.Module):
                         noisy_cond = noisy_cond_history[t_idx]
                     else:
                         # Fallback: compute on the fly (shouldn't happen with precompute)
-                        noise = torch.randn_like(observed_data)
+                        noise = self._randn_like_per_window(observed_data, generators)
                         alpha_t = self.alpha_hat[t_idx]
                         beta_t = self.beta[t_idx]
                         noisy_cond = (alpha_t**0.5) * observed_data + (beta_t**0.5) * noise
@@ -743,7 +778,7 @@ class TSDiffuser_base(nn.Module):
             strategy_type=strategy_type,
         )
 
-    def evaluate(self, batch, n_samples):
+    def evaluate(self, batch, n_samples, generators=None):
         """
         Standard evaluation using full diffusion process.
 
@@ -771,14 +806,21 @@ class TSDiffuser_base(nn.Module):
             side_info = self.get_side_info(observed_tp, cond_mask)
 
             normalized_data, data_mean, data_std = self._normalize_observed_data(observed_data)
-            samples = self.impute(normalized_data, cond_mask, side_info, n_samples, strategy_type)
+            samples = self.impute(
+                normalized_data,
+                cond_mask,
+                side_info,
+                n_samples,
+                strategy_type,
+                generators=generators,
+            )
             samples = self._denormalize_samples(samples, data_mean, data_std)
 
             for i in range(len(cut_length)):  # to avoid double evaluation
                 target_mask[i, ..., 0 : cut_length[i].item()] = 0
         return samples, observed_data, target_mask, observed_mask, observed_tp
 
-    def evaluate_with_dpm(self, batch, n_samples, dpm_steps=20):
+    def evaluate_with_dpm(self, batch, n_samples, dpm_steps=20, generators=None):
         """
         Fast evaluation using DPM-Solver for 50-100x speedup.
 
@@ -813,7 +855,13 @@ class TSDiffuser_base(nn.Module):
             normalized_data, data_mean, data_std = self._normalize_observed_data(observed_data)
             # Use DPM-Solver for fast sampling
             samples = self.dpm_solver_impute(
-                normalized_data, cond_mask, side_info, n_samples, strategy_type, num_steps=dpm_steps
+                normalized_data,
+                cond_mask,
+                side_info,
+                n_samples,
+                strategy_type,
+                num_steps=dpm_steps,
+                generators=generators,
             )
             samples = self._denormalize_samples(samples, data_mean, data_std)
 

--- a/ad_diffusion/models/utils.py
+++ b/ad_diffusion/models/utils.py
@@ -235,6 +235,7 @@ def evaluate(
     save_results=True,
     use_dpm_solver=False,
     dpm_steps=20,
+    window_seeds=None,
 ):
     """
     Evaluate the model on test data with optional DPM-Solver for fast inference.
@@ -286,15 +287,33 @@ def evaluate(
         else:
             logger.info("Using standard diffusion sampling")
 
+        window_offset = 0
         with tqdm(zip(test_loader1, test_loader2, strict=False), mininterval=5.0, maxinterval=50.0) as it:
             for batch_no, (test_batch1, test_batch2) in enumerate(it, start=1):
+                generators = None
+                if window_seeds is not None:
+                    batch_size = len(test_batch1["observed_data"])
+                    batch_seeds = window_seeds[window_offset : window_offset + batch_size]
+                    if len(batch_seeds) != batch_size:
+                        raise ValueError(
+                            f"Missing per-window seeds: need {batch_size} at offset {window_offset}, "
+                            f"got {len(batch_seeds)}."
+                        )
+                    generators = []
+                    for window_seed in batch_seeds:
+                        generator = torch.Generator(device=model.device)
+                        generator.manual_seed(int(window_seed))
+                        generators.append(generator)
+                    window_offset += batch_size
+
                 # Process first batch with selected sampling method
+                generator_kwargs = {"generators": generators} if generators is not None else {}
                 if use_dpm_solver:
                     samples, c_target, eval_points, observed_points, observed_time = model.evaluate_with_dpm(
-                        test_batch1, nsample, dpm_steps
+                        test_batch1, nsample, dpm_steps, **generator_kwargs
                     )
                 else:
-                    output = model.evaluate(test_batch1, nsample)
+                    output = model.evaluate(test_batch1, nsample, **generator_kwargs)
                     samples, c_target, eval_points, observed_points, observed_time = output
 
                 samples = samples.permute(0, 1, 3, 2)
@@ -304,9 +323,11 @@ def evaluate(
 
                 # Process second batch with selected sampling method
                 if use_dpm_solver:
-                    samples2, _, eval_points2, _, _ = model.evaluate_with_dpm(test_batch2, nsample, dpm_steps)
+                    samples2, _, eval_points2, _, _ = model.evaluate_with_dpm(
+                        test_batch2, nsample, dpm_steps, **generator_kwargs
+                    )
                 else:
-                    output2 = model.evaluate(test_batch2, nsample)
+                    output2 = model.evaluate(test_batch2, nsample, **generator_kwargs)
                     samples2, _, eval_points2, _, _ = output2
 
                 samples2 = samples2.permute(0, 1, 3, 2)
@@ -343,6 +364,9 @@ def evaluate(
                     },
                     refresh=True,
                 )
+
+        if window_seeds is not None and window_offset != len(window_seeds):
+            raise ValueError(f"Unused per-window seeds: consumed {window_offset}, received {len(window_seeds)}.")
 
         # Save generated outputs
         all_target = torch.cat(all_target, dim=0).to("cpu")

--- a/ad_diffusion/sdk/inference_ad.py
+++ b/ad_diffusion/sdk/inference_ad.py
@@ -112,6 +112,7 @@ PROFILE_RESIDUALS = os.environ.get("TESSERACT_PROFILE_RESIDUALS", "0") == "1"
 
 # Default seed for reproducibility
 DEFAULT_SEED = 42
+INFERENCE_BATCH_SIZE = 32
 
 
 def set_seed(seed: int = DEFAULT_SEED) -> None:
@@ -612,15 +613,18 @@ def _build_window_indexes(total_rows: int, window_length: int, window_split: int
 
 
 def _split_indexes(indexes: list[int], num_parts: int) -> list[list[int]]:
+    """Split indexes without changing canonical inference batch boundaries."""
     if num_parts <= 1:
         return [indexes]
-    chunk_size = len(indexes) // num_parts
-    remainder = len(indexes) % num_parts
+
+    batches = [indexes[i : i + INFERENCE_BATCH_SIZE] for i in range(0, len(indexes), INFERENCE_BATCH_SIZE)]
+    chunk_size = len(batches) // num_parts
+    remainder = len(batches) % num_parts
     chunks: list[list[int]] = []
     start = 0
     for i in range(num_parts):
         end = start + chunk_size + (1 if i < remainder else 0)
-        chunks.append(indexes[start:end])
+        chunks.append([index for batch in batches[start:end] for index in batch])
         start = end
     return chunks
 
@@ -645,9 +649,14 @@ def _build_window_tensor(
 
 def _create_shared_memory(array: np.ndarray) -> dict:
     shm = shared_memory.SharedMemory(create=True, size=array.nbytes)
-    shm_array = np.ndarray(array.shape, dtype=array.dtype, buffer=shm.buf)
-    shm_array[:] = array
-    return {"name": shm.name, "shape": array.shape, "dtype": array.dtype}
+    try:
+        shm_array = np.ndarray(array.shape, dtype=array.dtype, buffer=shm.buf)
+        shm_array[:] = array
+        return {"name": shm.name, "shape": array.shape, "dtype": array.dtype}
+    finally:
+        # The segment remains alive until unlink(), but this creator handle is no
+        # longer needed. Keeping it open triggers resource_tracker leak warnings.
+        shm.close()
 
 
 def _cleanup_shared_memory(shm_info: dict) -> None:
@@ -777,7 +786,15 @@ def combine_samples_and_compute_residuals(samples_list: list, target) -> dict:
     }
 
 
-def evaluate_ad_tesseract2(model, test_loader1, test_loader2, nsample=30, use_dpm_solver=False, dpm_steps=20):
+def evaluate_ad_tesseract2(
+    model,
+    test_loader1,
+    test_loader2,
+    nsample=30,
+    use_dpm_solver=False,
+    dpm_steps=20,
+    window_seeds=None,
+):
     """
     Evaluate the model on the test data with optional DPM-Solver support.
 
@@ -804,6 +821,7 @@ def evaluate_ad_tesseract2(model, test_loader1, test_loader2, nsample=30, use_dp
         save_results=False,
         use_dpm_solver=use_dpm_solver,
         dpm_steps=dpm_steps,
+        window_seeds=window_seeds,
     )
     timings["diffusion_sampling"] = time.perf_counter() - t0
 
@@ -1153,15 +1171,16 @@ def inference_ad_tesseract2_mp(
         dict with residual, residual_l2, target, recon, target_dim keys.
 
     Note:
-        Combining multiprocessing with DPM-Solver provides massive speedup!
-        Example: 4 GPUs * 50x DPM speedup = 200x total speedup vs single-GPU standard diffusion.
+        Multi-GPU scaling is workload-dependent. Workers process canonical batches
+        independently; additional visible GPUs do not imply linear speedup.
     """
     # Ensure weights are available locally before spinning up workers (which
     # otherwise each race to download the same files).
     resolved_model, resolved_config = _resolve_model_paths(model_path, config_path)
 
     total_gpus = torch.cuda.device_count() if torch.cuda.is_available() else 0
-    if total_gpus <= 1:
+    if total_gpus == 0:
+        set_seed(seed)
         return inference_ad_tesseract2(
             data,
             resolved_model,
@@ -1184,15 +1203,10 @@ def inference_ad_tesseract2_mp(
     # Log multiprocessing + DPM strategy
     method_str = f"DPM-Solver ({dpm_steps} steps)" if use_dpm_solver else "Standard Diffusion"
     logger.info("%s", "\n" + "=" * 60)
-    logger.info("MULTI-GPU INFERENCE with %s", method_str)
+    logger.info("GPU WORKER INFERENCE with %s", method_str)
     logger.info("%s", "=" * 60)
     logger.info("Processes: %s", num_processes)
     logger.info("GPU IDs: %s", gpu_ids)
-    if use_dpm_solver:
-        per_process_speedup = 1000 / dpm_steps
-        total_speedup = per_process_speedup * num_processes
-        logger.info("Per-GPU speedup: ~%.0fx", per_process_speedup)
-        logger.info("Total estimated speedup: ~%.0fx vs single-GPU standard", total_speedup)
     logger.info("%s\n", "=" * 60)
 
     model_path = Path(resolved_model)
@@ -1247,6 +1261,7 @@ def inference_ad_tesseract2_mp(
                         "dtype": str(shm_info["dtype"]),
                         "window_indices": chunk,
                         "split": split,
+                        "batch_size": INFERENCE_BATCH_SIZE,
                     },
                     "model_path": str(model_path),
                     "config": config,

--- a/ad_diffusion/sdk/inference_worker.py
+++ b/ad_diffusion/sdk/inference_worker.py
@@ -16,7 +16,7 @@ import logging
 import os
 import sys
 import time
-from multiprocessing import shared_memory
+from multiprocessing import resource_tracker, shared_memory
 
 # Log start time before any heavy imports
 start_time = time.time()
@@ -93,13 +93,13 @@ def main():
         # With CUDA_VISIBLE_DEVICES set, cuda:0 refers to our assigned GPU
         device = torch.device("cuda:0")
 
-        # Set seed for reproducibility
-        device_seed = seed + gpu_id
-        random.seed(device_seed)
-        np.random.seed(device_seed)
-        torch.manual_seed(device_seed)
+        # Keep process-level randomness independent of physical GPU assignment.
+        # Diffusion noise itself is seeded per global window below.
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
         if torch.cuda.is_available():
-            torch.cuda.manual_seed(device_seed)
+            torch.cuda.manual_seed(seed)
 
         # Load model
         checkpoint = torch.load(model_path, map_location="cpu", weights_only=False)
@@ -120,12 +120,17 @@ def main():
             # Create dataloader for this chunk
             if isinstance(data_chunk, dict) and data_chunk.get("window_shm"):
                 shm = shared_memory.SharedMemory(name=data_chunk["shm_name"])
+                # This worker only borrows the parent-owned segment. Without
+                # unregistering, every worker's resource tracker tries to unlink it
+                # at process exit and reports a false leak/double-unlink warning.
+                resource_tracker.unregister(shm._name, "shared_memory")
                 # Convert JSON-serialized dtype (str) and shape (list) back to numpy types
                 shm_dtype = np.dtype(data_chunk["dtype"])
                 shm_shape = tuple(data_chunk["shape"])
                 windows = np.ndarray(shm_shape, dtype=shm_dtype, buffer=shm.buf)
                 loader1, loader2 = get_dataloader_from_windows(
                     windows,
+                    batch_size=data_chunk.get("batch_size", 32),
                     split=data_chunk["split"],
                     window_indices=data_chunk["window_indices"],
                 )
@@ -145,6 +150,9 @@ def main():
                 nsample=nsample,
                 use_dpm_solver=use_dpm_solver,  # NEW: Pass DPM parameters
                 dpm_steps=dpm_steps,  # NEW: Pass DPM parameters
+                window_seeds=[seed + window_index for window_index in data_chunk["window_indices"]]
+                if isinstance(data_chunk, dict) and data_chunk.get("window_shm")
+                else None,
             )
         finally:
             if shm is not None:

--- a/ad_diffusion/sdk/tests/test_inference_rng.py
+++ b/ad_diffusion/sdk/tests/test_inference_rng.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for GPU-count-independent inference randomness."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from models.main_model import TSDiffuser_base
+from sdk.inference_ad import INFERENCE_BATCH_SIZE, _split_indexes
+
+
+def _generators(seeds: list[int]) -> list[torch.Generator]:
+    return [torch.Generator(device="cpu").manual_seed(seed) for seed in seeds]
+
+
+def test_per_window_noise_is_independent_of_batch_partition() -> None:
+    reference = torch.empty(5, 3, 4)
+    seeds = [42 + index for index in range(len(reference))]
+
+    noise_as_one_batch = TSDiffuser_base._randn_like_per_window(reference, _generators(seeds))
+    noise_as_two_batches = torch.cat(
+        [
+            TSDiffuser_base._randn_like_per_window(reference[:2], _generators(seeds[:2])),
+            TSDiffuser_base._randn_like_per_window(reference[2:], _generators(seeds[2:])),
+        ]
+    )
+
+    torch.testing.assert_close(noise_as_one_batch, noise_as_two_batches, rtol=0, atol=0)
+
+
+def test_worker_split_preserves_canonical_batch_boundaries() -> None:
+    indexes = list(range(INFERENCE_BATCH_SIZE * 2 + 6))
+
+    chunks = _split_indexes(indexes, num_parts=2)
+
+    assert chunks == [indexes[: INFERENCE_BATCH_SIZE * 2], indexes[INFERENCE_BATCH_SIZE * 2 :]]
+    assert [len(chunk) for chunk in chunks] == [INFERENCE_BATCH_SIZE * 2, 6]

--- a/ad_diffusion/sdk/tests/test_inference_worker.py
+++ b/ad_diffusion/sdk/tests/test_inference_worker.py
@@ -60,6 +60,7 @@ def install_worker_stubs(monkeypatch, *, fake_evaluate):
     monkeypatch.setitem(sys.modules, "models.main_model", fake_main_model)
     monkeypatch.setitem(sys.modules, "sdk.inference_ad", fake_inference_ad)
     monkeypatch.setattr(sdk, "inference_ad", fake_inference_ad, raising=False)
+    monkeypatch.setattr(inference_worker.resource_tracker, "unregister", lambda *_args, **_kwargs: None)
 
     return fake_inference_ad
 
@@ -76,6 +77,7 @@ def build_worker_args(tmp_path: Path) -> tuple[Path, Path]:
             "dtype": "float32",
             "window_indices": [0, 1],
             "split": 4,
+            "batch_size": 32,
         },
         "model_path": "model.pth",
         "config": {"model": {"target_dim": 4}},
@@ -98,6 +100,7 @@ def test_worker_keeps_shared_memory_open_until_after_evaluate(monkeypatch, tmp_p
     class FakeSharedMemory:
         def __init__(self, name):
             assert name == "fake-shm"
+            self._name = name
             self.buf = bytearray(np.zeros((2, 3, 4), dtype=np.float32).nbytes)
             self.closed = False
 
@@ -107,8 +110,8 @@ def test_worker_keeps_shared_memory_open_until_after_evaluate(monkeypatch, tmp_p
 
     fake_shm = FakeSharedMemory("fake-shm")
 
-    def fake_evaluate(model, loader1, loader2, nsample, use_dpm_solver, dpm_steps):
-        events.append(("evaluate", fake_shm.closed, loader1, loader2, nsample, use_dpm_solver, dpm_steps))
+    def fake_evaluate(model, loader1, loader2, nsample, use_dpm_solver, dpm_steps, window_seeds):
+        events.append(("evaluate", fake_shm.closed, loader1, loader2, nsample, use_dpm_solver, dpm_steps, window_seeds))
         return {
             "residual": np.array([1.0]),
             "residual_l2": np.array([2.0]),
@@ -118,8 +121,8 @@ def test_worker_keeps_shared_memory_open_until_after_evaluate(monkeypatch, tmp_p
 
     fake_inference_ad = install_worker_stubs(monkeypatch, fake_evaluate=fake_evaluate)
 
-    def fake_get_dataloader_from_windows(windows, *, split, window_indices):
-        events.append(("loaders", fake_shm.closed, windows.shape, split, tuple(window_indices)))
+    def fake_get_dataloader_from_windows(windows, *, batch_size, split, window_indices):
+        events.append(("loaders", fake_shm.closed, windows.shape, batch_size, split, tuple(window_indices)))
         return ["loader1"], ["loader2"]
 
     fake_inference_ad.get_dataloader_from_windows = fake_get_dataloader_from_windows
@@ -134,8 +137,8 @@ def test_worker_keeps_shared_memory_open_until_after_evaluate(monkeypatch, tmp_p
     assert saved["gpu_id"] == 0
     assert saved["results"]["residual"] == [1.0]
     assert events == [
-        ("loaders", False, (2, 3, 4), 4, (0, 1)),
-        ("evaluate", False, ["loader1"], ["loader2"], 5, False, 20),
+        ("loaders", False, (2, 3, 4), 32, 4, (0, 1)),
+        ("evaluate", False, ["loader1"], ["loader2"], 5, False, 20, [7, 8]),
         "close",
     ]
     assert fake_shm.closed is True
@@ -147,6 +150,7 @@ def test_worker_closes_shared_memory_when_evaluate_fails(monkeypatch, tmp_path):
     class FakeSharedMemory:
         def __init__(self, name):
             assert name == "fake-shm"
+            self._name = name
             self.buf = bytearray(np.zeros((2, 3, 4), dtype=np.float32).nbytes)
             self.closed = False
 
@@ -156,12 +160,15 @@ def test_worker_closes_shared_memory_when_evaluate_fails(monkeypatch, tmp_path):
 
     fake_shm = FakeSharedMemory("fake-shm")
 
-    def fake_evaluate(model, loader1, loader2, nsample, use_dpm_solver, dpm_steps):
+    def fake_evaluate(model, loader1, loader2, nsample, use_dpm_solver, dpm_steps, window_seeds):
         events.append(("evaluate", fake_shm.closed))
         raise RuntimeError("boom")
 
     fake_inference_ad = install_worker_stubs(monkeypatch, fake_evaluate=fake_evaluate)
-    fake_inference_ad.get_dataloader_from_windows = lambda windows, *, split, window_indices: (["loader1"], ["loader2"])
+    fake_inference_ad.get_dataloader_from_windows = lambda windows, *, batch_size, split, window_indices: (
+        ["loader1"],
+        ["loader2"],
+    )
     monkeypatch.setattr(inference_worker.shared_memory, "SharedMemory", lambda name: fake_shm)
 
     args_path, result_path = build_worker_args(tmp_path)


### PR DESCRIPTION
## Summary

  Fix anomaly-detection inference results changing with the number of GPUs.

  ## Root cause

  Workers previously used `seed + gpu_id`. Changing the GPU count therefore changed window-to-worker assignments and the diffusion noise applied to each
  window.

  ## Changes

  - Associate RNG seeds with global window indexes.
  - Use a dedicated `torch.Generator` for each window.
  - Preserve canonical batch boundaries when splitting work.
  - Align single- and multi-GPU inference paths.
  - Add regression tests for RNG consistency and worker splitting.

  ## Validation

  Verified using deterministic synthetic data with 1,000 rows, 40 channels, and `nsample=15`. Repeated runs across 1, 2, and 4 GPUs produced identical
  anomaly masks, row indexes, residuals, targets, and reconstructions.